### PR TITLE
Enrich Tensor Ops

### DIFF
--- a/autograd/functional.py
+++ b/autograd/functional.py
@@ -88,6 +88,12 @@ def binary_cross_entropy(y_pred: Tensor, y_true: Union[Tensor, np.ndarray]) -> T
         raise ValueError("y_pred must contain probabilities between 0 and 1")
 
     y_true = np.array(y_true.data) if isinstance(y_true, Tensor) else y_true
+
+    if y_true.ndim == 1 and y_pred.data.ndim == 1:
+        pass
+    elif y_true.ndim == 1:
+        y_true = y_true.reshape(-1, 1)
+
     if y_pred.data.shape[0] != y_true.shape[0]:
         raise ValueError("y_pred and y_true must have the same shape")
 

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -1,22 +1,139 @@
 import numpy as np
 import logging
-from typing import Union, Self
+from typing import Union, Self, List
 
 logger = logging.getLogger(__name__)
 
 
 class Tensor:
-    def __init__(self, data, prev=(), requires_grad=True):
+    def __init__(self, data, prev=None, requires_grad=True):
         if isinstance(data, (list, tuple)):
             data = np.array(data)
-        else:
-            data = data
 
         self.data = data
-        self.grad = np.zeros_like(self.data, dtype=np.float64)
+        self.grad = None  # lazy initialize, we will only initialize if needed in the backward pass
+
         self._backward = lambda: None
-        self.prev = set(prev)  # all the operations before this Tensor
+        self.prev = (
+            set(prev) if prev else set()
+        )  # all the operations before this Tensor
         self.requires_grad = requires_grad
+
+    @staticmethod
+    def stack(tensors: List[Self], axis=0):
+        """
+        Join a sequence of tensors along a new axis.
+
+        Args:
+            tensors (list of Tensors): sequence of tensors to stack
+            axis (int): axis along which to stack
+
+        Returns:
+            Tensor: stacked tensor
+        """
+        if not tensors:
+            raise ValueError("Need at least one tensor to stack")
+
+        # Convert any non-Tensor inputs to Tensors
+        tensors = [t if isinstance(t, Tensor) else Tensor(t) for t in tensors]
+
+        # Stack the underlying numpy arrays
+        stacked_data = np.stack([t.data for t in tensors], axis=axis)
+
+        # Create new tensor with stacked data
+        result = Tensor(
+            data=stacked_data,
+            prev=set(tensors),  # maintain connections to all input tensors
+            requires_grad=any(t.requires_grad for t in tensors),
+        )
+
+        def _backward():
+            # Split the gradient along the stacking axis
+            grads = np.split(result.grad, len(tensors), axis=axis)
+
+            # Distribute gradients to input tensors
+            for tensor, grad in zip(tensors, grads):
+                # Squeeze the gradient to match the input tensor's shape
+                tensor.grad += np.squeeze(grad, axis=axis)
+
+        result._backward = _backward
+        return result
+
+    @staticmethod
+    def cat(tensors, axis=0):
+        """Concatenates tensors along specified axis"""
+        data = np.concatenate([t.data for t in tensors], axis=axis)
+        requires_grad = any(t.requires_grad for t in tensors)
+
+        result = Tensor(data, requires_grad=requires_grad)
+
+        if requires_grad:
+
+            def _backward():
+                start_idx = 0
+                for t in tensors:
+                    shape = list(t.data.shape)
+                    slice_idx = [slice(None)] * len(shape)
+                    slice_idx[axis] = slice(start_idx, start_idx + shape[axis])
+                    t.grad += result.grad[tuple(slice_idx)]
+                    start_idx += shape[axis]
+
+            result._backward = _backward
+            result.prev = set(tensors)
+
+        return result
+
+    def transpose(self, *dims):
+        """
+        Transpose (permute) the dimensions of the tensor.
+        """
+        if not dims:
+            dims = tuple(range(len(self.data.shape)))[::-1]
+
+        result = Tensor(
+            data=np.transpose(self.data, dims),
+            requires_grad=self.requires_grad,
+            prev={self} if self.requires_grad else None,
+        )
+
+        if self.requires_grad:
+
+            def _backward():
+                # Create inverse permutation
+                inverse_dims = [0] * len(dims)
+                for i, d in enumerate(dims):
+                    inverse_dims[d] = i
+
+                logger.debug("\nTranspose backward debug:")
+                logger.debug(f"Original shape: {self.data.shape}")
+                logger.debug(f"Result shape: {result.data.shape}")
+                logger.debug(f"Result grad shape: {result.grad.shape}")
+                logger.debug(
+                    f"Self grad shape: {self.grad.shape if self.grad is not None else None}"
+                )
+
+                # Transpose gradient back using inverse permutation
+                transposed_grad = np.transpose(result.grad, inverse_dims)
+
+                # Reshape transposed_grad to match self.grad shape
+                if self.grad.shape != transposed_grad.shape:
+                    # Flatten both arrays to 1D first
+                    flat_grad = self.grad.reshape(-1)
+                    flat_transposed = transposed_grad.reshape(-1)
+
+                    # Ensure they have the same number of elements
+                    assert (
+                        flat_grad.size == flat_transposed.size
+                    ), f"Incompatible shapes: {self.grad.shape} and {transposed_grad.shape}"
+
+                    # Reshape transposed_grad to match self.grad shape
+                    transposed_grad = transposed_grad.reshape(self.grad.shape)
+
+                self.grad += transposed_grad
+
+            result._backward = _backward
+
+        return result
 
     # For each of these primitive operations, we need to adjust the backward gradient computation accordingly
     def __add__(self, other):
