### PR TITLE
Decouple inference from training and introduce callbacks

### DIFF
--- a/autograd/tools/callback.py
+++ b/autograd/tools/callback.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from autograd import nn
+from autograd.text import utils as text_utils
+from autograd.tools.config_schema import TransformerTrainingConfig
+
+
+def teacher_forcing_callback(
+    model: nn.Module,
+    forward_fn: nn.AbstractLLMForwardFn,
+    val_data_loader: Any,
+    config: TransformerTrainingConfig,
+) -> None:
+    """Runs teacher-forcing qualitative evaluation when enabled in the config."""
+    if config.teacher_enforcing and hasattr(val_data_loader, "data"):
+        text_utils.inference(
+            model=model,
+            prediction_func=forward_fn,
+            bpe=val_data_loader.bpe,
+            groundtruth_data=val_data_loader.data[: val_data_loader.seq_len // 3],
+            max_length=val_data_loader.seq_len // 3,
+        )
+
+
+def sampling_callback(
+    model: nn.Module,
+    forward_fn: nn.AbstractLLMForwardFn,
+    val_data_loader: Any,
+    config: TransformerTrainingConfig,
+) -> None:
+    """Runs free-sampling qualitative evaluation."""
+    text_utils.inference(
+        model=model,
+        prediction_func=forward_fn,
+        bpe=val_data_loader.bpe,
+        start_tokens=config.eval_start_string,
+        max_length=min(128, int(val_data_loader.seq_len * 0.4)),
+        temperature=1.0,
+        top_k=config.eval_top_k,
+    )

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -2,7 +2,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Callable, Dict, Optional, Tuple, cast
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, cast
 
 from tqdm import tqdm
 
@@ -13,7 +13,6 @@ from autograd.backend import (
     xp,
 )
 from autograd.tensor import Tensor
-from autograd.text import utils as text_utils
 from autograd.tools.config_schema import (
     GenericTrainingConfig,
     TransformerTrainingConfig,
@@ -75,7 +74,8 @@ class AbstractTrainer(ABC):
 
         Args:
             train_data_loader: An iterable or generator that yields training batches.
-            val_data_loader: (Optional) An iterable or generator that yields validation batches.
+            val_data_loader: (Optional) An iterable or generator that yields labeled
+                validation batches.
         """
         logger.info(
             f"Training {self.model.__class__.__name__} with "
@@ -96,7 +96,7 @@ class AbstractTrainer(ABC):
             if val_data_loader is not None:
                 if hasattr(val_data_loader, "on_epoch_start"):
                     val_data_loader.on_epoch_start()
-                val_loss = self.evaluate(train_data_loader, val_data_loader, epoch)
+                val_loss = self.evaluate(val_data_loader)
             else:
                 val_loss = None
 
@@ -135,6 +135,8 @@ class AbstractTrainer(ABC):
                 self.metrics["grad_l2_norm"].append(grad_l2_norm(self.model.parameters))
                 self.optimizer.zero_grad()
             batch_count += 1
+        # TODO: Decide whether to flush leftover accumulated gradients at epoch end when
+        # batch_count is not divisible by update_weights_every_n_steps.
         return total_loss / max(batch_count, 1)
 
     def _save_checkpoint(self, epoch: int, val_loss: Optional[float]):
@@ -224,13 +226,11 @@ class AbstractTrainer(ABC):
         logger.info(log_msg)
 
     @abstractmethod
-    def evaluate(self, train_data_loader, val_data_loader, epoch) -> float:
+    def evaluate(self, val_data_loader) -> float:
         """Evaluates the model on the validation set.
 
         Args:
-            train_data_loader: Training data loader (if needed for evaluation context).
             val_data_loader: Validation data loader providing validation batches.
-            epoch (int): Current epoch number, provided for logging or conditional evaluation.
 
         Returns:
             float: The average validation loss over the validation set.
@@ -419,13 +419,11 @@ class SimpleTrainer(AbstractTrainer):
         loss.backward()
         return float(loss.item())
 
-    def evaluate(self, train_data_loader, val_data_loader, epoch) -> float:
+    def evaluate(self, val_data_loader) -> float:
         """Evaluates the model on the validation data loader.
 
         Args:
-            train_data_loader: Unused in this implementation, but kept for interface consistency.
             val_data_loader: An iterable or generator providing validation batches.
-            epoch (int): The current epoch number.
 
         Returns:
             float: The average validation loss over the entire validation dataset.
@@ -458,15 +456,7 @@ class SimpleTrainer(AbstractTrainer):
             )
             self.metrics["val_accuracy"].append(acc_val)
 
-            if (
-                self.sample_predictions
-                and epoch
-                % max(
-                    1,
-                    self.config.total_epochs // min(10, self.config.total_epochs),
-                )
-                == 0
-            ):
+            if self.sample_predictions:
                 sample_count = min(5, len(y_pred_proc))
                 if sample_count > 0:
                     sample_lines = [
@@ -584,6 +574,19 @@ class LLMTrainer(AbstractTrainer):
         loss_fn: Callable,
         forward_fn: nn.AbstractLLMForwardFn,
         config: TransformerTrainingConfig,
+        eval_callbacks: Optional[
+            Sequence[
+                Callable[
+                    [
+                        nn.Module,
+                        nn.AbstractLLMForwardFn,
+                        Any,
+                        TransformerTrainingConfig,
+                    ],
+                    None,
+                ]
+            ]
+        ] = None,
         **kwargs,
     ):
         """Initializes the LLMTrainer.
@@ -596,6 +599,8 @@ class LLMTrainer(AbstractTrainer):
                 to handle how the model is invoked for language modeling tasks.
             config (TransformerTrainingConfig): A specialized config containing transformer
                 and training hyperparameters.
+            eval_callbacks: Optional callbacks run after evaluation using
+                `(model, forward_fn, val_data_loader, config)`.
             **kwargs: Additional arguments passed to the parent trainer.
         """
         super().__init__(model_cls, optimizer_cls, loss_fn, config=config, **kwargs)
@@ -603,6 +608,7 @@ class LLMTrainer(AbstractTrainer):
             TransformerTrainingConfig, self.config
         )
         self.forward_fn = forward_fn
+        self.eval_callbacks = list(eval_callbacks or [])
 
     def train_step(self, batch_data, data_loader) -> float:
         """Performs a forward pass for language modeling, computes the loss, and backpropagates.
@@ -629,63 +635,33 @@ class LLMTrainer(AbstractTrainer):
         loss.backward()
         return float(loss.item())
 
-    def evaluate(self, train_data_loader, val_data_loader, epoch) -> float:
+    def evaluate(self, val_data_loader) -> float:
         """Evaluates the model on the validation data loader for language modeling.
 
         Args:
-            train_data_loader: Training data loader (if needed for context).
             val_data_loader: Validation data loader providing batches with
                 (X, dec_inp, y, src_mask, tgt_mask, causal_mask).
-            epoch (int): Current epoch number.
 
         Returns:
             float: The average validation loss over the language modeling validation set.
         """
         self.model.eval()
-        total_loss = 0.0
-        batch_count = 0
-        for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
-            pred_probs, y = self.forward_fn(self.model, batch_data, mode="train")
-            loss = self.loss_fn(pred_probs, y, pad_idx=val_data_loader.pad_idx)
-            total_loss += float(loss.item())
-            batch_count += 1
-        avg_val_loss = total_loss / max(batch_count, 1)
-
-        if epoch % 2 == 0:  # Optionally perform inference every 2 epochs
-            self._perform_inference(train_data_loader)
-
-        self.model.train()
-        return avg_val_loss
-
-    def _perform_inference(self, train_data_loader):
-        """Optionally performs teacher-forcing or sampling-based inference.
-        Make sure LLMDataLoader has `data` if you rely on `train_data_loader.data`.
-
-        Args:
-            train_data_loader: Data loader that can provide the BPE tokenizer and some
-                sample data to generate from.
-        """
-        if self.config.teacher_enforcing and hasattr(train_data_loader, "data"):
-            text_utils.inference(
-                model=self.model,
-                prediction_func=self.forward_fn,
-                bpe=train_data_loader.bpe,
-                groundtruth_data=train_data_loader.data[
-                    : train_data_loader.seq_len // 3
-                ],
-                max_length=train_data_loader.seq_len // 3,
-            )
-
-        # Normal sampling inference
-        text_utils.inference(
-            model=self.model,
-            prediction_func=self.forward_fn,
-            bpe=train_data_loader.bpe,
-            start_tokens=self.config.eval_start_string,
-            max_length=min(128, int(train_data_loader.seq_len * 0.4)),
-            temperature=1.0,
-            top_k=self.config.eval_top_k,
-        )
+        try:
+            total_loss = 0.0
+            batch_count = 0
+            for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
+                pred_probs, y = self.forward_fn(self.model, batch_data, mode="train")
+                # TODO: Decide whether validation should use the same label_smoothing setting
+                # as training, or intentionally report unsmoothed cross-entropy.
+                loss = self.loss_fn(pred_probs, y, pad_idx=val_data_loader.pad_idx)
+                total_loss += float(loss.item())
+                batch_count += 1
+            avg_val_loss = total_loss / max(batch_count, 1)
+            for callback in self.eval_callbacks:
+                callback(self.model, self.forward_fn, val_data_loader, self.config)
+            return avg_val_loss
+        finally:
+            self.model.train()
 
 
 def grad_l2_norm(parameters: Dict[str, Tensor]) -> float:

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -10,6 +10,7 @@ from autograd.backend import xp
 from autograd.tensor import Tensor
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
+from autograd.tools.callback import sampling_callback, teacher_forcing_callback
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
 from autograd.tools.data import LLMDataLoader
 from autograd.tools.trainer import LLMTrainer
@@ -211,6 +212,7 @@ if __name__ == "__main__":
         loss_fn=functional.cross_entropy,
         config=CONFIG,
         forward_fn=GPT1ForwardFn(),
+        eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
     train_data_loader = LLMDataLoader(

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -10,6 +10,7 @@ from autograd.backend import xp
 from autograd.tensor import Tensor
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
+from autograd.tools.callback import sampling_callback, teacher_forcing_callback
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
 from autograd.tools.data import LLMDataLoader
 from autograd.tools.trainer import LLMTrainer
@@ -319,6 +320,7 @@ if __name__ == "__main__":
         loss_fn=functional.cross_entropy,
         config=CONFIG,
         forward_fn=GPT2ForwardFn(),
+        eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
     train_data_loader = LLMDataLoader(

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -6,6 +6,7 @@ from autograd.backend import xp
 from autograd.tensor import Tensor
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
+from autograd.tools.callback import sampling_callback, teacher_forcing_callback
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
 from autograd.tools.data import LLMDataLoader
 from autograd.tools.trainer import LLMTrainer
@@ -641,6 +642,7 @@ if __name__ == "__main__":
         loss_fn=functional.cross_entropy,
         config=CONFIG,
         forward_fn=TransformerForwardFn(),
+        eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
     train_data_loader = LLMDataLoader(

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -1,7 +1,7 @@
 import math
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from autograd.backend import xp
 from autograd.nn import Module
@@ -274,8 +274,34 @@ class TestLLMTrainer(BaseTrainerTest):
         loss_val = self.trainer.train_step(batch, self.train_loader)
         self.assertAlmostEqual(loss_val, 1.23, places=5)
 
-    @patch("autograd.text.utils.inference")
-    def test_perform_inference_called(self, mock_inference):
-        # epoch=0 => calls _perform_inference => at least one inference function is called
-        self.trainer.fit(self.train_loader, self.val_loader)
-        self.assertTrue(mock_inference.called)
+    def test_evaluate_does_not_require_loader_metadata(self):
+        class MinimalLoader:
+            pad_idx = 0
+
+            def __init__(self, data):
+                self.data = data
+
+            def __iter__(self):
+                return iter(self.data)
+
+        avg_val_loss = self.trainer.evaluate(MinimalLoader(self.val_data))
+
+        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+
+    def test_evaluate_runs_eval_callbacks_and_returns_val_loss(self):
+        callback = MagicMock()
+        trainer = LLMTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            forward_fn=self.forward_fn,
+            config=self.config,
+            eval_callbacks=[callback],
+        )
+
+        avg_val_loss = trainer.evaluate(self.val_loader)
+
+        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        callback.assert_called_once_with(
+            trainer.model, trainer.forward_fn, self.val_loader, trainer.config
+        )


### PR DESCRIPTION
## Description
Right now, LLMTrainer is highly coupled with inference. This is problematic if we want to extend the trainer or use the trainer for different language modeling tasks like supervised fine-tuning.

This PR will decouple the inference part of the evaluation into a callback. Then it's the caller's responsibility to actually configure which callbacks to use during evaluation. The vanilla evaluate() will be a simple forward pass + loss computation on the validation data.

## Tests
All unit tests passed.


GPT-2 Sample Run
```
(ml-by-hand) ➜  ml-by-hand git:(cleanup-trainer) ✗ python -m examples.gpt_2
2026-04-14 22:52:52,403 - INFO - 1115394 characters in the entire dataset. Sample:
First Citizen:
Before we proceed any further, hear me speak.

All:
Speak, speak.

First Citizen:
You
2026-04-14 22:52:52,403 - INFO - Loading the vocabulary from disk.
2026-04-14 22:52:52,405 - INFO - Found existing encoded data at 'training_data/bpe_3000_shakespeare_encoded_data.npz', loading it instead of re-encoding.
2026-04-14 22:52:52,407 - INFO - Vocabulary size: 3260
2026-04-14 22:52:52,407 - INFO - Encoded data length: 356417
Data length: len(train_data)=320775 len(test_data)=35642
2026-04-14 22:52:52,411 - INFO - No resume_epoch given; initializing model & optimizer from scratch.
2026-04-14 22:52:52,422 - INFO - Training GPT2 with 45.11M parameters.
Training:   0%|                                           | 0/10 [00:00<?, ?it/s2026-04-14 22:53:08,031 - INFO - Teacher forcing mode on!!
Groundtruth:
 the thing that feeds their fury:
Though little fire grows great with little wind,
Yet extreme gusts will blow out
2026-04-14 22:53:08,031 - INFO - Model:

,, the,,, the,,

 the,,,, the the,,
And the,:,,,
 the,

...

2026-04-14 22:56:07,884 - INFO - [Epoch 9]
grad_l2_norm = 0.8746
val_loss = 4.7662
train_loss = 5.1653
LR = 0.0001
2026-04-14 22:56:07,885 - INFO - Saved training metrics to training_runs/GPT2_shakespeare_mini.npz
2026-04-14 22:56:07,887 - INFO - Model:

Now see it could know being too more than
k? OVERCLLOFutous cause on her children. Gidarels I must learn,
Which, ancriesgar with good time that I must wish, the queen?

GREGincestetho, or eclation of me doth I as he told thou hast bear it.

JULIET:
You know.

BUCKINGHAM:
Fnow,
```