### PR TITLE
Add Cupy package as a drop-in replacement for GPU acceleration for Numpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Edit at https://www.toptal.com/developers/gitignore?templates=python
 
 checkpoints/
+training_data/
+training_runs/
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,127 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Debug Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "justMyCode": false
+        },
+        {
+            "name": "Mnist",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "examples.mnist"
+        },
+        {
+            "name": "Transpose",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_tensor.py::TestTensorTranspose::test_transpose_non_contiguous"]
+        },
+        {
+            "name": "Cifar",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "examples.cifar"
+        },
+        {
+            "name": "Neural Turing Machine",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "examples.neural_turing_machine"
+        },
+        {
+            "name": "Seq2Seq",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "examples.seq2seq"
+        },
+        {
+            "name": "Transformers",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "examples.transformers"
+        },
+        {
+            "name": "GPT-1",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "examples.gpt-1"
+        },
+        {
+            "name": "GPT-2",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "examples.gpt-2"
+        },
+        {
+            "name": "Tokenizer",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "autograd.text.tokenizer"
+        },
+        {
+            "name": "MaxPool2d",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_nn.py::TestMaxPool2d::test_forward"]
+        },
+        {
+            "name": "Tensor",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_tensor.py", "-k", "test_shift_invariance"]
+        },
+        {
+            "name": "Optim",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_optim.py::TestOptimizer"]
+        },
+        {
+            "name": "test_state_dict_and_load",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_nn.py::TestModule::test_state_dict_and_load"]
+        },
+        {
+            "name": "TestCrossEntropyWithLogits",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_functional.py::TestCrossEntropyWithLogits"]
+        },
+        {
+            "name": "TestConv2d",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_nn.py::TestConv2d::test_backward"]
+        },
+        {
+            "name": "TestEmbedding",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_nn.py::TestEmbedding::test_backward"]
+        },
+        {
+            "name": "TestLSTM",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/test_nn.py::TestLongShortTermMemoryBlock"]
+        }
+    ]
+}

--- a/autograd/functional.py
+++ b/autograd/functional.py
@@ -4,9 +4,10 @@ from typing import Any, Optional, Tuple, Union
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
-    import numpy as np
 
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
+    import numpy as np
 from autograd.tensor import Function, Tensor
 
 logger = logging.getLogger(__name__)

--- a/autograd/functional.py
+++ b/autograd/functional.py
@@ -1,7 +1,11 @@
 import logging
 from typing import Any, Optional, Tuple, Union
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd.tensor import Function, Tensor
 

--- a/autograd/init.py
+++ b/autograd/init.py
@@ -5,7 +5,9 @@ Initialization methods for weights of the neural network
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 from autograd.tensor import Tensor