@@ -31,7 +148,7 @@ class Tensor:
 
         result = Tensor(
             data=self.data + other.data,
-            prev=(self, other),
+            prev={self, other},
             requires_grad=self.requires_grad or other.requires_grad,
         )
 
@@ -60,11 +177,18 @@ class Tensor:
                     if g_dim != t_dim
                 )
 
-                # Sum over the identified axes
-                return np.sum(grad_to_add, axis=axes_to_sum).reshape(target_shape)
+                # Sum over the identified axes and ensure output shape matches target
+                result = np.sum(grad_to_add, axis=axes_to_sum)
+                result = result.reshape(target_shape)
+                return result
 
-            self.grad += result.grad
-            other.grad += reverse_broadcast(result.grad, other.data.shape)
+            # Update self gradient
+            if self.requires_grad:
+                self.grad += result.grad
+
+            # Update other gradient
+            if other.requires_grad:
+                other.grad += reverse_broadcast(result.grad, other.data.shape)
 
         result._backward = _backward
         return result
@@ -75,7 +199,7 @@ class Tensor:
 
         result = Tensor(
             data=self.data * other.data,
-            prev=(self, other),
+            prev={self, other},
             requires_grad=self.requires_grad or other.requires_grad,
         )
 
@@ -86,24 +210,39 @@ class Tensor:
             d(xy) / dx = y
             d(xy) / dy = x
             """
-            grad = result.grad
+            logger.debug(f"Mul backward - self: {self}, grad: {self.grad}")
+            logger.debug(f"Mul backward - other: {other}, grad: {other.grad}")
+            logger.debug(f"Mul backward - result: {result}, grad: {result.grad}")
+
+            # For scalar inputs, ensure we get scalar gradients
+            if np.isscalar(self.data) and np.isscalar(other.data):
+                if self.requires_grad:
+                    self.grad += float(other.data * result.grad)
+                if other.requires_grad:
+                    other.grad += float(self.data * result.grad)
+                return
+
             # Handle broadcasting: sum along broadcasted dimensions
             if np.isscalar(self.data) or (
                 isinstance(other.data, np.ndarray)
                 and self.data.shape != other.data.shape
             ):
-                self.grad += np.sum(other.data * grad)
+                if self.requires_grad:
+                    self.grad += np.sum(other.data * result.grad)
             else:
-                self.grad += other.data * grad
+                if self.requires_grad:
+                    self.grad += other.data * result.grad
 
             # Handle broadcasting: sum along broadcasted dimensions
             if np.isscalar(other.data) or (
                 isinstance(self.data, np.ndarray)
                 and self.data.shape != other.data.shape
             ):
-                other.grad += np.sum(self.data * grad)
+                if other.requires_grad:
+                    other.grad += np.sum(self.data * result.grad)
             else:
-                other.grad += self.data * grad
+                if other.requires_grad:
+                    other.grad += self.data * result.grad
 
         result._backward = _backward
         return result
@@ -121,13 +260,10 @@ class Tensor:
         #   - First operand (x): reshape to (1, n) row vector
         #   - Second operand (y): reshape to (n, 1) column vector
         # - If input is 2D matrix, keep original shape
-        x = self.data.reshape((1, -1)) if self.data.ndim == 1 else self.data
-        y = other.data.reshape((-1, 1)) if other.data.ndim == 1 else other.data
-
         result = Tensor(
-            data=np.matmul(x, y).squeeze(),
-            prev=(self, other),
+            data=np.matmul(self.data, other.data),
             requires_grad=self.requires_grad or other.requires_grad,
+            prev={self, other} if (self.requires_grad or other.requires_grad) else None,
         )
 
         def _backward():
@@ -153,31 +289,46 @@ class Tensor:
                    result.grad = (num_samples, num_classes)
                    x.T * result.grad = (num_features, num_classes)  # same shape as y
             """
