### PR TITLE
Add mnist example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We are creating an autograd engine from scratch and use it to build/train more c
 - All mathematical operations explicitly derived for comprehensive understanding
 
 > What I cannot create, I do not understand
-> 
+>
 > -- Richard Feynman
 
 <details>
@@ -21,8 +21,11 @@ We are creating an autograd engine from scratch and use it to build/train more c
   This project took inspiration from [Micrograd](https://github.com/karpathy/micrograd/tree/master), and kept the API interface as close as possible to [Pytorch](https://github.com/pytorch/pytorch/tree/main) to reduce extra usage overhead and utilize it to validate correctness.
 </details>
 
-## Demo
-End-to-end training implementation for a binary classifier on the [breast cancer dataset](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_breast_cancer.html) can be found in [`tests/autograd/test_train.py`](https://github.com/workofart/ml-by-hand/blob/c1156ee0c7a252484df1cd5234316a299e008b8b/test/autograd/test_train.py#L7-L66).
+## Demo/Examples
+
+`examples/` contains various examples of neural networks built using the library that tackle some classical problems
+- MNIST classifier: [`examples/mnist_classifier.py`](https://github.com/workofart/ml-by-hand/blob/main/examples/mnist_classifier.py)
+- End-to-end training implementation for a binary classifier on the [breast cancer dataset](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_breast_cancer.html) can be found in [`tests/autograd/test_train.py`](https://github.com/workofart/ml-by-hand/blob/c1156ee0c7a252484df1cd5234316a299e008b8b/test/autograd/test_train.py#L7-L66).
 
 ## Technical Overview
 - `tensor` (base class)

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -61,10 +61,18 @@ class Linear(Module):
         super().__init__(**kwargs)
 
         # weight is a matrix of shape (input_size, output_size)
-        self._parameters["weight"] = Tensor(np.random.randn(input_size, output_size))
+        # Xavier Normal Initialization
+        # https://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf
+        self._parameters["weight"] = Tensor(
+            np.random.uniform(
+                low=-np.sqrt(6.0 / (input_size + output_size)),
+                high=np.sqrt(6.0 / (input_size + output_size)),
+                size=(input_size, output_size),
+            )
+        )
 
         # bias is always 1-dimensional
-        self._parameters["bias"] = Tensor(np.zeros(output_size))
+        self._parameters["bias"] = Tensor(np.random.rand(output_size))
 
     def forward(self, x) -> Tensor:
         if not isinstance(x, Tensor):

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -1,0 +1,105 @@
+from autograd import nn, optim, functional, utils
+from sklearn.datasets import fetch_openml
+import logging
+import numpy as np
+
+logger = logging.getLogger(__name__)
+np.random.seed(1337)
+
+
+class MnistMultiClassClassifier(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.h1 = nn.Linear(784, 64)  # mnist image has shape 28*28=784
+        self.h2 = nn.Linear(64, 64)
+        self.h3 = nn.Linear(64, 10)
+
+    def forward(self, x):
+        x = functional.relu(self.h1(x))
+        x = functional.relu(self.h2(x))
+        x = self.h3(x)
+        return functional.softmax(
+            x
+        )  # <<--- this is the only difference between this and the One vs Rest Binary classifier
+
+
+class MnistOneVsRestBinaryClassifier(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.h1 = nn.Linear(784, 64)  # mnist image has shape 28*28=784
+        self.h2 = nn.Linear(64, 64)
+        self.h3 = nn.Linear(64, 1)
+
+    def forward(self, x):
+        x = functional.relu(self.h1(x))
+        x = functional.relu(self.h2(x))
+        x = self.h3(x)
+        return functional.sigmoid(
+            x
+        )  # <<--- this is the only difference between this and the multiclass classifier
+
+
+if __name__ == "__main__":
+    logger.info("Fetching data for MNIST_784")
+    X, y = fetch_openml(
+        "mnist_784", return_X_y=True, as_frame=False, parser="liac-arff"
+    )
+    X = X / 255.0  # normalize to [0, 1] to speed up convergence
+
+    X_train, X_test, y_train, y_test = utils.train_test_split(X, y, test_size=0.1)
+
+    logger.info("=" * 50)
+    logger.info("║   Starting to train One vs Rest MNIST model    ║")
+    logger.info("=" * 50)
+    one_vs_rest_models = []
+    for digit in range(10):
+        logger.info(f"Training {digit=}")
+        y_binary = (y_train == str(digit)).astype(int)
+        model = MnistOneVsRestBinaryClassifier()
+
+        utils.train(
+            model=model,
+            X=X_train,
+            y=y_binary,
+            loss_fn=functional.binary_cross_entropy,
+            optimizer=optim.SGD(model.parameters, lr=1e-3),
+            epochs=20,  # each digit will run for small number of epochs
+        )
+        one_vs_rest_models.append(model)
+
+    logger.info("Training complete")
+    # 10 models, each model predicts probability of digit 0-9
+    # predictions_by_digit[i][j] is the probability that the ith test example is the jth digit
+    predictions_by_digit = np.array(
+        [model(X_test).data for model in one_vs_rest_models]
+    ).T
+
+    logger.info(
+        f"Test Accuracy: {utils.accuracy(predictions_by_digit.argmax(axis=1), y_test.astype(int))}"
+    )
+    logger.info(
+        f"Test Precision: {utils.precision(predictions_by_digit.argmax(axis=1), y_test.astype(int))}"
+    )
+
+    logger.info("=" * 66)
+    logger.info("║            Starting to train Multi-class MNIST model              ║")
+    logger.info("=" * 66)
+
+    model = MnistMultiClassClassifier()
+    utils.train(
+        model=model,
+        X=X_train,
+        y=y_train.astype(int),
+        loss_fn=functional.sparse_cross_entropy,
+        optimizer=optim.SGD(model.parameters, lr=1e-3),
+        epochs=200,
+    )
+
+    y_pred = model(X_test).data
+
+    logger.info(
+        f"Test Accuracy: {utils.accuracy(y_pred.argmax(axis=1), y_test.astype(int))}"
+    )
+    logger.info(
+        f"Test Precision: {utils.precision(y_pred.argmax(axis=1), y_test.astype(int))}"
+    )

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
     )
 
     logger.info("=" * 66)
-    logger.info("║            Starting to train Multi-class MNIST model              ║")
+    logger.info("║            Starting to train Multi-class MNIST model           ║")
     logger.info("=" * 66)
 
     model = MnistMultiClassClassifier()
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         y=y_train.astype(int),
         loss_fn=functional.sparse_cross_entropy,
         optimizer=optim.SGD(model.parameters, lr=1e-3),
-        epochs=200,
+        epochs=500,
     )
 
     y_pred = model(X_test).data

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -21,7 +21,7 @@ class TestLinear(TestCase):
         # Trying to pass in (1x4 matrix)
         x = [[2, 2, 2, 2]]
         out = linear_layer(x)
-        assert np.allclose(out.data, [-2.75117575, -7.83881729])
+        assert np.allclose(out.data, [-2.7748068, 0.56519009])
         assert np.allclose(
             out.grad, [0, 0]
         )  # this should still be zero before we call backward


### PR DESCRIPTION
Using the autograd created by this project. We will build a image classification model to tackle the classic [MNIST challenge](https://en.wikipedia.org/wiki/MNIST_database).

In this PR, we are creating two classification models:
- binary classification with one-vs-rest to handle each digit as a binary classification problem. Then use all 10 models (one model for each of the 10 digits) to predict against the test dataset
- multi-class classification with one model to directly predict the probability for 10 classes.

## Weight Initialization

I noticed that with a random weight initialization, both models are not able to converge to a good optimum. Even with a very small learning rate 1e-5 and lots of epochs:

<img width="444" alt="image" src="https://github.com/user-attachments/assets/30d1abad-d13d-4e08-948d-f987f3146f5e">

Then I resorted to a better weight initialization -- Xavier Normal Initialization ([Paper](https://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf)). This helped significantly by mitigating the gradient saturation problem introduced by sigmoid functions.



## Tests
**One-vs-rest binary classification model**
Loss is the binary cross entropy loss.
Accuracy is the sparse categorical accuracy $= \frac{\text{prediction digit} == \text{actual digit}}{\text{number of samples}}$
<img width="400" alt="image" src="https://github.com/user-attachments/assets/431d5980-f232-4c5d-96eb-5b15d65e5ffb">

...

<img width="400" alt="image" src="https://github.com/user-attachments/assets/3468b4b9-1a7f-4127-99c8-e254e94a87da">

**Multi-class classification model**
Loss is the sparse cross entropy loss = $-y_{true} * \log(y_{pred})$
Accuracy is the sparse categorical accuracy $= \frac{\text{prediction digit} == \text{actual digit}}{\text{number of samples}}$
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7872e207-e983-4269-ac94-9fb094c3ebf0">

