### PR TITLE
Simulate larger batches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,6 +68,13 @@
             "module": "autograd.text.tokenizer"
         },
         {
+            "name": "Trainer",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["test/autograd/tools/test_trainer.py"]
+        },
+        {
             "name": "MaxPool2d",
             "type": "debugpy",
             "request": "launch",

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -30,6 +30,8 @@ class GenericTrainingConfig:
     resume_epoch: Optional[int] = None
     training_run_name: str = "default"
     dataset_name: Optional[str] = ""
+    # This is to simulate larger batches by updating the weights once every N batches.
+    update_weights_every_n_steps: int = 1
 
 
 @dataclass

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -167,7 +167,6 @@ class TestSimpleTrainer(BaseTrainerTest):
         batch = next(iter(self.train_data))
         loss_val = self.trainer.train_step(batch)
         self.assertAlmostEqual(loss_val, 1.23, places=5)
-        self.assertEqual(self.trainer.optimizer.step_call_count, 1)
 
 
 class TestLLMTrainer(BaseTrainerTest):
@@ -245,7 +244,6 @@ class TestLLMTrainer(BaseTrainerTest):
         batch = next(iter(self.train_data))
         loss_val = self.trainer.train_step(batch, self.train_loader)
         self.assertAlmostEqual(loss_val, 1.23, places=5)
-        self.assertEqual(self.trainer.optimizer.step_call_count, 1)
 
     @patch("autograd.text.utils.inference")
     def test_perform_inference_called(self, mock_inference):


### PR DESCRIPTION
## Description
To allow a limited memory machine to train with larger batch sizes, we are going to introduce a new functionality: `update_weights_every_n_steps`. This is to simulate larger batches by updating the weights once every N batches/steps.

**Changes:** Remove the `.step()` and `.zero_grad()` calls in the trainer class' `train_step()` function. We will be doing those two steps in the AbstractTrainer's `_train_one_epoch()`, which allows us to access the number of steps we have processed in a given epoch, and periodically perform `.step()` and `.zero_grad()` to achieve this.

Assume we have this training config in the example below: 
```
batch_size=16,
total_epochs=30,
steps_per_epoch=1600,
update_weights_every_n_steps=8, # simulate larger batch sizes
```
In each weight update, we will be processing 16 x 8 = 128 samples (simulating batch_size of 128, but we only keep 16 samples in the memory). Each epoch will run 1600 / 8 = 200 weight updates. For the entire training run, we will be doing 30 x 200 = 6000 weight updates.

## Tests
Updated one unit test to remove the `.step()` validation when the `train_step()` is called, because its reponsibility is no longer to perform the `.step()` function, explained above.