-            # Vector @ Vector case (result is scalar)
+            logger.debug("\nMatmul backward debug:")
+            logger.debug(f"self shape: {self.data.shape}")
+            logger.debug(f"other shape: {other.data.shape}")
+            logger.debug(f"result.grad shape: {result.grad.shape}")
+
+            # Handle vector @ vector case separately (1D @ 1D)
             if self.data.ndim == 1 and other.data.ndim == 1:
-                self.grad += result.grad * other.data
-                other.grad += result.grad * self.data
+                if self.requires_grad:
+                    self.grad += float(result.grad) * other.data
+                if other.requires_grad:
+                    other.grad += float(result.grad) * self.data
+                return
 
-            # Matrix @ Vector case (result is vector)
-            elif self.data.ndim == 2 and other.data.ndim == 1:
-                self.grad += np.outer(result.grad, other.data)
-                other.grad += np.matmul(self.data.T, result.grad)
+            # Handle N-D tensor multiplication (2D and higher)
+            # Let's say we intially have a self.data of shape (n, m)
+            # and other.data of shape (m, p)
+            # Then result.data will be of shape (n, p)
+            # We need to compute the gradient of the loss w.r.t. self.data
+            # d(loss) / d(self.data) = d(loss) / d(result) * d(result) / d(self.data)
+            # d(result) / d(self.data) = other.data.T
 
-            # Matrix @ Matrix case (result is matrix)
-            else:
-                # Ensure result.grad is 2D
-                if result.grad.ndim == 1:
-                    result_grad = result.grad.reshape(1, -1)
-                else:
-                    result_grad = result.grad
+            # The usage of swapaxes is to ensure that the matrix multiplication is correct
+            # when the dimensions are not in the expected order
+            # self.data:    (n, m)
+            # other.data:   (m, p)
+            # result.grad:  (n, p)
+            # other.T:      (p, m) --> T operation is equivalent to swapaxes(-1, -2)
+            # matmul(result.grad, other.T) = (n, p) @ (p, m) = (n, m) = self.grad
+            if self.requires_grad:
+                self.grad += np.matmul(result.grad, other.data.swapaxes(-1, -2))
 
