### PR TITLE
Extract configs into separate Dataclass and simplify training pipeline 

### DIFF
--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -997,15 +997,11 @@ class AbstractLLMForwardFn(ABC):
     """
 
     @abstractmethod
-    def sample(
-        self, model: Any, batch_data: Any, mode: str = "train"
-    ) -> Tuple[Any, Any]:
+    def sample(self, model: Any, batch_data: Any) -> Tuple[Any, Any]:
         pass
 
     @abstractmethod
-    def train(
-        self, model: Any, batch_data: Any, mode: str = "train"
-    ) -> Tuple[Any, Any]:
+    def train(self, model: Any, batch_data: Any) -> Tuple[Any, Any]:
         pass
 
     def __call__(

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -71,7 +71,7 @@ class Optimizer:
         self,
         model_parameters: Dict[str, Tensor],
         lr: float,
-        lr_scheduler: Optional[LRScheduler] = None,
+        lr_scheduler_kwargs: Optional[dict] = None,
         **kwargs: Any,
     ) -> None:
         self._states: Dict[str, Any] = defaultdict(dict)
@@ -81,7 +81,11 @@ class Optimizer:
         self.model_parameters = model_parameters
         self._hyperparams["lr"] = lr
         self.initial_lr = lr
-        self.lr_scheduler = lr_scheduler  # optional
+        if lr_scheduler_kwargs:
+            lr_scheduler_cls = lr_scheduler_kwargs.pop("lr_scheduler_cls")
+            self.lr_scheduler = lr_scheduler_cls(**lr_scheduler_kwargs)
+        else:
+            self.lr_scheduler = None
 
         # Store the global step within _states.
         self._states["timestep"] = 0

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -33,7 +33,7 @@ class CosineScheduler(LRScheduler):
     """
 
     def __init__(
-        self, warmup_steps: int = 100, lr_decay_iters: int = 5000, min_lr: float = 1e-4
+        self, warmup_steps: int = 100, lr_decay_iters: int = 200, min_lr: float = 1e-4
     ):
         self.warmup_steps = warmup_steps
         self.lr_decay_iters = lr_decay_iters

--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -264,7 +264,7 @@ class BytePairEncoder:
 
         return self._unicode_to_int_vocab, self._int_to_unicode_vocab
 
-    def encode(self, input_text: str) -> List[int]:
+    def encode(self, input_text: str, **kwargs) -> List[int]:
         """
         Encode `input_text` into a list of token IDs.
 

--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -114,19 +114,19 @@ class BytePairEncoder:
 
     def prepare_data(
         self,
-        raw_text_list: List[str],
+        raw_text: str,
         overwrite_vocabulary_file: bool = False,
         overwrite_encoded_data: bool = False,
         split_token: str = "<|endoftext|>",
     ) -> np.ndarray:
         """
         High-level method that:
-          1) Trains (or loads) the BPE vocabulary on the given raw_text_list.
+          1) Trains (or loads) the BPE vocabulary on the given raw_text.
           2) Encodes the text into a NumPy array of token IDs (in parallel).
           3) Caches the result to an .npz file (unless it already exists and we're not overwriting).
 
         Args:
-            raw_text_list: The list of texts from which to train or apply BPE.
+            raw_text: The raw texts from which to train or apply BPE.
             npz_file_path: File path to store (or load) the encoded .npz data.
             overwrite_saved_file: Whether to overwrite an existing .npz file with newly encoded data.
             split_token: Delimiter to insert between data blocks.
@@ -134,12 +134,8 @@ class BytePairEncoder:
         Returns:
             A NumPy array of encoded tokens.
         """
-        joined_text = split_token.join(raw_text_list)
-
         # 1) Train the vocabulary if needed
-        self.train_vocabulary(
-            joined_text, overwrite_saved_file=overwrite_vocabulary_file
-        )
+        self.train_vocabulary(raw_text, overwrite_saved_file=overwrite_vocabulary_file)
 
         # 2) Check if we already have an encoded .npz file
         if os.path.exists(self.encoded_data_path) and not overwrite_encoded_data:
@@ -151,10 +147,10 @@ class BytePairEncoder:
                 encoded_data = npz_data["arr_0"]
         else:
             # 3) Parallel encoding
-            chunk_size = max(1, len(joined_text) // self.n_workers)
+            chunk_size = max(1, len(raw_text) // self.n_workers)
             text_chunks = [
-                joined_text[i : i + chunk_size]
-                for i in range(0, len(joined_text), chunk_size)
+                raw_text[i : i + chunk_size]
+                for i in range(0, len(raw_text), chunk_size)
             ]
 
             with Pool(self.n_workers) as pool:

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -305,7 +305,7 @@ def inference(
     return prediction_text
 
 
-def load_wiki_simple():
+def load_wiki_simple() -> str:
     from autograd.tools.data import load_data
 
     if not os.path.exists("training_data/wiki_simple_english.txt"):
@@ -322,13 +322,16 @@ def load_wiki_simple():
         "training_data/wiki_simple_english.txt",
         "training_data/wiki_simple_english.txt",
     )
+    logger.info(f"{len(data)} characters in the entire dataset. Sample: {data[:100]}")
     return data
 
 
-def load_shakespeare_mini():
+def load_shakespeare_mini() -> str:
     from autograd.tools.data import load_data
 
-    return load_data(
+    data = load_data(
         "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt",
         "training_data/tinyshakespeare.txt",
     )
+    logger.info(f"{len(data)} characters in the entire dataset. Sample: {data[:100]}")
+    return data

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 from collections import defaultdict
 from typing import (
@@ -282,7 +283,7 @@ def inference(
     else:
         start_tokens = start_tokens or "<SOS>"
         output_ids = list(bpe.encode(start_tokens))
-        num_steps = max_length
+        num_steps = max_length - len(output_ids)
 
     # Main loop: decide input tokens based on the mode.
     for i in tqdm(range(num_steps), desc="Inference", leave=False):
@@ -302,3 +303,32 @@ def inference(
     logger.info(f"Prediction:\n\n{prediction_text}")
 
     return prediction_text
+
+
+def load_wiki_simple():
+    from autograd.tools.data import load_data
+
+    if not os.path.exists("training_data/wiki_simple_english.txt"):
+        print("Downloading data...")
+        os.system(
+            "curl -L -o examples/plain-text-wikipedia-simpleenglish.zip https://www.kaggle.com/api/v1/datasets/download/ffatty/plain-text-wikipedia-simpleenglish"
+        )
+        os.system("unzip examples/plain-text-wikipedia-simpleenglish.zip -d examples")
+        os.system("rm -rf examples/1of2")
+        os.system("rm -rf examples/2of2")
+        os.system("mv examples/AllCombined.txt training_data/wiki_simple_english.txt")
+
+    data = load_data(
+        "training_data/wiki_simple_english.txt",
+        "training_data/wiki_simple_english.txt",
+    )
+    return data
+
+
+def load_shakespeare_mini():
+    from autograd.tools.data import load_data
+
+    return load_data(
+        "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt",
+        "training_data/tinyshakespeare.txt",
+    )

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -297,7 +297,7 @@ def inference(
         groundtruth_text = "\n".join(
             bpe.decode(groundtruth_data.tolist()).split("<|endoftext|>")
         )
-        logger.info(f"Teacher forcing groundtruth:\n{groundtruth_text}")
+        logger.info(f"Teacher forcing mode on!!\nGroundtruth:\n{groundtruth_text}")
 
     prediction_text = "\n\n".join(bpe.decode(output_ids).split("<|endoftext|>"))
     logger.info(f"Prediction:\n\n{prediction_text}")
@@ -322,7 +322,7 @@ def load_wiki_simple() -> str:
         "training_data/wiki_simple_english.txt",
         "training_data/wiki_simple_english.txt",
     )
-    logger.info(f"{len(data)} characters in the entire dataset. Sample: {data[:100]}")
+    logger.info(f"{len(data)} characters in the entire dataset. Sample: \n{data[:100]}")
     return data
 
 
@@ -333,5 +333,5 @@ def load_shakespeare_mini() -> str:
         "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt",
         "training_data/tinyshakespeare.txt",
     )
-    logger.info(f"{len(data)} characters in the entire dataset. Sample: {data[:100]}")
+    logger.info(f"{len(data)} characters in the entire dataset. Sample: \n{data[:100]}")
     return data

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -1,0 +1,66 @@
+"""
+This module contains the schema for defining various configs for the training pipeline.
+It's optional to use, but may provide some quality of life improvements
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class GenericTrainingConfig:
+    """
+    Generic Configuration for training a model.
+    This follows the same interface as the AbstractTrainer class in `autograd.tools.trainer.py`
+    """
+
+    total_epochs: int
+    checkpoint_freq: float
+    # When we load from checkpoint, the below kwargs are restored from the checkpoint
+    # and cannot be modified because they are inherently tied to the model and optimizer
+    # state (e.g. hidden_size cannot be changed because the model artifact was created
+    # using the previous checkpoint's hidden_size)
+    # The above configs can be changed, and don't need to be loaded from the checkpoint
+    model_kwargs: dict
+    optimizer_kwargs: dict
+    steps_per_epoch: Optional[int] = 16
+    eval_iters: Optional[int] = 16
+    batch_size: Optional[int] = 32
+    # Whether to load from a checkpoint
+    resume_epoch: Optional[int] = None
+    training_run_name: Optional[str] = "default"
+    dataset_name: Optional[str] = ""
+
+
+@dataclass
+class CustomBpeConfig:
+    """
+    The configs for our custom BytePairEncoder class in `autograd.text.tokenizer.py`
+    """
+
+    num_merges: int
+    encoded_data_path: str
+    vocab_path: str
+    overwrite_encoded_data: bool
+    overwrite_vocabulary_file: bool
+    split_token: str
+
+
+@dataclass(kw_only=True)
+class TransformerTrainingConfig(GenericTrainingConfig):
+    # Whether to check the model performance by feeding the groundtruth tokens to compare whether the model can predict the next token correctly.
+    teacher_enforcing: bool
+    custom_bpe: Optional[CustomBpeConfig] = None
+    # If True, we create a separate 'dec_inp'
+    # array (common in seq2seq). If you just want normal GPT next-token,
+    # you can set this false.
+    include_decoder_input: bool
+    # If True, we create a padding for cases where
+    # we have sequences of different lengths across the training samples.
+    # If you're doing standard GPT, you'd typically want a causal mask, which is created
+    # by default, and isn't controlled by this flag.
+    create_padding_masks: bool
+    label_smoothing: float  # TODO: refactor this into loss function config
+    eval_start_string: Optional[str] = (
+        "\n"  # starting token for the evaluation during training
+    )

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -4,7 +4,7 @@ It's optional to use, but may provide some quality of life improvements
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 
 @dataclass
@@ -50,7 +50,7 @@ class CustomBpeConfig:
 class TransformerTrainingConfig(GenericTrainingConfig):
     # Whether to check the model performance by feeding the groundtruth tokens to compare whether the model can predict the next token correctly.
     teacher_enforcing: bool
-    custom_bpe: Optional[CustomBpeConfig] = None
+    custom_bpe: Union[CustomBpeConfig, None] = None
     # If True, we create a separate 'dec_inp'
     # array (common in seq2seq). If you just want normal GPT next-token,
     # you can set this false.

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -23,12 +23,12 @@ class GenericTrainingConfig:
     # The above configs can be changed, and don't need to be loaded from the checkpoint
     model_kwargs: dict
     optimizer_kwargs: dict
-    steps_per_epoch: Optional[int] = 16
-    eval_iters: Optional[int] = 16
-    batch_size: Optional[int] = 32
+    steps_per_epoch: int = 16
+    eval_iters: int = 16
+    batch_size: int = 32
     # Whether to load from a checkpoint
     resume_epoch: Optional[int] = None
-    training_run_name: Optional[str] = "default"
+    training_run_name: str = "default"
     dataset_name: Optional[str] = ""
 
 

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -161,6 +161,7 @@ class AbstractTrainer(ABC):
             if key != "epoch" and self.metrics[key][-1] is not None:
                 log_msg += f"\n{key} = {self.metrics[key][-1]:.4f}"
         log_msg += f"\nLR = {self.optimizer.lr:.4f}"
+        log_msg += f"\nGrad L2 Norm = {grad_l2_norm(self.model.parameters):.2f}"
         logger.info(log_msg)
 
     @abstractmethod
@@ -387,7 +388,7 @@ class LLMTrainer(AbstractTrainer):
                 prediction_func=self.forward_fn,
                 bpe=train_data_loader.bpe,
                 groundtruth_data=train_data_loader.data[: train_data_loader.seq_len],
-                max_length=train_data_loader.seq_len // 4,
+                max_length=train_data_loader.seq_len // 3,
             )
 
         # Normal sampling

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -85,14 +85,6 @@ class AbstractTrainer(ABC):
             else:
                 val_loss = None
 
