### PR TITLE
Avoid expand copy in some tensor level operations

### DIFF
--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -1644,11 +1644,10 @@ class Mean(Function):
         )
         grad_arr = grad_expanded.data
         # Scale gradient by number of elements
-        num_elements = (
-            np.prod(np.array([self.tensors[0].shape[ax] for ax in self.axis]))
-            if self.axis is not None
-            else self.tensors[0].shape
-        )
+        if self.axis is not None:
+            num_elements = np.prod([self.tensors[0].shape[ax] for ax in self.axis])
+        else:
+            num_elements = np.prod(self.tensors[0].shape)
         return grad_arr / num_elements
 
 

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -292,8 +292,6 @@ class Tensor:
         """
         if not isinstance(other, Tensor):
             other = Tensor(other, requires_grad=False)
-        if self.shape == other.shape:
-            return Add.apply(self, other)
 
         return Add.apply(self, other)
 
@@ -312,8 +310,6 @@ class Tensor:
         """
         if not isinstance(other, Tensor):
             other = Tensor(other, requires_grad=False)
-        if self.shape == other.shape:
-            return Mul.apply(self, other)
 
         return Mul.apply(self, other)
 
@@ -345,8 +341,6 @@ class Tensor:
         """
         if not isinstance(other, Tensor):
             other = Tensor(other, requires_grad=False)
-        if self.shape == other.shape:
-            return Pow.apply(self, other)
 
         return Pow.apply(self, other)
 


### PR DESCRIPTION
## Description
Previously, we were explicitly expanding the np.array by calling `np.expand` for some Tensor operations like `t1 * t2` if they are not the same shape. This `np.expand` causes unnecessary memory allocations and create more memory footprint when t1 or t2 are large matrices. Ultimately what we want is a way to broadcast in the forward pass (handled by numpy), and unbroadcast in the backward pass. So, we will be storing the shapes of t1 and t2 in the forward pass, and "unbroadcasting" the shapes of t1 and t2 in the backward pass.

## Tests
All unit tests passed.

## Memory Savings
Using the `examples/gpt-2.py` as a comparison reference point. Not bad for a 30%+ memory savings.

**Before**
<img width="275" alt="image" src="https://github.com/user-attachments/assets/e6f6774b-2f70-421e-8f23-e61f31692889" />


**After**
<img width="270" alt="image" src="https://github.com/user-attachments/assets/9330cd69-04e8-4b61-9735-720cf6da50ef" />