-                # Ensure result_grad has the same shape as the forward pass output
-                if result_grad.shape != (self.data.shape[0], other.data.shape[1]):
-                    result_grad = result_grad.reshape(
-                        self.data.shape[0], other.data.shape[1]
-                    )
-                self.grad += np.matmul(result_grad, other.data.T)
-                other.grad += np.matmul(self.data.T, result_grad)
+            # Compute gradient of loss w.r.t. other.data
+            # d(loss) / d(other.data) = d(loss) / d(result) * d(result) / d(other.data)
+            # d(result) / d(other.data) = self.data.T
+            # self.data:    (n, m)
+            # result.grad:  (n, p)
+            # self.T:       (m, n) --> T operation is equivalent to swapaxes(-1, -2)
+            # matmul(self.T, result.grad) = (m, n) @ (n, p) = (m, p) = other.grad
+            if other.requires_grad:
+                other.grad += np.matmul(self.data.swapaxes(-1, -2), result.grad)
 
         result._backward = _backward
         return result
@@ -188,7 +339,7 @@ class Tensor:
 
         result = Tensor(
             data=self.data**other.data,
-            prev=(self, other),
+            prev={self, other},
             requires_grad=self.requires_grad or other.requires_grad,
         )
 
@@ -223,35 +374,92 @@ class Tensor:
         result._backward = _backward
         return result
 
-    def __getitem__(self, idx):
+    def __iadd__(self, other):
         """
-        Support indexing operations on Tensor
+        In-place addition operation (+=).
+        This should maintain the computational graph while modifying the tensor in-place.
         """
-        result = Tensor(
-            data=self.data[idx], prev=(self,), requires_grad=self.requires_grad
-        )
+        if not isinstance(other, Tensor):
+            other = Tensor(other)
+
+        # Update data in-place
+        self.data = self.data + other.data
+        self.prev.add(other)
+        self.requires_grad = self.requires_grad or other.requires_grad
+
+        # Store original backward function
+        original_backward = self._backward
 
         def _backward():
-            # Create a gradient array of zeros with the same shape as the original data
-            grad = np.zeros_like(self.data)
-            # Use numpy's advanced indexing to accumulate gradients
-            np.add.at(grad, idx, result.grad)
-            self.grad += grad
+            # Call original backward first
+            original_backward()
+
+            if other.requires_grad:
+                if np.isscalar(other.data) or other.data.shape == ():
+                    other.grad += float(np.sum(self.grad))
+                else:
+                    # Handle broadcasting
+                    grad = self.grad
+                    if grad.shape != other.data.shape:
+                        # Sum across broadcasted dimensions
+                        sum_axes = tuple(range(len(grad.shape) - len(other.data.shape)))
+                        if sum_axes:
+                            grad = np.sum(grad, axis=sum_axes)
+                        # Handle broadcasting within common dimensions
+                        for i, (g, o) in enumerate(zip(grad.shape, other.data.shape)):
+                            if o == 1:
+                                grad = np.sum(grad, axis=i, keepdims=True)
+                    other.grad = other.grad + grad if other.grad is not None else grad
+
+        self._backward = _backward
+        return self
+
+    def __getitem__(self, idx):
+        result = Tensor(self.data[idx], prev={self}, requires_grad=self.requires_grad)
+
+        def _backward():
+            if isinstance(idx, tuple):
+                idx_list = list(idx)
+                for i, index in enumerate(idx_list):
+                    if isinstance(index, slice):
+                        if index.start is None and index.stop is None:
+                            idx_list[i] = slice(0, self.data.shape[i])
+                # Accumulate gradients instead of assigning
+                if isinstance(result.grad, np.ndarray):
+                    self.grad[tuple(idx_list)] += result.grad
+                else:
+                    self.grad[tuple(idx_list)] += np.array(result.grad)
+            else:
+                # Accumulate gradients instead of assigning
+                if isinstance(result.grad, np.ndarray):
+                    self.grad[idx] += result.grad
+                else:
+                    self.grad[idx] += np.array(result.grad)
 
         result._backward = _backward
         return result
 
     def __setitem__(self, idx, value):
-        """
-        Support assignment operations on Tensor
-        """
         if isinstance(value, Tensor):
