### PR TITLE
Iterative DFS traversal for computational graph

### DIFF
--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -217,19 +217,20 @@ class Tensor:
         topological_sorted_tensors = []
         visited = set()
 
-        def dfs(node: Tensor):
+        stack = [self]
+
+        while stack:
+            node = stack.pop()
             if node not in visited:
                 visited.add(node)
                 if node.creator is not None:
                     for input_tensor in node.creator.tensors:
                         if input_tensor.requires_grad:
-                            dfs(input_tensor)
+                            stack.append(input_tensor)
                 topological_sorted_tensors.append(node)
 
-        dfs(self)
-
         # Backward pass
-        for tensor in reversed(topological_sorted_tensors):
+        for tensor in topological_sorted_tensors:
             if tensor.creator is not None:
                 # Call function's backward to get gradients for inputs
                 grads = tensor.creator.backward(tensor.grad)


### PR DESCRIPTION
## Description
Switching from recursive to iterative DFS:
- Saves memory by removing unused references to nodes to avoid growing the stack exponentially for deeper graph structures
- Completely prevent the python recursion stack error, especially for sequence-to-sequence problems where we need to unroll long range of time steps for the RNN/LSTM backward pass.

## Tests
All unit tests passed.

## Performance Improvement
`memray run -o memray_output.bin -m pytest test/autograd/performance_test.py && memray tree memray_output.bin`


**Before (Recursive DFS)**
<img width="195" alt="image" src="https://github.com/user-attachments/assets/a12e9307-9fc4-4eb3-b3e4-da10ec1d60c7" />

<img width="555" alt="image" src="https://github.com/user-attachments/assets/1d69aa3f-98cb-4c8e-8fd8-6b22191c17a2" />


**After (Iterative DFS)**
<img width="194" alt="image" src="https://github.com/user-attachments/assets/e4ef2ce1-56e0-4556-b099-4001090942b2" />

<img width="555" alt="image" src="https://github.com/user-attachments/assets/11e4d0a1-bc79-465f-8a37-8555fdc8c453" />
