### PR TITLE
Add Residual Network

### DIFF
--- a/examples/models/resnet.py
+++ b/examples/models/resnet.py
@@ -1,0 +1,40 @@
+from autograd.nn import Module, Conv2d
+from autograd.functional import relu
+
+
+class ResidualBlock(Module):
+    """
+    Residual Block as described in Deep Residual Learning for Image Recognition
+    The residual block as a whole implements both F(x) and x (identity mapping)
+    The function that were trying to learn is H(x) = F(x) + x
+    F(x) is the convolutional layer with ReLU activation
+    x is the identity mapping
+
+    Paper: https://arxiv.org/abs/1512.03385
+    """
+
+    def __init__(self, in_channels, out_channels, stride=1):
+        super().__init__()
+        self.conv1 = Conv2d(
+            in_channels, out_channels, kernel_size=3, stride=stride, padding_mode="same"
+        )
+        self.conv2 = Conv2d(
+            out_channels,
+            out_channels,
+            kernel_size=3,
+            stride=stride,
+            padding_mode="same",
+        )
+
+        # Add projection shortcut when dimensions change
+        self.shortcut = Conv2d(
+            in_channels, out_channels, kernel_size=1, stride=stride, padding_mode="same"
+        )
+
+    def forward(self, x):
+        identity = self.shortcut(x)  # Match channels
+
+        out = self.conv1(x)
+        out = relu(out)
+        out = self.conv2(out)
+        return relu(out) + identity


### PR DESCRIPTION
## Description
Add the residual layer block to support Residual + Conv Neural Network for the MNIST and CIFAR problems.

Also updated the optimizer interface to support arbitrary depth of module composition (previously just assumes 1 - 2 modules deep, but with ResidualBlock, we now are building a 3 recursion depth module).

## Tests
All unit tests passed.

## Residual Network Performance
Faster convergence.

|                             | Residual Network                                                                                                  | Plain Convolutional Network                                                                                 |
|-----------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
| CIFAR-10 Problem | <img width="842" alt="image" src="https://github.com/user-attachments/assets/495b93ad-15b1-4ece-be26-63963df0d9f0" /> | <img width="832" alt="image" src="https://github.com/user-attachments/assets/9d8a115d-f435-47a1-b820-98ddec9a8046" /> |