+            # Create intermediate tensor for graph connectivity
+            temp = Tensor(
+                data=value.data, prev={value}, requires_grad=value.requires_grad
+            )
+
+            # Store original value and update data
             self.data[idx] = value.data
+            self.prev.add(temp)
 
             def _backward():
-                self.grad[idx] += value.grad
+                # Pass gradient to value tensor
+                if value.requires_grad:
+                    # Handle different index types
+                    if isinstance(idx, tuple):
+                        value.grad += np.sum(self.grad[idx])
+                    else:
+                        value.grad += self.grad[idx]
 
-            value._backward = _backward
+            self._backward = _backward
         else:
             self.data[idx] = value
 
@@ -270,9 +478,7 @@ class Tensor:
         """
         # Handle scalar case
         if not hasattr(self.data, "ndim") or self.data.ndim == 0:
-            return Tensor(
-                data=self.data, prev=(self,), requires_grad=self.requires_grad
-            )
+            return Tensor(data=self.data, prev={self}, requires_grad=self.requires_grad)
 
         # Normalize axis
         axis = (axis,) if isinstance(axis, int) else axis
@@ -280,27 +486,23 @@ class Tensor:
         # Compute sum
         result = Tensor(
             data=np.sum(self.data, axis=axis, keepdims=keepdims),
-            prev=(self,),
+            prev={self},
             requires_grad=self.requires_grad,
         )
 
         def _backward():
-            grad = result.grad
-            if axis is None:
-                self.grad = np.ones_like(self.data) * grad
+            # Expand along the summed axes
+            if keepdims:
+                expanded_shape = self.data.shape
             else:
-                if isinstance(axis, int):
-                    axes = (axis,)
-                else:
-                    axes = axis
-                grad = grad.reshape(
-                    [
-                        1 if ax in axes else self.data.shape[ax]
-                        for ax in range(self.data.ndim)
-                    ]
+                # Convert generator to list before adding to shape
+                expanded_shape = tuple(
+                    s for i, s in enumerate(self.data.shape) if i != axis
                 )
-                self.grad = np.broadcast_to(grad, self.data.shape)
-            # self.grad += grad
+            grad_expanded = np.broadcast_to(result.grad, expanded_shape)
+
+            # Add to existing gradient
+            self.grad += grad_expanded
 
         result._backward = _backward
         return result
@@ -324,7 +526,7 @@ class Tensor:
         # Create result tensor
         result = Tensor(
             data=np.mean(self.data, axis=axis, keepdims=keepdims),
-            prev=(self,),
+            prev={self},
             requires_grad=self.requires_grad,
         )
 
@@ -377,7 +579,7 @@ class Tensor:
 
         result = Tensor(
             data=np.max(self.data, axis=axis, keepdims=keepdims),
-            prev=(self,),
+            prev={self},
             requires_grad=self.requires_grad,
         )
 
@@ -387,9 +589,6 @@ class Tensor:
             d(loss) / d(max(x)) = result.grad
             d(max(x)) / dx = 1 if x == max(x), 0 otherwise
             """
-            # Initialize gradient array with zeros
-            grad = np.zeros_like(self.data)
-
             if axis is None:
                 # For global max, gradient flows only to elements equal to max value
                 # Create boolean mask of elements equal to max
@@ -415,68 +614,93 @@ class Tensor:
 
     def maximum(self, other: Union[Self, float, int]):
         """
-        Element-wise maximum between self and other
+        Element-wise maximum between self and other.
+        When both inputs equal the maximum, gradient is split equally between them.
         """
         if not isinstance(other, Tensor):
             other = Tensor(other, requires_grad=False)
 
         result = Tensor(
             data=np.maximum(self.data, other.data),
-            prev=(self, other),
+            prev={self, other},
             requires_grad=self.requires_grad or other.requires_grad,
         )
 
         def _backward():