--- a/autograd/init.py
+++ b/autograd/init.py
@@ -2,7 +2,11 @@
 Initialization methods for weights of the neural network
 """
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd.tensor import Tensor
 

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -5,9 +5,10 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
-    import numpy as np
 
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
+    import numpy as np
 from .functional import relu, sigmoid, softmax, tanh
 from .init import xavier_uniform
 from .tensor import Tensor

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -2,7 +2,11 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from .functional import relu, sigmoid, softmax, tanh
 from .init import xavier_uniform

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -2,7 +2,11 @@ import logging
 from collections import defaultdict
 from typing import Any, Callable, Dict, Optional
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd.tensor import Tensor
 

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -5,7 +5,9 @@ from typing import Any, Callable, Dict, Optional
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 from autograd.tensor import Tensor

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -11,7 +11,9 @@ from typing import (
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 logger = logging.getLogger(__name__)

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -8,7 +8,11 @@ from typing import (
     Union,
 )
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -4,7 +4,14 @@ import pickle
 from collections import Counter
 from typing import ByteString, Dict, List, Tuple
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
+    import numpy as np
+
 import regex
 from tqdm import tqdm
 

--- a/autograd/tools/metrics.py
+++ b/autograd/tools/metrics.py
@@ -1,7 +1,9 @@
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 

--- a/autograd/tools/metrics.py
+++ b/autograd/tools/metrics.py
@@ -1,4 +1,8 @@
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 
 def accuracy(y_pred, y_true):

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -1,7 +1,11 @@
 import logging
 from typing import Optional
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd import functional, nn, optim
 from autograd.tensor import Tensor

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -4,7 +4,9 @@ from typing import Optional
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 from autograd import functional, nn, optim

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -1,6 +1,10 @@
 import logging
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 from openml.datasets import get_dataset
 
 from autograd import functional, nn, optim

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -3,7 +3,9 @@ import logging
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 from openml.datasets import get_dataset
 

--- a/examples/movie_sentiment.py
+++ b/examples/movie_sentiment.py
@@ -3,7 +3,9 @@ import os
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 import pandas as pd
 

--- a/examples/movie_sentiment.py
+++ b/examples/movie_sentiment.py
@@ -1,6 +1,10 @@
 import os
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 import pandas as pd
 
 from autograd import functional, nn, optim

--- a/examples/neural_turing_machine.py
+++ b/examples/neural_turing_machine.py
@@ -1,7 +1,9 @@
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 from autograd import functional, nn, optim

--- a/examples/neural_turing_machine.py
+++ b/examples/neural_turing_machine.py
@@ -1,4 +1,8 @@
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd import functional, nn, optim
 from autograd.tensor import Tensor

--- a/examples/seq2seq.py
+++ b/examples/seq2seq.py
@@ -1,4 +1,8 @@
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd import functional, nn, optim, tensor
 from autograd.text.utils import create_vocabulary, text_to_one_hot_and_sparse

--- a/examples/seq2seq.py
+++ b/examples/seq2seq.py
@@ -1,9 +1,10 @@
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
-    import numpy as np
 
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
+    import numpy as np
 from autograd import functional, nn, optim, tensor
 from autograd.text.utils import create_vocabulary, text_to_one_hot_and_sparse
 from autograd.tools.data import SimpleDataLoader, load_data

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -1,7 +1,11 @@
 import logging
 from typing import Any, Optional
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd import functional, nn, optim
 from autograd.tensor import Tensor

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -4,7 +4,9 @@ from typing import Any, Optional
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 from autograd import functional, nn, optim

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+cupy-cuda12x; platform_system == "Linux"
 memray
 numpy
 psutil
@@ -10,3 +11,4 @@ openml # for dataset
 regex
 torch
 ruff
+tiktoken

--- a/requirements.in
+++ b/requirements.in
@@ -11,4 +11,3 @@ openml # for dataset
 regex
 torch
 ruff
-tiktoken

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,12 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.4.0
     # via requests
+cupy-cuda12x==13.3.0
+    # via -r requirements.in
 distlib==0.3.9
     # via virtualenv
+fastrlock==0.8.3
+    # via cupy-cuda12x
 filelock==3.16.1
     # via
     #   torch
@@ -64,6 +68,7 @@ nodeenv==1.9.1
 numpy==2.1.2
     # via
     #   -r requirements.in
+    #   cupy-cuda12x
     #   openml
     #   pandas
     #   scikit-learn
@@ -107,9 +112,13 @@ pytz==2024.2
 pyyaml==6.0.2
     # via pre-commit
 regex==2024.11.6
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   tiktoken
 requests==2.32.3
-    # via openml
+    # via
+    #   openml
+    #   tiktoken
 rich==13.9.4
     # via
     #   memray
@@ -124,6 +133,8 @@ scipy==1.14.1
     # via
     #   openml
     #   scikit-learn
+setuptools==75.8.0
+    # via torch
 six==1.16.0
     # via python-dateutil
 sympy==1.13.1
@@ -132,6 +143,8 @@ textual==1.0.0
     # via memray
 threadpoolctl==3.5.0
     # via scikit-learn
+tiktoken==0.8.0
+    # via -r requirements.in
 torch==2.5.0
     # via -r requirements.in
 tqdm==4.66.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,13 +112,9 @@ pytz==2024.2
 pyyaml==6.0.2
     # via pre-commit
 regex==2024.11.6
-    # via
-    #   -r requirements.in
-    #   tiktoken
+    # via -r requirements.in
 requests==2.32.3
-    # via
-    #   openml
-    #   tiktoken
+    # via openml
 rich==13.9.4
     # via
     #   memray
@@ -143,8 +139,6 @@ textual==1.0.0
     # via memray
 threadpoolctl==3.5.0
     # via scikit-learn
-tiktoken==0.8.0
-    # via -r requirements.in
 torch==2.5.0
     # via -r requirements.in
 tqdm==4.66.5

--- a/test/autograd/performance_test.py
+++ b/test/autograd/performance_test.py
@@ -6,7 +6,9 @@ from unittest import TestCase
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 import psutil
 

--- a/test/autograd/performance_test.py
+++ b/test/autograd/performance_test.py
@@ -3,7 +3,11 @@ import os
 import time
 from unittest import TestCase
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 import psutil
 
 from autograd import functional, nn, optim
@@ -149,8 +153,8 @@ class CIPipelinePerformanceTest(TestCase):
         """
         logger.info(f"\nPerformance Metrics for {model_name}:")
 
