### PR TITLE
Add batch normalization layer and mean/sum tensor operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We are creating an autograd engine from scratch and use it to build/train more c
 - `nn` (neural network components)
   - Module (base class)
   - Linear (basic building block for a perceptron/hidden layer)
+  - BatchNorm (batch normalization)
 - `functional` (including backprop derivation defined in `backward()`)
   - Activation functions: relu, sigmoid, softmax
   - Loss: binary_cross_entropy, sparse_cross_entropy

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -1,5 +1,5 @@
 from autograd import nn, optim, functional, utils
-from sklearn.datasets import fetch_openml
+from openml.datasets import get_dataset
 import logging
 import numpy as np
 
@@ -8,19 +8,26 @@ np.random.seed(1337)
 
 
 class MnistMultiClassClassifier(nn.Module):
-    def __init__(self):
+    def __init__(self, batch_norm=False):
         super().__init__()
+        self.batch_norm = batch_norm
         self.h1 = nn.Linear(784, 64)  # mnist image has shape 28*28=784
         self.h2 = nn.Linear(64, 64)
         self.h3 = nn.Linear(64, 10)
+        if self.batch_norm:
+            self.bn1 = nn.BatchNorm(64, momentum=0.1, epsilon=1e-8)
 
     def forward(self, x):
-        x = functional.relu(self.h1(x))
-        x = functional.relu(self.h2(x))
+        x = self.h1(x)
+        if self.batch_norm:
+            x = self.bn1(x)
+        x = functional.relu(x)
+
+        x = self.h2(x)
+        x = functional.relu(x)
+
         x = self.h3(x)
-        return functional.softmax(
-            x
-        )  # <<--- this is the only difference between this and the One vs Rest Binary classifier
+        return functional.softmax(x)
 
 
 class MnistOneVsRestBinaryClassifier(nn.Module):
@@ -39,22 +46,14 @@ class MnistOneVsRestBinaryClassifier(nn.Module):
         )  # <<--- this is the only difference between this and the multiclass classifier
 
 
-if __name__ == "__main__":
-    logger.info("Fetching data for MNIST_784")
-    X, y = fetch_openml(
-        "mnist_784", return_X_y=True, as_frame=False, parser="liac-arff"
-    )
-    X = X / 255.0  # normalize to [0, 1] to speed up convergence
-
-    X_train, X_test, y_train, y_test = utils.train_test_split(X, y, test_size=0.1)
-
+def train_mnist_one_vs_rest_model(X_train, y_train, X_test, y_test):
     logger.info("=" * 50)
-    logger.info("║   Starting to train One vs Rest MNIST model    ║")
+    logger.info("Starting to train One vs Rest MNIST model")
     logger.info("=" * 50)
     one_vs_rest_models = []
     for digit in range(10):
         logger.info(f"Training {digit=}")
-        y_binary = (y_train == str(digit)).astype(int)
+        y_binary = (y_train == digit).astype(int)
         model = MnistOneVsRestBinaryClassifier()
 
         utils.train(
@@ -62,8 +61,8 @@ if __name__ == "__main__":
             X=X_train,
             y=y_binary,
             loss_fn=functional.binary_cross_entropy,
-            optimizer=optim.SGD(model.parameters, lr=1e-3),
-            epochs=20,  # each digit will run for small number of epochs
+            optimizer=optim.Adam(model.parameters, lr=1e-3),
+            epochs=10,  # each digit will run for small number of epochs
         )
         one_vs_rest_models.append(model)
 
@@ -81,20 +80,23 @@ if __name__ == "__main__":
         f"Test Precision: {utils.precision(predictions_by_digit.argmax(axis=1), y_test.astype(int))}"
     )
 
-    logger.info("=" * 66)
-    logger.info("║            Starting to train Multi-class MNIST model           ║")
-    logger.info("=" * 66)
 