-            # For max(self,other), the gradient flows to self where self>other, and to other where other>self
-            # When self=other, gradient is split between both (we'll give it to self in this case)
-            mask = self.data >= other.data
-            self.grad += result.grad * mask
-            other.grad += result.grad * (~mask)
+            # Create masks for where each input equals the maximum
+            x_matches = self.data == result.data
+            y_matches = other.data == result.data
+
+            if self.requires_grad:
+                # Full gradient where only x matches, half where both match
+                self.grad += result.grad * (x_matches * (1.0 - 0.5 * y_matches))
+
+            if other.requires_grad:
+                # Handle broadcasting for y's gradient
+                grad = result.grad * (y_matches * (1.0 - 0.5 * x_matches))
+                if grad.shape != other.data.shape:
+                    # Sum across broadcasted dimensions
+                    sum_axes = tuple(range(len(grad.shape) - len(other.data.shape)))
+                    if sum_axes:
+                        grad = np.sum(grad, axis=sum_axes)
+                    # Handle broadcasting within common dimensions
+                    for i, (g, o) in enumerate(zip(grad.shape, other.data.shape)):
+                        if o == 1:
+                            grad = np.sum(grad, axis=i, keepdims=True)
+                other.grad += grad
 
         result._backward = _backward
         return result
 
     def pad(self, pad_width, mode="constant", constant_values=0):
-        # Convert PyTorch-style padding (left, right) to numpy-style padding
-        if isinstance(pad_width, tuple) and len(pad_width) == 2:
-            pad_width = (
-                (pad_width[0], pad_width[1]),
-            )  # Convert to numpy pad_width format
+        """
+        Pad the tensor with zeros.
+        Args:
+            pad_width: If tuple of 2 values, interpreted as padding for last dimension (PyTorch style).
+                      If tuple of tuples, each inner tuple is (pad_before, pad_after) for each dimension.
+                      If int, pad all dimensions with same value.
+            mode: Padding mode (default: "constant")
+            constant_values: Value to pad with (default: 0)
+        """
+        # Handle integer padding
+        if isinstance(pad_width, int):
+            if len(self.data.shape) == 1:
+                pad_width = ((pad_width, pad_width),)
+            elif len(self.data.shape) == 2:
+                pad_width = ((pad_width, pad_width), (pad_width, pad_width))
+            elif len(self.data.shape) == 3:
+                pad_width = ((0, 0), (pad_width, pad_width), (pad_width, pad_width))
+            elif len(self.data.shape) == 4:
+                pad_width = (
+                    (0, 0),
+                    (0, 0),
+                    (pad_width, pad_width),
+                    (pad_width, pad_width),
+                )
+            else:
+                raise ValueError("Unsupported number of dimensions")
+
+        # Convert PyTorch-style padding to numpy-style padding
+        elif isinstance(pad_width, tuple):
+            if len(pad_width) == 2 and not isinstance(pad_width[0], tuple):
+                # Convert (left, right) to ((left, right),)
+                pad_width = ((pad_width[0], pad_width[1]),)
+            elif len(pad_width) == 4 and not isinstance(pad_width[0], tuple):
+                # Convert (left, right, top, bottom) to ((top, bottom), (left, right))
+                pad_width = ((pad_width[2], pad_width[3]), (pad_width[0], pad_width[1]))
 
         result = Tensor(
             data=np.pad(
                 self.data,
                 pad_width=pad_width,
-                constant_values=constant_values,
                 mode=mode,
+                constant_values=constant_values,
             ),
-            prev=(self,),
+            prev={self},
             requires_grad=self.requires_grad,
         )
 
         def _backward():
-            if self.grad is None:
-                self.grad = np.zeros_like(self.data)
-            # Store original pad_width
-            nonlocal pad_width
-
-            if isinstance(pad_width, int):
-                if len(self.data.shape) == 1:
-                    pad_width = (pad_width, pad_width)
-                elif len(self.data.shape) == 2:
-                    pad_width = ((pad_width, pad_width), (pad_width, pad_width))
-                elif len(self.data.shape) == 3:
-                    pad_width = ((0, 0), (pad_width, pad_width), (pad_width, pad_width))
-                elif len(self.data.shape) == 4:
-                    pad_width = (
-                        (0, 0),
-                        (0, 0),
-                        (pad_width, pad_width),
-                        (pad_width, pad_width),
-                    )
-                else:
-                    raise ValueError("Unsupported number of dimensions")
-
             if (
                 len(self.data.shape) == 4
             ):  # For 4D tensors (batch, channels, height, width)