-        forward_stats = self._compute_stats(metrics["forward_times"])
-        backward_stats = self._compute_stats(metrics["backward_times"])
+        forward_stats = self._compute_stats(np.array(metrics["forward_times"]))
+        backward_stats = self._compute_stats(np.array(metrics["backward_times"]))
 
         logger.info("Timing (seconds):")
         logger.info("Forward Pass:")

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -3,7 +3,9 @@ from unittest import TestCase
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 import torch  # for test comparisons
 

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 import torch  # for test comparisons
 
 from autograd import functional

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -5,7 +5,9 @@ from unittest import TestCase
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 import torch  # for comparison
 

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -2,7 +2,11 @@ import random
 from copy import deepcopy
 from unittest import TestCase
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 import torch  # for comparison
 
 from autograd.nn import (

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -4,7 +4,9 @@ from unittest import TestCase
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 import torch  # for test validation
 

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -1,7 +1,11 @@
 from copy import deepcopy
 from unittest import TestCase
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 import torch  # for test validation
 
 from autograd.nn import Tensor

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 import torch  # for comparison
 
 from autograd.tensor import Tensor

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -3,7 +3,9 @@ from unittest import TestCase
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 import torch  # for comparison
 

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -1,7 +1,11 @@
 import logging
 from unittest import TestCase
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 from sklearn.datasets import load_breast_cancer, load_diabetes
 
 from autograd import functional, nn, optim

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -4,7 +4,9 @@ from unittest import TestCase
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 from sklearn.datasets import load_breast_cancer, load_diabetes
 

--- a/test/autograd/test_utils.py
+++ b/test/autograd/test_utils.py
@@ -3,7 +3,9 @@ from unittest import TestCase
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 from autograd.tools.data import train_test_split

--- a/test/autograd/test_utils.py
+++ b/test/autograd/test_utils.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd.tools.data import train_test_split
 from autograd.tools.metrics import accuracy, precision

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -5,9 +5,10 @@ from unittest.mock import MagicMock, patch
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
-    import numpy as np
 
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
+    import numpy as np
 from autograd.text.utils import (
     clean_and_tokenize,
     create_causal_mask,

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -2,7 +2,11 @@ import re
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd.text.utils import (
     clean_and_tokenize,

--- a/test/autograd/tools/test_model.py
+++ b/test/autograd/tools/test_model.py
@@ -5,7 +5,9 @@ from unittest import TestCase
 try:
     # drop-in replacement for numpy for GPU acceleration
     import cupy as np  # type: ignore
-except ImportError:
+
+    _ = np.cuda.runtime.getDeviceCount()  # Check if a CUDA device is available
+except Exception:
     import numpy as np
 
 from autograd.init import xavier_uniform

--- a/test/autograd/tools/test_model.py
+++ b/test/autograd/tools/test_model.py
@@ -2,7 +2,11 @@ import os
 from copy import deepcopy
 from unittest import TestCase
 
-import numpy as np
+try:
+    # drop-in replacement for numpy for GPU acceleration
+    import cupy as np  # type: ignore
+except ImportError:
+    import numpy as np
 
 from autograd.init import xavier_uniform
 from autograd.nn import Module


### PR DESCRIPTION
## Description
This is a low-hanging fruit to speed up the training process by leveraging GPU acceleration without writing custom CUDA code or using a "swiss knife" (e.g. [Jax](https://github.com/jax-ml/jax), [MLX](https://github.com/ml-explore/mlx)), because our goal is to keep our implementation at the numpy-level for educational purposes.

By leveraging [Cupy](https://github.com/cupy/cupy), we can just perform a drop-in replacement of Numpy, with little-no-none changes in the underlying framework or API.

## Tests
All unit tests passed :)