-    model = MnistMultiClassClassifier()
+def train_mnist_multiclass_model(
+    X_train, y_train, X_test, y_test, optimizer, model, msg=""
+):
+    logger.info("=" * 66)
+    logger.info(f"Starting to train Multi-class MNIST model {msg}")
+    logger.info("=" * 66)
     utils.train(
         model=model,
         X=X_train,
         y=y_train.astype(int),
         loss_fn=functional.sparse_cross_entropy,
-        optimizer=optim.SGD(model.parameters, lr=1e-3),
-        epochs=500,
+        optimizer=optimizer,
+        epochs=30,
     )
 
+    model.eval()
     y_pred = model(X_test).data
 
     logger.info(
@@ -103,3 +105,48 @@ if __name__ == "__main__":
     logger.info(
         f"Test Precision: {utils.precision(y_pred.argmax(axis=1), y_test.astype(int))}"
     )
+
+
+if __name__ == "__main__":
+    logger.info("Fetching data for MNIST_784")
+    X, y, _, __ = get_dataset(dataset_id=554, download_data=True).get_data(
+        target="class", dataset_format="array"
+    )
+    X /= 255.0  # normalize to [0, 1] to speed up convergence
+
+    X_train, X_test, y_train, y_test = utils.train_test_split(X, y, test_size=0.1)
+
+    model = MnistMultiClassClassifier(batch_norm=False)
+    train_mnist_multiclass_model(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        optimizer=optim.SGD(model.parameters, lr=1e-3),
+        model=model,
+        msg="(without batch norm, SGD optimizer)",
+    )
+
+    model = MnistMultiClassClassifier(batch_norm=True)
+    train_mnist_multiclass_model(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        optimizer=optim.SGD(model.parameters, lr=1e-3),
+        model=model,
+        msg="(with batch norm, SGD optimizer)",
+    )
+
+    model = MnistMultiClassClassifier(batch_norm=True)
+    train_mnist_multiclass_model(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        optimizer=optim.Adam(model.parameters, lr=1e-3),
+        model=model,
+        msg="(with batch norm, Adam optimizer)",
+    )
+
+    train_mnist_one_vs_rest_model(X_train, y_train, X_test, y_test)

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -134,3 +134,23 @@ class TestBatchNorm(TestCase):
         assert np.allclose(
             self.bn.running_var, self.torch_bn.running_var.numpy(), atol=1e-5
         )
+
+    def test_backward(self):
+        x_data = np.array([[1.0, 2.0], [4.0, 5.0], [7.0, 8.0]], dtype=np.float32)
+        x = Tensor(x_data)
+        x_torch = torch.tensor(x_data, requires_grad=True, dtype=torch.float32)
+
+        self.bn.train()
+        self.torch_bn.train()
+
+        output = self.bn(x)
+        output_torch = self.torch_bn(x_torch)
+
+        # Create a simple loss = sum of all elements
+        loss = output.sum()
+        loss_torch = output_torch.sum()
+
+        loss.backward()
+        loss_torch.backward()
+
+        assert np.allclose(x.grad, x_torch.grad.numpy(), atol=1e-5)

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -86,3 +86,116 @@ class TestTensor(TestCase):
         # x.T * result.grad
         assert np.array_equal(y.grad, np.array([[4.0, 4.0], [6.0, 6.0]]))
         assert np.array_equal(z.grad, np.array([[1, 1], [1, 1]]))
+
+    def test_sum(self):
+        # Scalar tensor sum
+        x = Tensor(5.0, requires_grad=True)
+        s = x.sum()
+        assert s.data == 5.0
+        assert s.requires_grad == x.requires_grad
+
+        # 1D tensor sum (global)
+        x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+        s = x.sum()
+        assert s.data == 6.0
+        assert s.prev == {x}
+
+        # 1D tensor sum (axis)
+        x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+        s = x.sum(axis=0)
+        assert s.data == 6.0
+
+        # 2D tensor sum (global)
+        x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        s = x.sum()
+        assert s.data == 10.0
+
+        # 2D tensor sum (axis=0)
+        x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        s = x.sum(axis=0)  # (2, 2) -> (2,)
+        assert np.array_equal(s.data, [4.0, 6.0])
+
+        # 2D tensor sum (axis=1)
+        x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        s = x.sum(axis=1)  # (2, 2) -> (2,)
+        assert np.array_equal(s.data, [3.0, 7.0])
+
+        # 2D tensor sum with keepdims
+        x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        s = x.sum(axis=0, keepdims=True)
+        assert s.data.shape == (1, 2)  # (2,2) -> (1,2)
+        assert np.array_equal(s.data, [[4.0, 6.0]])
+
+        # 3D tensor sum
+        x = Tensor(
+            [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], requires_grad=True
+        )
+        s = x.sum(axis=(1, 2))  # (2,2,2) -> (2,)
+        assert np.array_equal(s.data, [10.0, 26.0])
+
+        # Verify requires_grad propagation
+        x = Tensor([1.0, 2.0, 3.0], requires_grad=False)
+        s = x.sum()
+        assert not s.requires_grad
+
+    def test_mean(self):
+        # Scalar tensor mean
+        x = Tensor(5.0, requires_grad=True)
+        m = x.mean()
+        assert m.data == 5.0
+        assert m.requires_grad == x.requires_grad
+
+        # 1D tensor mean (global)
+        x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+        m = x.mean()
+        assert m.data == 2.0
+        assert m.prev == {x}
+
+        # 1D tensor mean (axis)
+        x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+        m = x.mean(axis=0)
+        assert m.data == 2.0
+
+        # 2D tensor mean (global)
+        x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        m = x.mean()
+        assert m.data == 2.5
+
+        # 2D tensor mean (axis=0)
+        x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        m = x.mean(axis=0)  # (2, 2) -> (2,)
+        assert np.array_equal(m.data, [2.0, 3.0])
+
+        # 2D tensor mean (axis=1)
+        x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        m = x.mean(axis=1)  # (2, 2) -> (2,)
+        assert np.array_equal(m.data, [1.5, 3.5])
+
+        # 2D tensor mean with keepdims
+        x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+        m = x.mean(axis=0, keepdims=True)
+        assert m.data.shape == (1, 2)  # (2,2) -> (1,2)
+        assert np.array_equal(m.data, [[2.0, 3.0]])
+
+        # 3D tensor mean
+        x = Tensor(
+            [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], requires_grad=True
+        )
+        m = x.mean(axis=(1, 2))  # (2,2,2) -> (2,)
+        assert np.array_equal(m.data, [2.5, 6.5])
+
+        # Multiple axis mean
+        x = Tensor(
+            [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]], requires_grad=True
+        )
+        m = x.mean(axis=(0, 1))  # (2,2,2) -> (2,)
+        # Intermediate after axis 0:
+        # [[3.0, 4.0], [5.0, 6.0]]
+        # Imediate after axis 1:
+        # [4.0, 5.0]
+        assert np.array_equal(m.data, [4.0, 5.0])
+
+        # Verify requires_grad propagation
+        x = Tensor([1.0, 2.0, 3.0], requires_grad=False)
+        m = x.mean()
+        assert not m.requires_grad

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -45,4 +45,6 @@ class TestTrain(TestCase):
         y_pred = model(X).data
 
         # compare y_pred and y on the classification accuracy
-        logger.info(f"Accuracy: {(sum((y_pred > 0.5).astype(int) == y) / X.shape[0])}")
+        accuracy = sum((y_pred > 0.5).astype(int) == y) / X.shape[0]
+        logger.info(f"Accuracy: {accuracy}")
+        assert accuracy > 0.9


### PR DESCRIPTION
## Description
- Add batch norm layer (forward implementation, backward implementation covered by Tensor primitive backward operations)
- Add mean/sum tensor operations to support batch norm operations

## Tests

Added unit tests for batch norm, mean, sum.

Updated mnist.py to compare with or without batch norm and Adam vs SGD.
<img width="555" alt="image" src="https://github.com/user-attachments/assets/9965f30a-073b-4dba-8624-c94a47e1376b">

<img width="555" alt="image" src="https://github.com/user-attachments/assets/81131773-2f06-4f70-b782-04b79945daa7">