@@ -498,14 +722,9 @@ class Tensor:
                     pad_width[1][0] : result.grad.shape[1] - pad_width[1][1],
                 ]
             elif len(self.data.shape) == 1:  # For 1D tensors
-                if isinstance(pad_width[0], tuple):
-                    self.grad = result.grad[
-                        pad_width[0][0] : result.grad.shape[0] - pad_width[0][1]
-                    ]
-                else:
-                    self.grad = result.grad[
-                        pad_width[0] : result.grad.shape[0] - pad_width[0]
-                    ]
+                self.grad += result.grad[
+                    pad_width[0][0] : result.grad.shape[0] - pad_width[0][1]
+                ]
             else:
                 raise ValueError("Unsupported number of dimensions")
 
@@ -515,7 +734,18 @@ class Tensor:
     def forward(self, data):
         pass
 
-    def backward(self):
+    def backward(self, grad=None):
+        if not self.requires_grad:
+            return
+
+        # Note that this is important to ensure our gradients shape is not a scalar
+        # to ensure we follow the same matmul assumption as Pytorch.
+        if self.grad is None:
+            if np.isscalar(self.data):
+                self.grad = np.array([grad or 1.0])
+            else:
+                self.grad = np.ones_like(self.data)
+
         topological_sorted_tensors = []
         visited = set()
 
@@ -523,7 +753,15 @@ class Tensor:
             if node not in visited:
                 visited.add(node)
                 for prev in node.prev:
-                    dfs(prev)
+                    if prev.requires_grad:
+                        # Initialize the intermediate gradients, the initialization above is
+                        # only for the leaf (last) node in which we call backward().
+                        if prev.grad is None and prev.requires_grad:
+                            if np.isscalar(prev.data):
+                                prev.grad = np.array([0.0], dtype=np.float64)
+                            else:
+                                prev.grad = np.zeros_like(prev.data, dtype=np.float64)
+                        dfs(prev)
                 # the order in which we append to the list is in reverse order
                 # because we always move backwards looking at the previous nodes
                 # that point to the current node
@@ -531,9 +769,6 @@ class Tensor:
 
         dfs(self)
 
-        # Note that this is important to ensure our gradients shape is not a scalar
-        # to ensure we follow the same matmul assumption as Pytorch.
-        self.grad = np.ones_like(self.data)
         for tensor in reversed(topological_sorted_tensors):
             tensor._backward()
 
@@ -552,6 +787,18 @@ class Tensor:
     def reshape(self, *shape):
         self.data = self.data.reshape(*shape)
         return self
+
+    @property
+    def T(self):
+        """
+        Convenience method for 2D matrix transpose.
+        For higher dimensions, use transpose() with explicit dims.
+        """
+        if len(self.data.shape) != 2:
+            raise ValueError(
+                "T property is only defined for 2D tensors. Use transpose() for higher dimensions."
+            )
+        return self.transpose(1, 0)
 
     ##### Wrappers #####
     def __radd__(self, other):

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -3,10 +3,11 @@ from autograd.nn import Linear, BatchNorm, Dropout
 from autograd.tensor import Tensor
 import random
 import numpy as np
-import torch
+import torch  # for comparison
 
 random.seed(1337)
 np.random.seed(1337)
+torch.manual_seed(1337)
 
 
 class TestLinear(TestCase):
@@ -24,15 +25,9 @@ class TestLinear(TestCase):
         x = [[2, 2, 2, 2]]
         out = linear_layer(x)
         assert np.allclose(out.data, [-2.7748068, 0.56519009])
