### PR TITLE
Convolutional Layer (part 3 and final optimized)

### DIFF
--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -178,10 +178,14 @@ class Conv2d(Module):
         )
 
         # Reshape kernel for matrix multiplication
-        kernel_flat = self._parameters["weight"].reshape(self.out_channels, -1)
+        kernel_flat = (
+            self._parameters["weight"]
+            .permute(1, 2, 3, 0)
+            .reshape(-1, self.out_channels)
+        )
 
         # Compute convolution using matrix multiplication
-        output = windows @ kernel_flat.T
+        output = windows @ kernel_flat
 
         # Reshape output to (batch_size, H_out, W_out, out_channels)
         output = output.reshape(batch_size, H_out, W_out, self.out_channels)
@@ -329,7 +333,7 @@ class Dropout(Module):
 ########### Utility Functions ###########
 def extract_windows(x, kernel_size, stride, padding_mode="valid"):
     """
-    Shared utility function to extract windows from input tensor while maintaining computational graph
+    Extract windows from input tensor while maintaining computational graph.
 
     Args:
         x (Tensor): Input tensor of shape (batch_size, channels, height, width)
@@ -347,43 +351,21 @@ def extract_windows(x, kernel_size, stride, padding_mode="valid"):
 
     batch_size, in_channels, H, W = x.data.shape
 
-    # Calculate output dimensions first
     if padding_mode == "same":
-        # For MaxPool2d with kernel_size=2 and stride=2, PyTorch adds 1 pixel padding first
-        pad_h = pad_w = 1
+        pad_h = pad_w = kernel_size // 2
         x_padded = x.pad(
             pad_width=((0, 0), (0, 0), (pad_h, pad_h), (pad_w, pad_w)),
             mode="constant",
             constant_values=0,
         )
-        # Output size calculation after padding
-        H_padded = H + 2 * pad_h
-        W_padded = W + 2 * pad_w
-        H_out = (H_padded - kernel_size) // stride + 1
-        W_out = (W_padded - kernel_size) // stride + 1
-    elif padding_mode == "valid":
-        x_padded = x
-        H_out = (H - kernel_size) // stride + 1
-        W_out = (W - kernel_size) // stride + 1
     else:
-        raise ValueError(f"Invalid padding mode: {padding_mode}")
+        x_padded = x
 
-    windows_list = []
+    # Get windows using strided_windows
+    windows = x_padded.strided_windows(kernel_size, stride)
 
-    # Extract windows using numpy's advanced indexing
-    i_indices = np.arange(0, x_padded.shape[2] - kernel_size + 1, stride)
-    j_indices = np.arange(0, x_padded.shape[3] - kernel_size + 1, stride)
+    # Calculate output dimensions
+    H_out = (x_padded.shape[2] - kernel_size) // stride + 1
+    W_out = (x_padded.shape[3] - kernel_size) // stride + 1
 
-    # Use numpy's advanced indexing to extract all windows at once
-    windows_list = [
-        x_padded[:, :, i : i + kernel_size, j : j + kernel_size]
-        for i in i_indices
-        for j in j_indices
-    ]
-
-    # Verify we got the expected number of windows
-    assert (
-        len(windows_list) == H_out * W_out
-    ), f"Expected {H_out * W_out} windows, got {len(windows_list)}"
-
-    return Tensor.stack(windows_list, axis=0), (H_out, W_out)
+    return windows, (H_out, W_out)

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -189,8 +189,7 @@ class Conv2d(Module):
 
         # Add bias
         if self.bias:
-            for c in range(self.out_channels):
-                output[:, c] = output[:, c] + self._parameters["bias"][c]
+            output += self._parameters["bias"].reshape(-1, 1, 1)
         return output
 
 
@@ -371,11 +370,16 @@ def extract_windows(x, kernel_size, stride, padding_mode="valid"):
 
     windows_list = []
 
-    # Extract windows
-    for i in range(0, x_padded.shape[2] - kernel_size + 1, stride):
-        for j in range(0, x_padded.shape[3] - kernel_size + 1, stride):
-            window = x_padded[:, :, i : i + kernel_size, j : j + kernel_size]
-            windows_list.append(window)
+    # Extract windows using numpy's advanced indexing
+    i_indices = np.arange(0, x_padded.shape[2] - kernel_size + 1, stride)
+    j_indices = np.arange(0, x_padded.shape[3] - kernel_size + 1, stride)
+
+    # Use numpy's advanced indexing to extract all windows at once
+    windows_list = [
+        x_padded[:, :, i : i + kernel_size, j : j + kernel_size]
+        for i in i_indices
+        for j in j_indices
+    ]
 
     # Verify we got the expected number of windows
     assert (

--- a/autograd/utils.py
+++ b/autograd/utils.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from autograd import nn, utils
 import numpy as np
 
@@ -57,6 +58,7 @@ def train(
     for epoch in range(epochs):
         total_loss = 0.0
         grad_norms = []
+        start_time = time.time()
 
         if shuffle_each_epoch:
             # Create random permutation for shuffling
@@ -105,9 +107,12 @@ def train(
         # Calculate average loss for the epoch
         avg_loss = total_loss / n_samples
         avg_grad_norm = np.mean(grad_norms)
+        epoch_time = time.time() - start_time
+        epochs_per_second = n_batches / epoch_time
         logger.info(
-            f"Epoch: {epoch}, Loss: {avg_loss:.4f}, Grad norm: {avg_grad_norm:.4f}"
-        )
-        logger.info(
-            f"Accuracy: {utils.accuracy(y_pred.data.argmax(axis=1), batch_y.astype(int))}"
+            f"\nEpoch: {epoch}"
+            f"\n\tLoss: {avg_loss:.4f}"
+            f"\n\tGrad Norm: {avg_grad_norm:.4f}"
+            f"\n\tEpochs/sec: {epochs_per_second:.2f}"
+            f"\n\tAccuracy: {utils.accuracy(y_pred.data.argmax(axis=1), batch_y.astype(int)):.2f}"
         )

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -218,16 +218,16 @@ class TestDropout(TestCase):
 class TestConv2d(TestCase):
     def setUp(self):
         self.conv2d = Conv2d(
-            in_channels=3, out_channels=2, kernel_size=3, stride=1, padding_mode="valid"
+            in_channels=2, out_channels=2, kernel_size=3, stride=1, padding_mode="valid"
         )
-        self.x = Tensor(np.random.randn(1, 3, 32, 32))  # shape: (N, in_channels, H, W)
+        self.x = Tensor(np.random.randn(1, 2, 6, 6))  # shape: (N, in_channels, H, W)
         self.x_torch = torch.from_numpy(self.x.data).float()
         self.torch_conv2d = torch.nn.Conv2d(
-            in_channels=3, out_channels=2, kernel_size=3, stride=1, padding=0
+            in_channels=2, out_channels=2, kernel_size=3, stride=1, padding=0
         )
 
         # Single channel input
-        self.x_single = Tensor(np.random.randn(2, 1, 16, 16))
+        self.x_single = Tensor(np.random.randn(2, 1, 4, 4))
         self.x_single_torch = torch.tensor(self.x_single.data, requires_grad=True)
 
         # Copy our weights to PyTorch conv layer
@@ -241,7 +241,7 @@ class TestConv2d(TestCase):
 
     def test_forward(self):
         output = self.conv2d(self.x)
-        assert output.data.shape == (1, 2, 30, 30)  # shape: (N, out_channels, H', W')
+        assert output.data.shape == (1, 2, 4, 4)  # shape: (N, out_channels, H', W')
 
         output_torch = self.torch_conv2d(self.x_torch)
         assert np.allclose(output.data, output_torch.detach().numpy(), atol=1e-5)

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -1164,3 +1164,54 @@ class TestTensorPermute(TestTensor):
 
         expected_grad = np.ones_like(self.x_nhwc.data) * 2
         assert np.allclose(self.x_nhwc.grad.data, expected_grad)
+
+
+class TestTensorStridedWindows(TestTensor):
+    def test_custom_strided_windows(self):
+        # Define a simple input tensor
+        x = np.array(
+            [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]
+        ).reshape(1, 1, 4, 4)
+
+        tensor = Tensor(x)
+
+        # Define expected output for 2x2 kernel with stride 1
+        expected_2x2 = np.array(
+            [
+                [[1, 2], [5, 6]],
+                [[2, 3], [6, 7]],
+                [[3, 4], [7, 8]],
+                [[5, 6], [9, 10]],
+                [[6, 7], [10, 11]],
+                [[7, 8], [11, 12]],
+                [[9, 10], [13, 14]],
+                [[10, 11], [14, 15]],
+                [[11, 12], [15, 16]],
+            ]
+        ).reshape(9, 1, 1, 2, 2)  # Updated shape
+
+        # Get the output from strided_windows
+        windows_2x2 = tensor.strided_windows(kernel_size=2, stride=1)
+
+        # Compare with expected output
+        assert np.array_equal(
+            windows_2x2.data, expected_2x2
+        ), "2x2 windows do not match expected output"
+
+        # Define expected output for 3x3 kernel with stride 1
+        expected_3x3 = np.array(
+            [
+                [[1, 2, 3], [5, 6, 7], [9, 10, 11]],
+                [[2, 3, 4], [6, 7, 8], [10, 11, 12]],
+                [[5, 6, 7], [9, 10, 11], [13, 14, 15]],
+                [[6, 7, 8], [10, 11, 12], [14, 15, 16]],
+            ]
+        ).reshape(4, 1, 1, 3, 3)  # Updated shape
+
+        # Get the output from strided_windows
+        windows_3x3 = tensor.strided_windows(kernel_size=3, stride=1)
+
+        # Compare with expected output
+        assert np.array_equal(
+            windows_3x3.data, expected_3x3
+        ), "3x3 windows do not match expected output"


### PR DESCRIPTION
## Description
- Vectorize Conv2D's forward pass bias operation, instead of looping through output channels
- Introduce tensor-level "movement operation" called `strided_window` with associated forward/backward implementation. This leverages numpy's [stride_tricks function](https://numpy.org/devdocs/reference/generated/numpy.lib.stride_tricks.as_strided.html#numpy.lib.stride_tricks.as_strided), which avoids looping through height/width and creating unnecessary memory allocations and solely rely on the newly created "view" without copying the underlying data.
- Refactored extract_window Conv2d helper function to utilize the `tensor.strided_window` function

## Tests

Added new unit tests for the `strided_window` tensor operation.


## Performance gains:
Forward pass:
- 18% memory usage reduction
- 59% CPU usage reduction
- 4X relative speed up

Backward pass:
- 89% memory usage reduction
- 13% CPU usage reduction
- 8X relative speed up

**Before convolutional layer optimization (master branch)**
<img width="700" alt="image" src="https://github.com/user-attachments/assets/3f917f93-959c-4093-bcdf-b26559354609" />


**After convolutional layer optimization**
<img width="700" alt="image" src="https://github.com/user-attachments/assets/3255c9c8-2278-4397-974d-0d023c10408a" />
