### PR TITLE
Add hinge loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We are creating an autograd engine from scratch and use it to build/train more c
 ## Technical Overview
 - `tensor` (base class)
   - support scalar, vector, N-dimensional matrices
-  - arithmetic: add, mul, matmul, pow, sub, division, neg
+  - arithmetic: add, mul, matmul, pow, sub, division, neg, max, mean
   - core: forward, backward, reshape
 - `nn` (neural network components)
   - Module (base class)
@@ -40,7 +40,7 @@ We are creating an autograd engine from scratch and use it to build/train more c
   - Dropout (regularization)
 - `functional` (including backprop derivation defined in `backward()`)
   - Activation functions: relu, sigmoid, softmax
-  - Loss: binary_cross_entropy, sparse_cross_entropy
+  - Loss: binary_cross_entropy, sparse_cross_entropy, hinge_loss
 - `optim`
   - Optimizer (base class)
   - SGD (stochastic gradient descent)

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -1,5 +1,6 @@
 import numpy as np
 import logging
+from typing import Union, Self
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ class Tensor:
         result._backward = _backward
         return result
 
-    def __matmul__(self, other):
+    def __matmul__(self, other: Union[Self, float, int]):
         if not isinstance(other, Tensor):
             other = Tensor(other)
 
@@ -222,18 +223,6 @@ class Tensor:
         result._backward = _backward
         return result
 
-    def __sub__(self, other):
-        return self + (-other)
-
-    def __truediv__(self, other):
-        return self * other**-1
-
-    def __neg__(self):
-        return self * -1
-
-    def __repr__(self):
-        return f"Tensor(data={self.data}, grad={self.grad})"
-
     def sum(self, axis=None, keepdims=False):
         """
         Compute the sum of tensor elements
@@ -292,6 +281,50 @@ class Tensor:
         result._backward = lambda: self._reduce_ops_backward(
             output=result, axis=axis, keepdims=keepdims
         )
+        return result
+
+    def max(self, axis=None, keepdims=False):
+        """
+        Compute the max of tensor elements
+
+        Args:
+            axis (int or tuple of ints, optional): Axis or axes along which a max is performed. The default, axis=None, maxes all of the elements of the input tensor.
+            keepdims (bool, optional): If this is set to True, the axes which are reduced are left in the result as dimensions with size one. With this option, the result will broadcast correctly against the input tensor.
+        """
+        axis = (axis,) if isinstance(axis, int) else axis
+
+        result = Tensor(
+            data=np.max(self.data, axis=axis, keepdims=keepdims),
+            prev=(self,),
+            requires_grad=self.requires_grad,
+        )
+
+        result._backward = lambda: self._reduce_ops_backward(
+            output=result, axis=axis, keepdims=keepdims
+        )
+        return result
+
+    def maximum(self, other: Union[Self, float, int]):
+        """
+        Element-wise maximum between self and other
+        """
+        if not isinstance(other, Tensor):
+            other = Tensor(other, requires_grad=False)
+
+        result = Tensor(
+            data=np.maximum(self.data, other.data),
+            prev=(self, other),
+            requires_grad=self.requires_grad or other.requires_grad,
+        )
+
+        def _backward():
+            # For max(self,other), the gradient flows to self where self>other, and to other where other>self
+            # When self=other, gradient is split between both (we'll give it to self in this case)
+            mask = self.data >= other.data
+            self.grad += result.grad * mask
+            other.grad += result.grad * (~mask)
+
+        result._backward = _backward
         return result
 
     def _reduce_ops_backward(self, output, axis=None, keepdims=False):
@@ -361,3 +394,37 @@ class Tensor:
     def reshape(self, *shape):
         self.data = self.data.reshape(*shape)
         return self
+
+    ##### Wrappers #####
+    def __radd__(self, other):
+        return self + other
+
+    def __rmul__(self, other):
+        return self * other
+
+    def __sub__(self, other):
+        return self + (-other)
+
+    def __rsub__(self, other):
+        return other + (-self)
+
+    def __truediv__(self, other):
+        return self * other**-1
+
+    def __neg__(self):
+        return self * -1
+
+    def __repr__(self):
+        return f"Tensor(data={self.data}, grad={self.grad})"
+
+    def __lt__(self, other):
+        return self.data < other
+
+    def __le__(self, other):
+        return self.data <= other
+
+    def __gt__(self, other):
+        return self.data > other
+
+    def __ge__(self, other):
+        return self.data >= other


### PR DESCRIPTION
## Description

- Add hinge loss and associated backward propagation implementation
- Add some missing primitive Tensor ops (e.g. `__rsub__`, `__gt__`, max, maximum) that are used by other higher-level ops
- Add an example mnist model using Hinge loss

## Tests

**Added unit tests for hinge loss**

**MNIST model using hinge loss**
<img width="444" alt="image" src="https://github.com/user-attachments/assets/b46eedfc-0df8-4c82-8806-cda5267dc1b9">
<img width="444" alt="image" src="https://github.com/user-attachments/assets/4536c9de-a23d-4a8b-b908-8347d8ebbf5a">

