### PR TITLE
Fix CNN and add CIFAR-10/CIFAR-100 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,19 @@ We are creating an autograd engine from scratch and use it to build/train more c
 
 ## Demo/Examples
 
-`examples/` contains various examples of neural networks built using the library that tackle some classical problems
-- MNIST classifier: [`examples/mnist.py`](https://github.com/workofart/ml-by-hand/blob/main/examples/mnist.py)
-- CIFAR-10/CIFAR-100 classifier: [`examples/cifar.py`](https://github.com/workofart/ml-by-hand/blob/main/examples/cifar.py)
-- End-to-end training implementation for a binary classifier on the [breast cancer dataset](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_breast_cancer.html) can be found in [`tests/autograd/test_train.py`](https://github.com/workofart/ml-by-hand/blob/c1156ee0c7a252484df1cd5234316a299e008b8b/test/autograd/test_train.py#L7-L66).
+[`examples/`](https://github.com/workofart/ml-by-hand/tree/main/examples) contains various examples of neural networks built using the library that tackle some classical problems
+
+- [x] Regression using Deep Neural Network
+  - [White Wine](https://github.com/workofart/ml-by-hand/blob/a2d55fdd9dc969f3848e0b15c3ac01a47736e655/test/autograd/test_train.py#L30)
+- [x] Binary Classification using Deep Logistic Regression
+  - [MNIST (One vs Rest)](https://github.com/workofart/ml-by-hand/blob/f4d3ab9e7903e2e675bdcd781695ab3e23908472/examples/mnist.py#L82)
+  - [Breast Cancer](https://github.com/workofart/ml-by-hand/blob/f4d3ab9e7903e2e675bdcd781695ab3e23908472/test/autograd/test_train.py#L12)
+- [x] Multi-class Classification using Deep Logistic Regression
+  - [MNIST](https://github.com/workofart/ml-by-hand/blob/f4d3ab9e7903e2e675bdcd781695ab3e23908472/examples/mnist.py#L14)
+  - [CIFAR-10/CIFAR-100](https://github.com/workofart/ml-by-hand/blob/f4d3ab9e7903e2e675bdcd781695ab3e23908472/examples/cifar.py#L13)
+- [x] Convolutional Neural Network
+  - [MNIST](https://github.com/workofart/ml-by-hand/blob/a2d55fdd9dc969f3848e0b15c3ac01a47736e655/examples/mnist.py#L37)
+  - [CIFAR-10/CIFAR-100](https://github.com/workofart/ml-by-hand/blob/f8dbe2454fa2b04fe2fe2a9bca02c584c9c7b54a/examples/cifar.py#L35)
 
 ## Technical Overview
 - `tensor` (base class)
@@ -37,6 +46,8 @@ We are creating an autograd engine from scratch and use it to build/train more c
   - Module (base class)
   - Linear (basic building block for a perceptron/hidden layer)
   - BatchNorm (batch normalization)
+  - Conv2d (convolutional layer)
+  - MaxPool2d (max pooling layer)
   - Dropout (regularization)
 - `functional` (including backprop derivation defined in `backward()`)
   - Activation functions: relu, sigmoid, softmax
@@ -45,6 +56,10 @@ We are creating an autograd engine from scratch and use it to build/train more c
   - Optimizer (base class)
   - SGD (stochastic gradient descent)
   - Adam
+- `tools`
+  - `trainer.py` (end-to-end training runner to train a model on a given dataset)
+  - `data.py` (data loading, splitting, etc.)
+  - `metrics.py` (accuracy etc.)
 - `test/`
   - All the unit tests for the above functionality
   - End-to-end training run by combining all the components on a real dataset
@@ -54,7 +69,7 @@ We are creating an autograd engine from scratch and use it to build/train more c
 
 Then you can activate the installed virtual environment by `source .venv/bin/activate`
 
-`numpy` is the main dependencies. `pytorch` is only used for validating gradient calculation correctness in the tests.
+`numpy` is the main dependency. `pytorch` is only used for validating gradient calculation correctness in the tests.
 
 ## Tests
 Comprehensive unit tests and integration tests available in `test/autograd`

--- a/autograd/functional.py
+++ b/autograd/functional.py
@@ -227,6 +227,19 @@ class HingeLoss(Function):
         return grad_y_pred, None
 
 
+class MeanSquaredLoss(Function):
+    def forward(self, y_pred, y_true):
+        self.y_pred = y_pred
+        self.y_true = y_true
+        return np.mean((y_pred - y_true) ** 2)
+
+    def backward(self, grad):
+        """
+        dL/dx = 2 * (x - y)
+        """
+        return 2 * (self.y_pred - self.y_true) * grad.data
+
+
 def binary_cross_entropy(y_pred: Tensor, y_true: Union[Tensor, np.ndarray]) -> Tensor:
     if not isinstance(y_true, Tensor):
         y_true = Tensor(y_true, requires_grad=False)
@@ -271,3 +284,9 @@ def hinge_loss(
     if not isinstance(y_true, Tensor):
         y_true = Tensor(y_true, requires_grad=False)
     return HingeLoss.apply(y_pred, y_true, reduction=reduction)
+
+
+def mean_squared_loss(y_pred: Tensor, y_true: Union[Tensor, np.ndarray]) -> Tensor:
+    if not isinstance(y_true, Tensor):
+        y_true = Tensor(y_true, requires_grad=False)
+    return MeanSquaredLoss.apply(y_pred, y_true)

--- a/autograd/tools/metrics.py
+++ b/autograd/tools/metrics.py
@@ -13,3 +13,8 @@ def precision(y_pred, y_true):
     true_positives = np.sum((y_true == 1) & (y_pred == 1))
     predicted_positives = np.sum(y_pred == 1)
     return true_positives / predicted_positives if predicted_positives != 0 else 0.0
+
+
+def mean_squared_error(y_pred, y_true):
+    assert len(y_true) == len(y_pred)
+    return np.mean((y_pred - y_true) ** 2)

--- a/examples/cifar.py
+++ b/examples/cifar.py
@@ -32,17 +32,59 @@ class CifarMulticlassClassifier(nn.Module):
         return functional.softmax(self.h4(x))
 
 
-def train_cifar_multiclass_model(model: nn.Module, X_train, y_train, X_test, y_test):
-    logger.info("=" * 66)
-    logger.info("Starting to train Multi-class CIFAR model")
-    logger.info("=" * 66)
+class CifarConvolutionalClassifier(nn.Module):
+    def __init__(self, num_classes: int):
+        super().__init__()
+        self.conv1 = nn.Conv2d(
+            in_channels=3, out_channels=8, kernel_size=3, padding_mode="same"
+        )  # (N, 8, 32, 32) maintain the same spatial dimensions because of "same" padding
+        self.conv2 = nn.Conv2d(
+            in_channels=8, out_channels=8, kernel_size=3, padding_mode="same"
+        )  # (N, 8, 32, 32) maintain the same spatial dimensions because of "same" padding
+        self.pool1 = nn.MaxPool2d(
+            kernel_size=3, stride=2
+        )  # (N, 8, 16, 16), where (8 - 3) / 2 + 1 = 3
 
+        self.conv3 = nn.Conv2d(
+            in_channels=8, out_channels=16, kernel_size=3, padding_mode="same"
+        )  # (N, 16, 16, 16) maintain the same spatial dimensions because of "same" padding
+
+        self.conv4 = nn.Conv2d(
+            in_channels=16, out_channels=16, kernel_size=3, padding_mode="same"
+        )  # (N, 16, 16, 16) maintain the same spatial dimensions because of "same" padding
+        self.pool2 = nn.MaxPool2d(
+            kernel_size=3, stride=2
+        )  # (N, 16, 7, 7), where (16 - 3) / 2 + 1 = 7
+
+        self.fc1 = nn.Linear(16 * 7 * 7, num_classes)
+
+    def forward(self, x):
+        batch_size = x.shape[0]
+        # cifar-10 image has shape 32 x 32 x 3 (color channels)
+        x = x.reshape(batch_size, 3, 32, 32)  # (N, in_channels, H, W)
+
+        # First conv block
+        x = functional.relu(self.conv1(x))
+        x = functional.relu(self.conv2(x))
+        x = self.pool1(x)
+
+        # Second conv block
+        x = functional.relu(self.conv3(x))
+        x = functional.relu(self.conv4(x))
+        x = self.pool2(x)
+
+        # Flatten and dense layers
+        x = x.reshape(batch_size, -1)
+        return functional.softmax(self.fc1(x))
+
+
+def train_cifar_multiclass_model(model: nn.Module, X_train, y_train, X_test, y_test):
     trainer = Trainer(
         model=model,
         loss_fn=functional.sparse_cross_entropy,
         optimizer=optim.Adam(model.parameters, lr=1e-3),
         epochs=100,
-        batch_size=512,
+        batch_size=256,
         output_type="softmax",
     )
     trainer.fit(X_train, y_train.astype(int))
@@ -63,10 +105,22 @@ if __name__ == "__main__":
         target="class", dataset_format="array"
     )
     X = X / 255.0  # normalize to [0, 1] to speed up convergence
-    X = (X - X.mean(axis=0)) / X.std(axis=0)  # center the data
+
+    # To speed up the training on local machine
+    X = X[:2000]
+    y = y[:2000]
+    logger.info(f"{X.shape=}, {y.shape=}")
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
+
+    logger.info("Training Convolutional CIFAR-10 model")
+    cifar10_model = CifarConvolutionalClassifier(num_classes=10)
+    logger.info(f"There are {cifar10_model.num_parameters()} parameters in the model")
+    train_cifar_multiclass_model(cifar10_model, X_train, y_train, X_test, y_test)
+
+    logger.info("Training Dense CIFAR-10 model")
     cifar10_model = CifarMulticlassClassifier(num_classes=10)
+    logger.info(f"There are {cifar10_model.num_parameters()} parameters in the model")
     train_cifar_multiclass_model(cifar10_model, X_train, y_train, X_test, y_test)
 
     logger.info("Fetching data for CIFAR-100")
@@ -74,8 +128,18 @@ if __name__ == "__main__":
         target="class", dataset_format="array"
     )
     X = X / 255.0  # normalize to [0, 1] to speed up convergence
-    X = (X - X.mean(axis=0)) / X.std(axis=0)  # center the data
+    X = X[:5000]
+    y = y[:5000]
+    logger.info(f"{X.shape=}, {y.shape=}")
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
+
+    logger.info("Training Convolutional CIFAR-100 model")
+    cifar100_model = CifarConvolutionalClassifier(num_classes=100)
+    logger.info(f"There are {cifar100_model.num_parameters()} parameters in the model")
+    train_cifar_multiclass_model(cifar100_model, X_train, y_train, X_test, y_test)
+
+    logger.info("Training Dense CIFAR-100 model")
     cifar100_model = CifarMulticlassClassifier(num_classes=100)
+    logger.info(f"There are {cifar100_model.num_parameters()} parameters in the model")
     train_cifar_multiclass_model(cifar100_model, X_train, y_train, X_test, y_test)

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -38,27 +38,27 @@ class MnistConvolutionalClassifier(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = nn.Conv2d(
-            in_channels=1, out_channels=32, kernel_size=5, padding_mode="same"
-        )  # (N, 32, 28, 28) maintain the same spatial dimensions because of "same" padding
+            in_channels=1, out_channels=8, kernel_size=3, padding_mode="same"
+        )  # (N, 8, 28, 28) maintain the same spatial dimensions because of "same" padding
         self.conv2 = nn.Conv2d(
-            in_channels=32, out_channels=32, kernel_size=5, padding_mode="same"
-        )  # (N, 32, 28, 28) maintain the same spatial dimensions because of "same" padding
+            in_channels=8, out_channels=8, kernel_size=3, padding_mode="same"
+        )  # (N, 8, 28, 28) maintain the same spatial dimensions because of "same" padding
         self.pool1 = nn.MaxPool2d(
-            kernel_size=5, stride=2
-        )  # (N, 32, 12, 12), where (28 - 5) / 2 + 1 = 12
+            kernel_size=3, stride=2
+        )  # (N, 32, 12, 12), where (28 - 3) / 2 + 1 = 13
 
         self.conv3 = nn.Conv2d(
-            in_channels=32, out_channels=64, kernel_size=3, padding_mode="same"
-        )  # (N, 64, 12, 12) maintain the same spatial dimensions because of "same" padding
+            in_channels=8, out_channels=16, kernel_size=3, padding_mode="same"
+        )  # (N, 16, 13, 13) maintain the same spatial dimensions because of "same" padding
 
         self.conv4 = nn.Conv2d(
-            in_channels=64, out_channels=64, kernel_size=3, padding_mode="same"
-        )  # (N, 64, 12, 12) maintain the same spatial dimensions because of "same" padding
+            in_channels=16, out_channels=16, kernel_size=3, padding_mode="same"
+        )  # (N, 16, 13, 13) maintain the same spatial dimensions because of "same" padding
         self.pool2 = nn.MaxPool2d(
             kernel_size=3, stride=2
-        )  # (N, 64, 5, 5), where (12 - 3) / 2 + 1 = 5
+        )  # (N, 16, 6, 6), where (13 - 3) / 2 + 1 = 6
 
-        self.fc1 = nn.Linear(64 * 5 * 5, 10)
+        self.fc1 = nn.Linear(16 * 6 * 6, 10)
 
     def forward(self, x):
         batch_size = x.shape[0]
@@ -181,7 +181,7 @@ def train_mnist_multiclass_model(
         loss_fn=loss_fn,
         optimizer=optimizer,
         epochs=epochs,
-        batch_size=512,
+        batch_size=256,
         output_type="softmax",
     )
     trainer.fit(X_train, y_train.astype(int))
@@ -203,26 +203,24 @@ if __name__ == "__main__":
     )
     X /= 255.0  # normalize to [0, 1] to speed up convergence
 
-    X = X[:3000]
-    y = y[:3000]
-
     logger.info(f"X shape: {X.shape}")
     logger.info(f"y shape: {y.shape}")
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
 
-    # model = MnistConvolutionalClassifier()
-    # train_mnist_multiclass_model(
-    #     X_train,
-    #     y_train,
-    #     X_test,
-    #     y_test,
-    #     optimizer=optim.Adam(model.parameters, lr=1e-3),
-    #     model=model,
-    #     loss_fn=functional.sparse_cross_entropy,
-    #     epochs=10,
-    #     msg="Convolutional Neural Network (with batch norm, Adam optimizer)",
-    # )
+    model = MnistConvolutionalClassifier()
+    logger.info(f"Number of parameters: {model.num_parameters()}")
+    train_mnist_multiclass_model(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        optimizer=optim.Adam(model.parameters, lr=1e-3),
+        model=model,
+        loss_fn=functional.sparse_cross_entropy,
+        epochs=3,
+        msg="Convolutional Neural Network (with batch norm, Adam optimizer)",
+    )
 
     model = MnistMultiClassClassifier(batch_norm=False)
     train_mnist_multiclass_model(

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -207,3 +207,29 @@ class TestHingeLoss(TestCase):
     def test_hinge_loss_invalid_reduction(self):
         with self.assertRaises(ValueError):
             functional.hinge_loss(self.y_pred, self.y_true, reduction="invalid")
+
+
+class TestMeanSquaredLoss(TestCase):
+    def setUp(self):
+        # Explicitly use float32 dtype
+        self.y_pred = Tensor(
+            data=np.array([1.0, 2.0, 3.0], dtype=np.float32), requires_grad=True
+        )
+        self.y_true = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        self.y_pred_torch = torch.tensor(
+            self.y_pred.data, dtype=torch.float32, requires_grad=True
+        )
+        self.y_true_torch = torch.tensor(self.y_true, dtype=torch.float32)
+
+    def test_mean_squared_loss(self):
+        mse_loss = functional.mean_squared_loss(self.y_pred, self.y_true)
+        mse_loss_torch = torch.nn.functional.mse_loss(
+            self.y_pred_torch, self.y_true_torch
+        )
+        assert np.allclose(mse_loss.data, mse_loss_torch.detach().numpy())
+
+        mse_loss.backward()
+        mse_loss_torch.backward()
+        assert np.allclose(
+            self.y_pred.grad.data, self.y_pred_torch.grad.detach().numpy()
+        )

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -1,12 +1,16 @@
 import numpy as np
 from autograd import nn, optim, functional
 from sklearn.datasets import load_breast_cancer
+from openml.datasets import get_dataset
 from unittest import TestCase
 import logging
 
 from autograd.tools.trainer import Trainer
+from autograd.tools.metrics import accuracy, mean_squared_error
 
 logger = logging.getLogger(__name__)
+
+np.random.seed(42)
 
 
 class Classifier(nn.Module):
@@ -20,6 +24,20 @@ class Classifier(nn.Module):
         x = functional.relu(self.linear1(x))
         x = functional.relu(self.linear2(x))
         x = functional.sigmoid(self.linear3(x))
+        return x
+
+
+class RegressionModel(nn.Module):
+    def __init__(self, input_size, hidden_size, output_size):
+        super(RegressionModel, self).__init__()
+        self.linear1 = nn.Linear(input_size, hidden_size)
+        self.linear2 = nn.Linear(hidden_size, hidden_size)
+        self.linear3 = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x):
+        x = functional.relu(self.linear1(x))
+        x = functional.relu(self.linear2(x))
+        x = self.linear3(x)
         return x
 
 
@@ -51,9 +69,39 @@ class TestTrain(TestCase):
         )
         trainer.fit(X, y)
 
+        model.eval()
         y_pred = model(X).data
 
         # compare y_pred and y on the classification accuracy
-        accuracy = sum((y_pred.squeeze() > 0.5).astype(int) == y) / X.shape[0]
-        logger.info(f"Accuracy: {accuracy}")
-        assert accuracy > 0.9
+        acc = accuracy((y_pred > 0.5).astype(int).squeeze(), y)
+        logger.info(f"Accuracy: {acc}")
+        assert acc > 0.9
+
+    def test_regression(self):
+        X, y, _, __ = get_dataset(dataset_id=44971, download_data=True).get_data(
+            target="quality", dataset_format="array"
+        )
+        logger.info(f"Dataset: {X.shape=}, {y.shape=}")
+        logger.info(f"y unique values: {np.unique(y)}")
+
+        eps = 1e-8
+        X = (X - X.mean(axis=0)) / (X.std(axis=0) + eps)
+        y = (y - y.mean()) / (y.std() + eps)
+
+        model = RegressionModel(
+            input_size=X.shape[-1], hidden_size=32, output_size=1
+        )  # Smaller network
+        trainer = Trainer(
+            model,
+            functional.mean_squared_loss,
+            optim.Adam(model.parameters, lr=1e-5),  # Smaller learning rate
+            epochs=100,
+            output_type=None,
+        )
+        trainer.fit(X, y)
+
+        model.eval()
+        y_pred = model(X).data
+
+        logger.info(f"Mean Squared Error: {mean_squared_error(y_pred, y):.2f}")
+        assert mean_squared_error(y_pred, y) < 1.3


### PR DESCRIPTION
## Description
Fixed the Conv2d forward pass dimension permutation problem! This was causing the Convolution Neural Networks (CNN) failing to learn. More specifically, with the wrong dimensions for the extracted windows, the flattening (reshaping to N * H_out * W_out, C * kernel H * kernel W) and matrix multiplication end up "misaligning" inputs and weights. This can result in nonsensical forward passes and gradients, making learning impossible.

Other additions:
- Added Mean Squared Loss
- Added Neural Network for Regression Problem
- Refactor the training flow into a trainer, metric, and data module.


## CNN Trained on CIFAR dataset
CNNs are shown to be very parameter efficient due to its parameter sharing mechanism. 

For CIFAR-10, the Convolutional Neural Network has 12146 parameters (Kernel Size * Kernel Size * # Filters * Input Depth Dimension). In contrast, the plain dense neural network has 3807498 parameters.

For CIFAR-100, the Convolutional Neural Network has 82796 parameters (Kernel Size * Kernel Size * # Filters * Input Depth Dimension). In contrast, the plain dense neural network has 3830628 parameters.

**CIFAR-10**
<img width="666" alt="image" src="https://github.com/user-attachments/assets/ae30ab05-a76b-4398-958e-8464fec3d436" />

**CIFAR-100**
<img width="666" alt="image" src="https://github.com/user-attachments/assets/5f0de483-cc05-424d-8625-d1e698666ae4" />


## Tests
All unit tests passed.