-            # val_loss = None
-            # if val_data_loader is not None:
-            #     if hasattr(val_data_loader, "on_epoch_start"):
-            #         val_data_loader.on_epoch_start()
-            #     val_loss = self.evaluate(
-            #         train_data_loader, val_data_loader, epoch
-            #     )
-
             self._on_epoch_end(epoch, train_loss, val_loss)
 
         self._save_metrics()

--- a/examples/gpt-2.py
+++ b/examples/gpt-2.py
@@ -8,8 +8,9 @@ from autograd import functional, nn, optim
 from autograd.tensor import Tensor
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
+from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
 from autograd.tools.data import LLMDataLoader
-from autograd.tools.trainer import LLMTrainer, load_model_and_optimizer
+from autograd.tools.trainer import LLMTrainer
 
 # The feedforward layer is the same as the original transformers
 from examples.transformers import (
@@ -183,69 +184,89 @@ class GPT2ForwardFn(nn.AbstractLLMForwardFn):
 
 
 if __name__ == "__main__":
-    SHAPESPEARE_CONFIG = {
-        "training_run_name": "shakespeare_mini",
-        "model_kwargs": {
+    SHAPESPEARE_CONFIG = TransformerTrainingConfig(
+        training_run_name="shakespeare_mini",
+        dataset_name="shakespeare_mini",
+        batch_size=64,  # GPT-2 uses 512
+        total_epochs=25,
+        eval_iters=10,
+        steps_per_epoch=20,
+        checkpoint_freq=2,
+        model_kwargs={
             "num_attention_heads": 6,  # GPT-2 small uses 12
             "hidden_size": 72,  # GPT-2 small uses 768, must be divisible by num_attention_heads
             "dropout_prob": 0.2,
             "max_seq_len": 64,  # GPT-2 uses 1024
             "num_decoder_layers": 6,  # GPT-2 uses 12
         },
-        "optimizer_kwargs": {
+        optimizer_kwargs={
             "lr": 1e-3,
             "beta2": 0.99,
             "max_grad_norm": 1.0,
             "weight_decay": 0.1,
+            "lr_scheduler_kwargs": {
+                "lr_scheduler_cls": optim.CosineScheduler,  # TODO: check if we can serialize this into checkpoint
+                "warmup_steps": 100,
+                "lr_decay_iters": 500,  # steps_per_epoch * total_epochs
+            },
         },
-        "num_epochs": 25,
-        "warmup_steps": 100,
-        "eval_iters": 10,
-        "steps_per_epoch": 20,
-        "checkpoint_freq": 2,
-        "batch_size": 64,  # GPT-2 uses 512
-        "label_smoothing": 0.1,
-        # Whether to check the model performance by feeding the groundtruth tokens to compare whether the model can predict the next token correctly.
-        "teacher_enforcing": False,
-        "resume_epoch": 24,  # Whether to load from a checkpoint
-        # if True, we use our own BPE, otherwise we use TikToken library
-        "custom_bpe": {
-            "num_merges": 0,
-            "npz_file_path": "training_data/bpe_0_shakespeare_encoded_data",
-            "vocab_file_path": "training_data/shakespeare_vocab_0.pkl",
-        },
-    }
+        resume_epoch=24,
+        teacher_enforcing=False,
+        include_decoder_input=False,
+        create_padding_masks=False,
+        label_smoothing=0.1,
+        eval_start_string="First",
+        custom_bpe=CustomBpeConfig(
+            num_merges=0,
+            encoded_data_path="training_data/bpe_0_shakespeare_encoded_data.npz",
+            vocab_path="training_data/shakespeare_vocab_0.pkl",
+            overwrite_encoded_data=False,
+            overwrite_vocabulary_file=False,
+            split_token="<|endoftext|>",
+        ),
+    )
 
-    WIKI_CONFIG = {
-        "training_run_name": "wiki",
-        "model_kwargs": {
+    WIKI_CONFIG = TransformerTrainingConfig(
+        training_run_name="wiki",
+        dataset_name="wiki_simple_english",
+        batch_size=64,  # GPT-2 uses 512
+        total_epochs=30,
+        eval_iters=100,
+        steps_per_epoch=200,
+        checkpoint_freq=2,
+        model_kwargs={
             "num_attention_heads": 12,  # GPT-2 small uses 12
             "hidden_size": 768,  # GPT-2 small uses 768, must be divisible by num_attention_heads
             "dropout_prob": 0.2,
             "max_seq_len": 192,  # GPT-2 uses 1024
             "num_decoder_layers": 12,  # GPT-2 uses 12
         },
-        "optimizer_kwargs": {
+        optimizer_kwargs={
             "lr": 1e-3,
             "beta2": 0.99,
             "max_grad_norm": 1.0,
+            "weight_decay": 0.1,
+            "lr_scheduler_kwargs": {
+                "lr_scheduler_cls": optim.CosineScheduler,
+                "warmup_steps": 100,
+                "lr_decay_iters": 500,
+            },
         },
-        "num_epochs": 60,
-        "warmup_steps": 100,
-        "eval_iters": 100,
-        "steps_per_epoch": 200,
-        "checkpoint_freq": 2,
-        "batch_size": 64,  # GPT-2 uses 512
-        "label_smoothing": 0.1,
-        # Whether to check the model performance by feeding the groundtruth tokens to compare whether the model can predict the next token correctly.
-        "teacher_enforcing": False,
-        "resume_epoch": 29,  # Whether to load from a checkpoint
-        "custom_bpe": {
-            "num_merges": 12000,
-            "npz_file_path": "training_data/bpe_12000_wiki_simple_encoded_data",
-            "vocab_file_path": "training_data/wikipedia_simpleenglish_vocab_12000.pkl",
-        },  # if non-empty, we use our own BPE, otherwise we use TikToken library
-    }
+        resume_epoch=None,
+        teacher_enforcing=False,
+        include_decoder_input=False,
+        create_padding_masks=False,
+        label_smoothing=0.1,
+        eval_start_string="April is",
+        custom_bpe=CustomBpeConfig(
+            num_merges=12000,
+            encoded_data_path="training_data/bpe_12000_wiki_simple_encoded_data",
+            vocab_path="training_data/wikipedia_simpleenglish_vocab_12000.pkl",
+            overwrite_encoded_data=False,
+            overwrite_vocabulary_file=False,
+            split_token="<|endoftext|>",
+        ),
+    )
 
     CONFIG = SHAPESPEARE_CONFIG
 
@@ -255,100 +276,57 @@ if __name__ == "__main__":
     data = text_utils.load_shakespeare_mini()
     # data = text_utils.load_wiki_simple()
 
-    logger.info(f"{len(data)} characters in the entire dataset")
-    # data = data[:50_000]
-    print(data[:100])
-
-    n = int(len(data) * 0.9)
-    train_data, test_data = data[:n], data[n:]
-
-    if CONFIG.get("custom_bpe"):
+    if CONFIG.custom_bpe:
         # Create a Byte Pair Encoder and prepare data
         bpe = BytePairEncoder(
-            num_merges=CONFIG["custom_bpe"]["num_merges"],
-            vocab_file_path=CONFIG["custom_bpe"]["vocab_file_path"],
-            encoded_data_path=f"{CONFIG["custom_bpe"]["npz_file_path"]}.npz",
+            num_merges=CONFIG.custom_bpe.num_merges,
+            vocab_file_path=CONFIG.custom_bpe.vocab_path,
+            encoded_data_path=CONFIG.custom_bpe.encoded_data_path,
         )
-        # Train the vocabulary on the entire dataset
-        bpe.train_vocabulary(
-            data,
-            overwrite_saved_file=False,
-        )
-        data_len = len(data.split("\n\n"))
-        print(f"Total length of data after split: {data_len}")
-        # Override the path with training path
-        bpe.encoded_data_path = f"{CONFIG["custom_bpe"]["npz_file_path"]}_train.npz"
-        train_data = bpe.prepare_data(
-            raw_text_list=train_data.split("\n\n"),
-            overwrite_encoded_data=False,
-            overwrite_vocabulary_file=False,
-            split_token="<|endoftext|>",
-        )
-        # Override the path with test path
-        bpe.encoded_data_path = f"{CONFIG["custom_bpe"]["npz_file_path"]}_test.npz"
-        test_data = bpe.prepare_data(
-            raw_text_list=test_data.split("\n\n"),
-            overwrite_encoded_data=False,
-            overwrite_vocabulary_file=False,
-            split_token="<|endoftext|>",
+        encoded_data = bpe.prepare_data(
+            raw_text=data,
+            overwrite_encoded_data=CONFIG.custom_bpe.overwrite_encoded_data,
+            overwrite_vocabulary_file=CONFIG.custom_bpe.overwrite_vocabulary_file,
+            split_token=CONFIG.custom_bpe.split_token,
         )
     else:
         # Using Tiktoken for tokenizer
         bpe = tiktoken.get_encoding("gpt2")
-        train_data = bpe.encode(train_data)
-        test_data = bpe.encode(test_data)
+        encoded_data = bpe.encode(data)
 
+    n = int(len(encoded_data) * 0.9)
+    train_data, test_data = encoded_data[:n], encoded_data[n:]
     print(f"Data length: {len(train_data)=} {len(test_data)=}")
 
-    CONFIG["model_kwargs"]["vocab_size"] = bpe.n_vocab
+    CONFIG.model_kwargs["vocab_size"] = bpe.n_vocab
 
-    # Build GPT-2 model, reusing the same training logic
-    model, optimizer, checkpoint = load_model_and_optimizer(
-        GPT2,
-        optim.Adam,
-        model_kwargs=CONFIG["model_kwargs"],
-        optimizer_kwargs=CONFIG["optimizer_kwargs"],
-        resume_epoch=CONFIG["resume_epoch"],
+    trainer = LLMTrainer(
+        model_cls=GPT2,
+        optimizer_cls=optim.Adam,
+        loss_fn=functional.cross_entropy,
+        config=CONFIG,
+        forward_fn=GPT2ForwardFn(),
     )
-
-    hparams = checkpoint.get("hyperparams", CONFIG)
 
     train_data_loader = LLMDataLoader(
         data=np.array(train_data),
         bpe=bpe,
-        batch_size=hparams["batch_size"],
-        seq_len=model.max_seq_len,
-        steps_per_epoch=hparams["steps_per_epoch"],
+        batch_size=CONFIG.batch_size,
+        seq_len=trainer.model.max_seq_len,
+        steps_per_epoch=CONFIG.steps_per_epoch,
         shuffle=True,
-        include_decoder_input=False,
-        create_decoder_inp=False,
-        create_masks=False,
+        include_decoder_input=CONFIG.include_decoder_input,
+        create_padding_masks=CONFIG.create_padding_masks,
     )
     test_data_loader = LLMDataLoader(
         data=np.array(test_data),
         bpe=bpe,
-        batch_size=hparams["batch_size"] // 2,
-        seq_len=model.max_seq_len,
-        steps_per_epoch=hparams["eval_iters"],
+        batch_size=CONFIG.batch_size // 2,
+        seq_len=trainer.model.max_seq_len,
+        steps_per_epoch=CONFIG.eval_iters,
         shuffle=False,
-        include_decoder_input=False,
-        create_decoder_inp=False,
-        create_masks=False,
-    )
-
-    trainer = LLMTrainer(
-        model=model,
-        optimizer=optimizer,
-        loss_fn=functional.cross_entropy,
-        epochs=hparams["num_epochs"],
-        warmup_steps=hparams["warmup_steps"],
-        label_smoothing=hparams["label_smoothing"],
-        checkpoint_freq=hparams["checkpoint_freq"],
-        forward_fn=GPT2ForwardFn(),
-        teacher_enforcing=hparams["teacher_enforcing"],
-        hyperparams=hparams,
-        checkpoint=checkpoint,
-        start_tokens="First",
+        include_decoder_input=CONFIG.include_decoder_input,
+        create_padding_masks=CONFIG.create_padding_masks,
     )
 
     trainer.fit(train_data_loader, test_data_loader)
@@ -356,11 +334,11 @@ if __name__ == "__main__":
     # Inference test
     for k in range(10):
         text_utils.inference(
-            model=model,
+            model=trainer.model,
             prediction_func=GPT2ForwardFn(),
             bpe=bpe,
             start_tokens="April is a charming day",  # Example start token
-            max_length=int(model.max_seq_len * 0.9),
+            max_length=int(trainer.model.max_seq_len * 0.9),
             temperature=0.7,
             # top_k=200,
         )

--- a/examples/gpt-2.py
+++ b/examples/gpt-2.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any, Optional
 
 import numpy as np
-import tiktoken
 
 from autograd import functional, nn, optim
 from autograd.tensor import Tensor
@@ -290,7 +289,10 @@ if __name__ == "__main__":
             split_token=CONFIG.custom_bpe.split_token,
         )
     else:
-        # Using Tiktoken for tokenizer
+        # TODO: Experimental to debug whether the model learning is poorly due to
+        # the tokenizer. Need to install the python package manually via `uv pip install tiktoken`
+        import tiktoken
+
         bpe = tiktoken.get_encoding("gpt2")
         encoded_data = bpe.encode(data)
 

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -401,15 +401,19 @@ if __name__ == "__main__":
     data = load_data(
         "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt",
         "examples/tinyshakespeare.txt",
-    )
+    )[:10000]
     logger.info(f"{len(data)} characters in the entire dataset")
 
     # Create the vocabulary first
-    bpe = BytePairEncoder(num_merges=3000, vocab_file_path="vocab.pkl")
+    bpe = BytePairEncoder(
+        num_merges=3000,
+        vocab_file_path="vocab.pkl",
+        encoded_data_path="bpe_mini_shakespeare.npz",
+    )
     encoded_data = bpe.prepare_data(
         raw_text_list=data.split("\n\n"),
-        npz_file_path="bpe_mini_shakespeare.npz",
-        overwrite_saved_file=False,
+        overwrite_encoded_data=False,
+        overwrite_vocabulary_file=False,
         split_token="<|endoftext|>",
     )[:5000]
 

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from unittest import TestCase
 
 try:
@@ -49,6 +50,18 @@ class RegressionModel(nn.Module):
 
 
 class TestTrain(TestCase):
+    def tearDown(self) -> None:
+        reg_metrics_path = (
+            f"{SimpleTrainer.METRICS_DIR}/{RegressionModel.__name__}_default.npz"
+        )
+        classifier_metrics_path = (
+            f"{SimpleTrainer.METRICS_DIR}/{Classifier.__name__}_default.npz"
+        )
+        if os.path.exists(reg_metrics_path):
+            os.remove(reg_metrics_path)
+        if os.path.exists(classifier_metrics_path):
+            os.remove(classifier_metrics_path)
+
     def test_binary_classification(self):
         X, y = load_breast_cancer(return_X_y=True)
         logger.info(f"Dataset: {X.shape=}, {y.shape=}")

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -230,7 +230,7 @@ class TestTextUtils(TestCase):
             bpe=self.bpe,  # type: ignore
             start_tokens="<SOS>",
             groundtruth_data=None,
-            max_length=max_length,
+            max_length=max_length + 1,  # +1 for the start_token
             temperature=1.0,
             top_k=5,
         )

--- a/test/autograd/tools/test_data.py
+++ b/test/autograd/tools/test_data.py
@@ -135,12 +135,12 @@ class TestDataLoaders(unittest.TestCase):
         X_chunk, dec_inp, Y_chunk, smask, tmask, causal_mask = batch
         self.assertEqual(X_chunk.shape, (self.batch_size_llm, self.seq_len))
         self.assertEqual(Y_chunk.shape, (self.batch_size_llm, self.seq_len))
-        if loader.include_decoder_input and loader.create_decoder_inp:
+        if loader.include_decoder_input:
             self.assertEqual(dec_inp.shape, (self.batch_size_llm, self.seq_len))
             self.assertTrue(np.all(dec_inp[:, 0] == loader.sos_idx))
         else:
             self.assertIsNone(dec_inp)
-        if loader.create_masks:
+        if loader.create_padding_masks:
             self.assertEqual(smask.shape, (self.batch_size_llm, 1, 1, self.seq_len))
             self.assertEqual(
                 tmask.shape, (self.batch_size_llm, 1, self.seq_len, self.seq_len)

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -57,6 +58,13 @@ class BaseTrainerTest(unittest.TestCase):
 
         # A mock loss function returning a constant scalar
         self.loss_fn = MagicMock(return_value=Tensor(1.23))
+
+    def tearDown(self) -> None:
+        metrics_path = (
+            f"{SimpleTrainer.METRICS_DIR}/{self.model.__class__.__name__}_default.npz"
+        )
+        if os.path.exists(metrics_path):
+            os.remove(metrics_path)
 
 
 class TestSimpleTrainer(BaseTrainerTest):

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 
 from autograd.nn import Module
+from autograd.optim import Optimizer
 from autograd.tensor import Tensor
+from autograd.tools.config_schema import (
+    GenericTrainingConfig,
+    TransformerTrainingConfig,
+)
 from autograd.tools.trainer import LLMTrainer, SimpleTrainer
 
 
@@ -34,6 +39,67 @@ class MockDataLoader:
         return iter(self.data)
 
 
+class MockModelClass(Module):
+    """
+    A minimal mock model class conforming to nn.Module that returns
+    a constant prediction and tracks calls to num_parameters().
+    """
+
+    def __init__(self, hidden_size=128, **kwargs):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self._num_params = 1e6  # pretend we have 1 million params
+
+    def num_parameters(self):
+        return self._num_params
+
+    def __call__(self, x):
+        # Return a consistent shape for classification (e.g. batch_size x num_classes)
+        # Or adapt to your needs.
+        batch_size = x.shape[0]
+        return Tensor(np.zeros((batch_size, 3), dtype=np.float32))
+
+    def train(self):
+        pass
+
+    def eval(self):
+        pass
+
+    def load_state_dict(self, state_dict):
+        pass
+
+    def state_dict(self):
+        # Return something that can be saved as checkpoint
+        return {}
+
+
+class MockOptimizerClass(Optimizer):
+    """
+    A minimal mock optimizer that tracks step calls and has a .lr property.
+    """
+
+    def __init__(self, parameters, lr=1e-3, **kwargs):
+        super().__init__(parameters, lr=lr)
+        self._lr = lr
+        self.step_call_count = 0
+
+    @property
+    def lr(self):
+        return self._lr
+
+    def step(self):
+        self.step_call_count += 1
+
+    def zero_grad(self):
+        pass
+
+    def load_state_dict(self, state_dict):
+        pass
+
+    def state_dict(self):
+        return {}
+
+
 class BaseTrainerTest(unittest.TestCase):
     """
     A base test class that provides common setUp logic for any trainer.
@@ -41,27 +107,12 @@ class BaseTrainerTest(unittest.TestCase):
     """
 
     def setUp(self):
-        # Mock model with numeric num_parameters() and an override for __call__.
-        self.model = Module()
-        # model.num_parameters() must return a float so that format strings work (:.2f).
-        self.model.num_parameters = MagicMock()
-        self.model.num_parameters.return_value = 1e6
-        self.model.state_dict = MagicMock()
-        self.model.state_dict.return_value = {}
-        # We'll leave self.model.__call__ to be defined in child classes (because shapes differ).
-
-        # Mock optimizer with a numeric .lr property
-        self.optimizer = MagicMock()
-        self.optimizer.lr = 0.01
-        self.optimizer.zero_grad = MagicMock()
-        self.optimizer.step = MagicMock()
-
         # A mock loss function returning a constant scalar
         self.loss_fn = MagicMock(return_value=Tensor(1.23))
 
     def tearDown(self) -> None:
         metrics_path = (
-            f"{SimpleTrainer.METRICS_DIR}/{self.model.__class__.__name__}_default.npz"
+            f"{SimpleTrainer.METRICS_DIR}/{MockModelClass.__name__}_default.npz"
         )
         if os.path.exists(metrics_path):
             os.remove(metrics_path)
@@ -70,6 +121,16 @@ class BaseTrainerTest(unittest.TestCase):
 class TestSimpleTrainer(BaseTrainerTest):
     def setUp(self):
         super().setUp()
+
+        # Build a GenericTrainingConfig
+        self.config = GenericTrainingConfig(
+            total_epochs=2,
+            checkpoint_freq=1,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            resume_epoch=None,
+        )
+
         # Make the model return a fake_pred
         self.fake_pred = np.zeros((2, 3), dtype=np.float32)
 
@@ -88,25 +149,25 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         # Create the trainer
         self.trainer = SimpleTrainer(
-            model=self.model,
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
             loss_fn=self.loss_fn,
-            optimizer=self.optimizer,
-            epochs=2,
+            config=self.config,
             output_type="logits",
         )
 
     def test_fit_calls_optimizer_step(self):
-        with patch.object(self.model, "forward", return_value=Tensor(self.fake_pred)):
-            self.trainer.fit(self.train_loader, self.val_loader)
-            # We have 2 epochs * 2 train batches => 4 calls to optimizer.step
-            self.assertEqual(self.optimizer.step.call_count, 4)
+        """Check that fit() results in the correct number of optimizer steps."""
+        self.trainer.fit(self.train_loader, self.val_loader)
+        # 2 epochs * 2 train batches = 4 steps
+        self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
     def test_train_step_returns_loss(self):
-        with patch.object(self.model, "forward", return_value=Tensor(self.fake_pred)):
-            batch = next(iter(self.train_data))
-            loss_val = self.trainer.train_step(batch)
-            self.assertAlmostEqual(loss_val, 1.23, places=5)
-            self.optimizer.step.assert_called_once()
+        """Check that the train_step returns the expected scalar loss."""
+        batch = next(iter(self.train_data))
+        loss_val = self.trainer.train_step(batch)
+        self.assertAlmostEqual(loss_val, 1.23, places=5)
+        self.assertEqual(self.trainer.optimizer.step_call_count, 1)
 
 
 class TestLLMTrainer(BaseTrainerTest):
@@ -116,7 +177,6 @@ class TestLLMTrainer(BaseTrainerTest):
 
         # For LLM, define a shape like (batch_size, seq_len, vocab_size).
         self.fake_pred = np.zeros((2, seq_len, 10), dtype=np.float32)
-        self.model.hidden_size = 128  # for the trainer's warmup logic
 
         # LLM data (just 2 batches for training, 1 batch for validation)
         self.train_data = [
@@ -153,29 +213,39 @@ class TestLLMTrainer(BaseTrainerTest):
             np.zeros((2, seq_len), dtype=np.int32),
         )
 
+        self.config = TransformerTrainingConfig(
+            total_epochs=2,
+            checkpoint_freq=1,
+            model_kwargs={"hidden_size": 128},
+            optimizer_kwargs={"lr": 0.01},
+            resume_epoch=None,
+            label_smoothing=0.0,
+            teacher_enforcing=False,
+            include_decoder_input=True,
+            create_padding_masks=False,
+        )
+
         # Construct the trainer
         self.trainer = LLMTrainer(
-            model=self.model,
-            optimizer=self.optimizer,
-            forward_fn=self.forward_fn,
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
             loss_fn=self.loss_fn,
-            warmup_steps=100,
-            tokenizer=MagicMock(),
-            epochs=2,
+            forward_fn=self.forward_fn,
+            config=self.config,
         )
 
     def test_fit_calls_optimizer_step(self):
-        with patch.object(self.model, "forward", return_value=Tensor(self.fake_pred)):
-            self.trainer.fit(self.train_loader, self.val_loader)
-            # 2 epochs * 2 train batches => 4 calls to optimizer.step
-            self.assertEqual(self.optimizer.step.call_count, 4)
+        """Check that fit() calls optimizer.step the correct number of times."""
+        self.trainer.fit(self.train_loader, self.val_loader)
+        # 2 epochs * 2 train batches = 4 steps
+        self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
     def test_train_step_returns_loss(self):
-        with patch.object(self.model, "forward", return_value=Tensor(self.fake_pred)):
-            batch = next(iter(self.train_data))
-            loss_val = self.trainer.train_step(batch)
-            self.assertAlmostEqual(loss_val, 1.23, places=5)
-            self.optimizer.step.assert_called_once()
+        """Check that a single train step returns the constant scalar loss."""
+        batch = next(iter(self.train_data))
+        loss_val = self.trainer.train_step(batch)
+        self.assertAlmostEqual(loss_val, 1.23, places=5)
+        self.assertEqual(self.trainer.optimizer.step_call_count, 1)
 
     @patch("autograd.text.utils.inference")
     def test_perform_inference_called(self, mock_inference):

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -18,6 +18,7 @@ class MockDataLoader:
         self.data = data
         self.pad_idx = pad_idx
         self.seq_len = seq_len
+        self.bpe = MagicMock()
 
     def on_epoch_start(self):
         # If you want to shuffle or do something each epoch, do it here


### PR DESCRIPTION
## Description
- Add config schema dataclass for `GenericTrainingConfig`, `TransformerTrainingConfig` and `CustomBpeConfig`
- Greatly simplify the trainer class (e.g. args, state management, 
- Make learning rate scheduler configurable by instantiating in the trainer class using kwargs from the configs
- Move the load_wiki_simple() and load_shakespeare_mini() data fetching functions into the `autograd/text/utils.py` to make the examples slim
- Refactor the forward function for Transformer-based models to implement the `AbstractLLMForwardFn` interface with a clean `train` and `sample` mode  interface

## Tests
Updated unit tests for all updated functionalities, especially the trainer class <-> config integration, to solidify the contract between them.

All examples training successfully.