-        assert np.allclose(
-            out.grad, [0, 0]
-        )  # this should still be zero before we call backward
-        assert np.allclose(
-            parameters["weight"].grad, np.zeros_like(parameters["weight"].data)
-        )
-        assert np.allclose(
-            parameters["bias"].grad, np.zeros_like(parameters["bias"].data)
-        )
+        assert out.grad is None
+        assert parameters["weight"].grad is None
+        assert parameters["bias"].grad is None
         out.backward()
 
         # weight gradient = x.T @ out.grad = [[2], [2], [2], [2]] * [1, 1]
@@ -46,7 +41,7 @@ class TestLinear(TestCase):
             ],
         )
         assert np.array_equal(parameters["bias"].grad, [1, 1])
-        assert np.array_equal(out.grad, [1, 1])
+        assert np.array_equal(out.grad, [[1, 1]])
 
         # Trying to pass in (4x1 matrix)
         x = [[2], [2], [2], [2]]

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -237,3 +237,36 @@ class TestTensor(TestCase):
         z = x.max(axis=1, keepdims=True)
         assert z.data.shape == (2, 1)  # (2,3) -> (2,1)
         assert np.array_equal(z.data, [[3.0], [2.0]])
+
+    def test_getitem(self):
+        x = Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], requires_grad=True)
+        y = x[0, 1]
+        assert y.data == 2.0
+        assert y.prev == {x}
+        y.backward()
+        assert np.array_equal(x.grad, np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0]]))
+
+        x = Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], requires_grad=True)
+        z = x[0:2, 1]
+        assert np.array_equal(z.data, [2.0, 5.0])
+        z.backward()
+        assert np.array_equal(x.grad, np.array([[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]]))
+
+        x = Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], requires_grad=True)
+        a = x[0]
+        assert np.array_equal(a.data, [1.0, 2.0, 3.0])
+        a.backward()
+        assert np.array_equal(x.grad, np.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]))
+
+        x = Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], requires_grad=True)
+        b = x[-1, -1]
+        c = b * 2
+        assert b.data == 6.0
+        assert c.data == 12.0
+        c.backward()
+        assert np.array_equal(x.grad, np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]))
+
+    def test_setitem(self):
+        x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+        x[0] = 4.0
+        np.array_equal(x.data, [4.0, 2.0, 3.0])

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -45,6 +45,6 @@ class TestTrain(TestCase):
         y_pred = model(X).data
 
         # compare y_pred and y on the classification accuracy
-        accuracy = sum((y_pred > 0.5).astype(int) == y) / X.shape[0]
+        accuracy = sum((y_pred.squeeze() > 0.5).astype(int) == y) / X.shape[0]
         logger.info(f"Accuracy: {accuracy}")
         assert accuracy > 0.9


### PR DESCRIPTION
## Description
Enriched the Tensor class operations preparing for more complex operations in the future (e.g. convolution operations)

- Add `stack()`
- Add `cat()`
- Add `transpose()`, and `T` (alias)
- Add `pad()`
- Add `__iadd__()`
- Add `__getitem__()` and `__setitem()__`
- Add `shape` (alias)
- Updated `__mul__()` to handle scalar inputs correctly to get scalar gradients
- Updated `__add__()` to correctly accumulate gradients
- Updated `sum()` to handle gradient broadcasting correctly for N-dimensional matrices
- Updated `maximum()` to follow pytorch's implementation of splitting grade
- Move `_reduce_ops_backward` to the `_backward()` function of `mean()`
- Simplified __matmul__() to handle N-dimensional matrix multiplication by leveraging numpy's `matmul` function with `swapaxes`
- changes to all tensor ops
  - updated all the `prev` to use set instead of tuple
  - check for requires_grad before accumulating gradients for `self` or `other`
- Updated `Tensor.backward()` to lazy initialize the gradients inside here, instead of in the Tensor `__init__` constructor

## Tests
Added associated unit tests for each change.

Verified all the training examples are working as expected.
<!-- How did you test your changes? Did you add unit tests for new features? -->
