### PR TITLE
Dataloader redesign

### DIFF
--- a/autograd/tools/callback.py
+++ b/autograd/tools/callback.py
@@ -1,40 +1,46 @@
-from typing import Any
+from typing import Optional
 
 from autograd import nn
+from autograd.backend import Array
 from autograd.text import utils as text_utils
-from autograd.tools.config_schema import TransformerTrainingConfig
+from autograd.text.tokenizer import BytePairEncoder
 
 
-def teacher_forcing_callback(
+# TODO: Convert these qualitative inference helpers into real trainer lifecycle
+# callbacks once the callback boundary is redesigned. For now they are invoked
+# manually from examples and do not participate in trainer evaluation.
+def run_teacher_forcing_inference(
     model: nn.Module,
     forward_fn: nn.AbstractLLMForwardFn,
-    val_data_loader: Any,
-    config: TransformerTrainingConfig,
-) -> None:
-    """Runs teacher-forcing qualitative evaluation when enabled in the config."""
-    if config.teacher_enforcing and hasattr(val_data_loader, "data"):
-        text_utils.inference(
-            model=model,
-            prediction_func=forward_fn,
-            bpe=val_data_loader.bpe,
-            groundtruth_data=val_data_loader.data[: val_data_loader.seq_len // 3],
-            max_length=val_data_loader.seq_len // 3,
-        )
-
-
-def sampling_callback(
-    model: nn.Module,
-    forward_fn: nn.AbstractLLMForwardFn,
-    val_data_loader: Any,
-    config: TransformerTrainingConfig,
-) -> None:
-    """Runs free-sampling qualitative evaluation."""
-    text_utils.inference(
+    bpe: BytePairEncoder,
+    groundtruth_data: Array,
+    max_length: int,
+) -> str:
+    """Runs teacher-forcing qualitative inference with explicit context."""
+    return text_utils.inference(
         model=model,
         prediction_func=forward_fn,
-        bpe=val_data_loader.bpe,
-        start_tokens=config.eval_start_string,
-        max_length=min(128, int(val_data_loader.seq_len * 0.4)),
+        bpe=bpe,
+        groundtruth_data=groundtruth_data,
+        max_length=max_length,
+    )
+
+
+def run_sampling_inference(
+    model: nn.Module,
+    forward_fn: nn.AbstractLLMForwardFn,
+    bpe: BytePairEncoder,
+    start_tokens: Optional[str],
+    max_length: int,
+    top_k: Optional[int] = None,
+) -> str:
+    """Runs free-sampling qualitative inference with explicit context."""
+    return text_utils.inference(
+        model=model,
+        prediction_func=forward_fn,
+        bpe=bpe,
+        start_tokens=start_tokens,
+        max_length=max_length,
         temperature=1.0,
-        top_k=config.eval_top_k,
+        top_k=top_k,
     )

--- a/autograd/tools/data.py
+++ b/autograd/tools/data.py
@@ -140,7 +140,7 @@ class IterableDataset(ABC):
         pass
 
     def __len__(self) -> int:
-        raise NotImplementedError
+        raise TypeError(f"object of type '{self.__class__.__name__}' has no len()")
 
 
 class PairedIterableDataset(IterableDataset):
@@ -335,7 +335,7 @@ class TokenSequenceDataset(IterableDataset):
 
     def __len__(self) -> int:
         if self.random_window:
-            raise NotImplementedError
+            raise TypeError(f"object of type '{self.__class__.__name__}' has no len()")
         return self.num_examples
 
 

--- a/autograd/tools/data.py
+++ b/autograd/tools/data.py
@@ -1,7 +1,20 @@
+"""
+Data pipeline boundary:
+
+1. Per-sample transforms/tokenization
+- dataset / transforms
+
+2. Batch assembly and batch-time shaping
+- collate_fn
+
+3. Training-specific logic
+- trainer / training loop / model forward
+"""
+
 import csv
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Iterator, Optional, Tuple, Union
+from typing import Any, Callable, Iterator, Optional, Sequence, Tuple, Union
 from urllib.request import urlopen
 
 from pyarrow import parquet as pq  # pyright: ignore[reportMissingImports]
@@ -100,285 +113,550 @@ def load_data(
             return f.read()
 
 
-class AbstractDataLoader(ABC):
+class IterableDataset(ABC):
     """
-    An abstract base class for DataLoaders.
-    A base interface for DataLoaders that yield batches of data for training,
-    with an optional per-epoch hook.
-    """
+    Abstract interface for iterable datasets that yield single examples.
 
-    def __init__(self, batch_size: int, shuffle: bool = True) -> None:
-        """
-        Args:
-            batch_size (int): Number of samples per batch.
-            shuffle (bool): Whether to shuffle the data every epoch (implementation can vary).
-        """
-        self.batch_size = batch_size
-        self.shuffle = shuffle
+    Each iteration should yield one example dictionary. The exact keys depend on
+    the task, but examples should contain enough information for a downstream
+    `collate_fn` to build the final trainer batch.
+
+    Examples:
+        >>> class DummyIterableDataset(IterableDataset):
+        ...     def __iter__(self):
+        ...         yield {"tokens": xp.array([1, 2, 3], dtype=xp.int32)}
+        ...     def __len__(self):
+        ...         return 1
+        >>> dataset = DummyIterableDataset()
+        >>> next(iter(dataset))["tokens"].shape
+        (3,)
+    """
 
     def on_epoch_start(self) -> None:
-        """
-        Optional hook to perform actions at the start of an epoch.
-        The default implementation does nothing.
-        Subclasses (e.g. for shuffling) can override this method.
-        """
+        pass
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[dict[str, Any]]:
         pass
 
     def __len__(self) -> int:
-        """
-        Returns the number of batches per epoch if defined,
-        otherwise raises an error.
-        """
-        raise NotImplementedError(
-            "This DataLoader does not support __len__ by default."
-        )
-
-    @abstractmethod
-    def __iter__(self) -> Iterator[Any]:
-        """
-        Should yield one batch at a time.
-        The batch format can vary depending on the type of data.
-        Please implement this method in the subclasses.
-        """
-        pass
+        raise NotImplementedError
 
 
-class SimpleDataLoader(AbstractDataLoader):
+class PairedIterableDataset(IterableDataset):
     """
-    A basic DataLoader for supervised tasks (e.g., classification or regression).
-    It handles:
-      - In-memory storage of X and y.
-      - Optional shuffling at the start of each epoch.
-      - Batching data into (batch_X, batch_y) pairs.
+    Iterates over in-memory paired `(X, y)` data one example at a time.
 
     Examples:
-        >>> from autograd.backend import xp
-        >>> from your_module import SimpleDataLoader  # Replace 'your_module' with your actual module name.
-        >>> # Create dummy data: 100 samples, each with 10 features.
-        >>> X = xp.random.uniform(0.0, 1.0, (100, 10))
-        >>> y = xp.random.randint(0, 2, (100, 1))
-        >>> # Instantiate the data loader with a batch size of 32.
-        >>> loader = SimpleDataLoader(X, y, batch_size=32, shuffle=True)
-        >>> # Iterate over batches.
-        >>> for batch_X, batch_y in loader:
-        ...     print(batch_X.shape, batch_y.shape)
-        (32, 10) (32, 1)
+        >>> X = xp.arange(6).reshape(3, 2)
+        >>> y = xp.array([0, 1, 2])
+        >>> dataset = PairedIterableDataset(X, y, shuffle=False)
+        >>> example = next(iter(dataset))
+        >>> example["inputs"].shape, int(example["targets"])
+        ((2,), 0)
     """
 
     def __init__(
-        self,
-        X: Array,
-        y: Array,
-        batch_size: int = 32,
-        shuffle: bool = True,
+        self, X: Sequence[Any], y: Sequence[Any], shuffle: bool = True
     ) -> None:
-        super().__init__(batch_size=batch_size, shuffle=shuffle)
+        if len(X) != len(y):
+            raise ValueError("X and y must contain the same number of examples")
         self.X = X
         self.y = y
+        self.shuffle = shuffle
         self.num_samples = len(X)
         self.indices = xp.arange(self.num_samples)
 
     def on_epoch_start(self) -> None:
-        # Shuffle the index array if needed.
         if self.shuffle:
             self.indices = xp.random.permutation(self.num_samples)
 
-    def __iter__(self) -> Iterator[Tuple[Array, Array]]:
-        for start in range(0, self.num_samples, self.batch_size):
-            batch_indices = self.indices[start : start + self.batch_size]
-            yield self.X[batch_indices], self.y[batch_indices]
+    def __iter__(self) -> Iterator[dict[str, Array]]:
+        for sample_idx in self.indices:
+            idx = int(sample_idx)
+            yield {"inputs": self.X[idx], "targets": self.y[idx]}
 
     def __len__(self) -> int:
-        # Compute the number of batches per epoch.
-        return (self.num_samples + self.batch_size - 1) // self.batch_size
-
-    def preprocess(self, preprocess_func) -> None:
-        """
-        Optionally preprocess the data using the provided function.
-
-        Args:
-            preprocess_func: A function that takes (X, y) and returns preprocessed (X, y).
-
-        Examples:
-            >>> def dummy_preprocess(X, y):
-            ...     return X * 2, y  # Example: double the features.
-            >>> loader.preprocess(dummy_preprocess)
-        """
-        self.X, self.y = preprocess_func(self.X, self.y)
+        return self.num_samples
 
 
-class LLMDataLoader(AbstractDataLoader):
+class TransformDataset(IterableDataset):
     """
-    A specialized DataLoader for language modeling or next-token tasks,
-    where it samples random chunks of contiguous sequences of data.
-    It handles:
-      - A single tokenized array (e.g. integer IDs of text).
-      - Random chunk sampling: each batch picks 'batch_size' random slices
-        of length (seq_len+1).
-      - Optional creation of a decoder_input by prepending a special <SOS> token.
-      - Optional creation of a causal mask or other masks.
-      - If a finite 'steps_per_epoch' is provided, each epoch produces that number of batches.
-        Otherwise, batches can be yielded infinitely.
+    Wraps another dataset and applies per-example transforms during iteration.
 
     Examples:
-        >>> from autograd.backend import xp
-        >>> from your_module import LLMDataLoader  # Replace 'your_module' with your actual module name.
-        >>> # Define a dummy Byte Pair Encoder (BPE) with minimal encode/decode functionality.
-        >>> class DummyBPE:
-        ...     def encode(self, text, allowed_special=None):
-        ...         # Simple encoding: return ASCII codes of characters.
-        ...         return [ord(c) for c in text]
-        ...     def decode(self, tokens):
-        ...         return ''.join(chr(t) for t in tokens)
-        >>> bpe = DummyBPE()
-        >>>
-        >>> # Create dummy token data: an array of token IDs (integers).
-        >>> token_data = xp.random.randint(0, 100, (1000,))  # 1000 tokens.
-        >>>
-        >>> # Instantiate the LLMDataLoader.
-        >>> loader = LLMDataLoader(
-        ...     data=token_data,
-        ...     bpe=bpe,
-        ...     batch_size=4,
-        ...     seq_len=10,
-        ...     steps_per_epoch=5,  # Produce 5 batches per epoch.
-        ...     include_decoder_input=True,
-        ...     create_padding_masks=True,
-        ...     sos_token="<SOS>",
-        ...     pad_token="<PAD>"
+        >>> dataset = PairedIterableDataset(
+        ...     xp.arange(6).reshape(3, 2),
+        ...     xp.array([0, 1, 2]),
+        ...     shuffle=False,
         ... )
-        >>>
-        >>> # Iterate over one epoch of batches.
-        >>> for batch in loader:
-        ...     X_chunk, dec_inp, Y_chunk, smask, tmask, causal_mask = batch
-        ...     print(X_chunk.shape, Y_chunk.shape)
-        (4, 10) (4, 10)
+        >>> wrapped = TransformDataset(
+        ...     dataset,
+        ...     target_transform=lambda y: xp.array(int(y == 1), dtype=xp.int32),
+        ... )
+        >>> int(next(iter(wrapped))["targets"])
+        0
     """
 
     def __init__(
         self,
-        data: Array,  # array of token IDs
-        bpe,
-        batch_size: int,
-        seq_len: int,
-        shuffle: bool = True,
-        steps_per_epoch: Optional[int] = 1000,
-        include_decoder_input: bool = True,
-        create_padding_masks: bool = True,
-        sos_token: Union[str, bytes] = "<SOS>",
-        pad_token: Union[str, bytes] = "<PAD>",
+        dataset: IterableDataset,
+        transform: Optional[Callable[[Array], Array]] = None,
+        target_transform: Optional[Callable[[Array], Array]] = None,
     ) -> None:
-        """
-        Args:
-            data (Array): Tokenized integer IDs of the entire dataset.
-            bpe: BytePairEncoder or other tokenizer with .encode() / .decode().
-            batch_size (int): Number of sequences per batch.
-            seq_len (int): Length of each sequence (X) fed to the model.
-                           (seq_len+1 tokens are sliced so that position i can predict i+1).
-            shuffle (bool): Whether to randomize each epoch's sampling.
-            steps_per_epoch (Optional[int]): If given, produces exactly this many batches per epoch.
-                                             Otherwise, batches can be yielded infinitely.
-            include_decoder_input (bool): If True, creates a separate decoder input array.
-            create_padding_masks (bool): If True, creates padding masks for variable-length sequences.
-            sos_token (Union[str, bytes]): The start-of-sequence token for the decoder input.
-            pad_token (Union[str, bytes]): The token for padding.
-        """
-        super().__init__(batch_size=batch_size, shuffle=shuffle)
-
-        self.data = xp.array(data)
-        self.bpe = bpe
-        self.seq_len = seq_len
-        self.steps_per_epoch = steps_per_epoch
-        self.include_decoder_input = include_decoder_input
-        self.create_padding_masks = create_padding_masks
-
-        # For ignoring or masking out pad tokens:
-        self.pad_idx = bpe.encode(pad_token, allowed_special={pad_token})[0]
-        if self.include_decoder_input:
-            self.sos_idx = bpe.encode(sos_token, allowed_special={sos_token})[0]
-        else:
-            self.sos_idx = None
-
-        self.data_size = len(self.data)
+        self.dataset = dataset
+        self.transform = transform
+        self.target_transform = target_transform
 
     def on_epoch_start(self) -> None:
-        """
-        Called at the start of each epoch.
-        For random chunking, reseeds the RNG to ensure different random offsets each epoch if shuffle is True.
-        """
-        if self.shuffle:
-            xp.random.seed(int.from_bytes(os.urandom(4), "big"))
+        self.dataset.on_epoch_start()
 
-    def __iter__(
+    def __iter__(self) -> Iterator[dict[str, Array]]:
+        for example in self.dataset:
+            transformed_example = dict(example)
+            if self.transform is not None:
+                transformed_example["inputs"] = self.transform(
+                    xp.array(example["inputs"])
+                )
+            if self.target_transform is not None:
+                transformed_example["targets"] = self.target_transform(
+                    xp.array(example["targets"])
+                )
+            yield transformed_example
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+
+class TokenSequenceDataset(IterableDataset):
+    """
+    Iterates over LM token sequences with per-token loss masks.
+
+    This class supports two modes:
+    - finite examples stored in memory
+    - infinite random windows sampled from one flat token stream
+
+    Examples:
+        >>> dataset = TokenSequenceDataset(
+        ...     token_sequences=[xp.array([10, 11, 20], dtype=xp.int32)],
+        ...     loss_masks=[xp.array([0, 0, 1], dtype=xp.int32)],
+        ...     shuffle=False,
+        ... )
+        >>> example = next(iter(dataset))
+        >>> example["tokens"].tolist(), example["loss_mask"].tolist()
+        ([10, 11, 20], [0, 0, 1])
+        >>> random_window_dataset = TokenSequenceDataset(
+        ...     data=xp.arange(32, dtype=xp.int32),
+        ...     seq_len=4,
+        ...     shuffle=False,
+        ...     random_window=True,
+        ... )
+        >>> next(iter(random_window_dataset))["tokens"].shape
+        (5,)
+    """
+
+    def __init__(
         self,
-    ) -> Iterator[
-        Tuple[
-            Array,  # X_chunk: (batch_size, seq_len)
-            Optional[Array],  # dec_inp: (batch_size, seq_len) or None
-            Array,  # Y_chunk: (batch_size, seq_len)
-            Optional[Array],  # source mask (e.g., padding mask)
-            Optional[Array],  # target mask (e.g., causal + padding)
-            Optional[Array],  # causal mask
-        ]
-    ]:
-        step = 0
-        # Allow infinite iteration if steps_per_epoch is None.
-        while self.steps_per_epoch is None or step < self.steps_per_epoch:
-            step += 1
+        token_sequences: Optional[Sequence[Array]] = None,
+        loss_masks: Optional[Sequence[Array]] = None,
+        *,
+        data: Optional[Array] = None,
+        seq_len: Optional[int] = None,
+        shuffle: bool = True,
+        random_window: bool = False,
+    ) -> None:
+        self.shuffle = shuffle
+        self.random_window = random_window
 
+        if self.random_window:
+            if data is None or seq_len is None:
+                raise ValueError("random_window datasets require both data and seq_len")
+            if token_sequences is not None or loss_masks is not None:
+                raise ValueError(
+                    "random_window datasets do not accept token_sequences or loss_masks"
+                )
+            self.data = xp.array(data, dtype=xp.int32)
+            self.seq_len = seq_len
+            self.data_size = len(self.data)
+            return
+
+        if token_sequences is None:
+            raise ValueError("token_sequences are required when random_window=False")
+        if loss_masks is None:
+            loss_masks = [
+                xp.ones((len(tokens),), dtype=xp.int32) for tokens in token_sequences
+            ]
+        if len(token_sequences) != len(loss_masks):
+            raise ValueError(
+                "token_sequences and loss_masks must contain the same number of examples"
+            )
+        self.examples = []
+        for tokens, loss_mask in zip(token_sequences, loss_masks):
+            tokens_array = xp.array(tokens, dtype=xp.int32)
+            loss_mask_array = xp.array(loss_mask, dtype=xp.int32)
+            if len(tokens_array) != len(loss_mask_array):
+                raise ValueError(
+                    "token sequence and loss mask must have the same length"
+                )
+            self.examples.append({"tokens": tokens_array, "loss_mask": loss_mask_array})
+        self.num_examples = len(self.examples)
+        self.indices = xp.arange(self.num_examples)
+
+    def on_epoch_start(self) -> None:
+        if self.random_window:
+            if self.shuffle:
+                xp.random.seed(int.from_bytes(os.urandom(4), "big"))
+            return
+        if self.shuffle:
+            self.indices = xp.random.permutation(self.num_examples)
+
+    def __iter__(self) -> Iterator[dict[str, Array]]:
+        if self.random_window:
             max_offset = self.data_size - (self.seq_len + 1)
             if max_offset < 1:
                 raise ValueError(
                     f"Dataset too small ({self.data_size} tokens) for seq_len={self.seq_len + 1}"
                 )
+            while True:
+                offset = int(xp.random.randint(0, max_offset, (), dtype=xp.int32))
+                tokens = self.data[offset : offset + self.seq_len + 1]
+                yield {
+                    "tokens": tokens,
+                    "loss_mask": xp.ones(tokens.shape, dtype=xp.int32),
+                }
+            return
 
-            # Randomly choose starting offsets for each sequence in the batch.
-            offsets = xp.random.randint(
-                0, max_offset, (self.batch_size,), dtype=xp.int32
-            )
-            # Extract chunks of (seq_len+1) tokens.
-            batch_chunks = [
-                self.data[int(offset) : int(offset) + self.seq_len + 1]
-                for offset in offsets
-            ]
-            # Stack to shape: (batch_size, seq_len+1)
-            batch = xp.stack(batch_chunks, axis=0)
-
-            # Prepare input (X) and target (Y) by shifting the sequence.
-            X_chunk = batch[:, :-1]  # (batch_size, seq_len)
-            Y_chunk = batch[:, 1:]  # (batch_size, seq_len)
-
-            # Optionally create a decoder input by prepending the SOS token.
-            if self.include_decoder_input:
-                assert self.sos_idx is not None
-                sos_column = xp.full(
-                    (self.batch_size, 1), self.sos_idx, dtype=Y_chunk.dtype
-                )
-                dec_inp = xp.concatenate([sos_column, Y_chunk[:, :-1]], axis=1)
-            else:
-                dec_inp = None
-
-            # Create a causal mask (e.g., for next-token prediction).
-            causal_mask = text_utils.create_causal_mask(
-                seq_len=self.seq_len, batch_size=self.batch_size
-            )
-
-            smask, tmask = None, None
-            if self.create_padding_masks:
-                smask = text_utils.create_padding_mask(X_chunk, self.pad_idx)
-                pmask = text_utils.create_padding_mask(Y_chunk, self.pad_idx)
-                tmask = pmask + causal_mask if causal_mask is not None else pmask
-
-            yield (
-                X_chunk,  # (batch_size, seq_len)
-                dec_inp,  # (batch_size, seq_len) or None
-                Y_chunk,  # (batch_size, seq_len)
-                smask,  # source mask or None
-                tmask,  # target mask or None
-                causal_mask,  # causal mask or None
-            )
+        for sample_idx in self.indices:
+            example = self.examples[int(sample_idx)]
+            yield {
+                "tokens": example["tokens"],
+                "loss_mask": example["loss_mask"],
+            }
 
     def __len__(self) -> int:
-        if self.steps_per_epoch is None:
-            raise NotImplementedError("Infinite DataLoader does not support __len__.")
-        return self.steps_per_epoch
+        if self.random_window:
+            raise NotImplementedError
+        return self.num_examples
+
+
+def openai_chat_to_prompt_completion(chat_example: dict[str, Any]) -> dict[str, str]:
+    """
+    Converts one OpenAI chat-format SFT record into prompt/completion text.
+
+    Examples:
+        >>> example = openai_chat_to_prompt_completion(
+        ...     {
+        ...         "messages": [
+        ...             {"role": "user", "content": "ABC"},
+        ...             {"role": "assistant", "content": "DE"},
+        ...         ]
+        ...     },
+        ... )
+        >>> example["prompt_text"], example["completion_text"]
+        ('ABC', 'DE')
+    """
+    messages = chat_example.get("messages")
+    if not messages:
+        raise ValueError("chat example must contain at least one message")
+    if messages[-1].get("role") != "assistant":
+        raise ValueError("chat example must end with an assistant message")
+
+    prompt_parts = []
+    for message in messages[:-1]:
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise ValueError("message content must be a string")
+        prompt_parts.append(content)
+
+    response_content = messages[-1].get("content")
+    if not isinstance(response_content, str):
+        raise ValueError("message content must be a string")
+
+    return {
+        "prompt_text": "".join(prompt_parts),
+        "completion_text": response_content,
+    }
+
+
+def tokenize_prompt_completion(
+    prompt_completion_example: dict[str, str], bpe
+) -> dict[str, Array]:
+    """
+    Tokenizes one prompt/completion example into LM tokens and a loss mask.
+
+    Examples:
+        >>> class DummyBPE:
+        ...     def encode(self, text, allowed_special=None):
+        ...         return [ord(char) for char in text]
+        >>> example = tokenize_prompt_completion(
+        ...     {"prompt_text": "ABC", "completion_text": "DE"},
+        ...     DummyBPE(),
+        ... )
+        >>> example["tokens"].tolist(), example["loss_mask"].tolist()
+        ([65, 66, 67, 68, 69], [0, 0, 0, 1, 1])
+    """
+    prompt_tokens = xp.array(
+        bpe.encode(prompt_completion_example["prompt_text"]),
+        dtype=xp.int32,
+    )
+    completion_tokens = xp.array(
+        bpe.encode(prompt_completion_example["completion_text"]),
+        dtype=xp.int32,
+    )
+    if len(completion_tokens) == 0:
+        raise ValueError("assistant completion must contain at least one token")
+    return {
+        "tokens": xp.concatenate([prompt_tokens, completion_tokens], axis=0),
+        "loss_mask": xp.concatenate(
+            [
+                xp.zeros(prompt_tokens.shape, dtype=xp.int32),
+                xp.ones(completion_tokens.shape, dtype=xp.int32),
+            ],
+            axis=0,
+        ),
+    }
+
+
+def pack_tokens(tokens: Array, max_tokens: int, pad_idx: int) -> Array:
+    """
+    Left-truncates and right-pads one token sequence to `max_tokens`.
+
+    Examples:
+        >>> packed = pack_tokens(
+        ...     tokens=xp.array([10, 11, 12, 20, 21]),
+        ...     max_tokens=6,
+        ...     pad_idx=0,
+        ... )
+        >>> packed.shape
+        (6,)
+    """
+    if len(tokens) > max_tokens:
+        tokens = tokens[-max_tokens:]
+    if len(tokens) < max_tokens:
+        pad_width = max_tokens - len(tokens)
+        tokens = xp.concatenate(
+            [tokens, xp.full((pad_width,), pad_idx, dtype=xp.int32)],
+            axis=0,
+        )
+    return tokens
+
+
+class Collator(ABC):
+    """
+    Abstract interface for collators that turn example lists into batches.
+    """
+
+    @abstractmethod
+    def __call__(self, examples: Sequence[dict[str, Array]]) -> Any:
+        pass
+
+
+class PairedCollator(Collator):
+    """
+    Batches paired examples from `PairedIterableDataset`.
+
+    Examples:
+        >>> collator = PairedCollator()
+        >>> batch_X, batch_y = collator(
+        ...     [
+        ...         {"inputs": xp.array([1, 2]), "targets": xp.array(0)},
+        ...         {"inputs": xp.array([3, 4]), "targets": xp.array(1)},
+        ...     ]
+        ... )
+        >>> batch_X.shape, batch_y.shape
+        ((2, 2), (2,))
+    """
+
+    def __call__(self, examples: Sequence[dict[str, Array]]) -> Tuple[Array, Array]:
+        batch_X = xp.stack(
+            [xp.array(example["inputs"]) for example in examples], axis=0
+        )
+        batch_y = xp.stack(
+            [xp.array(example["targets"]) for example in examples],
+            axis=0,
+        )
+        return batch_X, batch_y
+
+
+class OneHotCollator(Collator):
+    """
+    Batches token-id examples and materializes one-hot inputs.
+
+    This keeps token IDs in memory and expands them to one-hot features at
+    batch time.
+
+    Examples:
+        >>> collator = OneHotCollator(num_classes=4)
+        >>> batch_X, batch_y = collator(
+        ...     [
+        ...         {"inputs": xp.array([0, 2]), "targets": xp.array(1)},
+        ...         {"inputs": xp.array([1, 3]), "targets": xp.array(0)},
+        ...     ]
+        ... )
+        >>> batch_X.shape, batch_y.shape
+        ((2, 2, 4), (2,))
+    """
+
+    def __init__(self, num_classes: int, dtype: Array = xp.float32) -> None:
+        self.num_classes = num_classes
+        self.dtype = dtype
+
+    def __call__(self, examples: Sequence[dict[str, Array]]) -> Tuple[Array, Array]:
+        # TODO: replace batch-time one-hot with direct token-id model inputs.
+        eye = xp.eye(self.num_classes, dtype=self.dtype)
+        batch_tokens = xp.stack(
+            [xp.array(example["inputs"], dtype=xp.int32) for example in examples],
+            axis=0,
+        )
+        batch_y = xp.stack(
+            [xp.array(example["targets"]) for example in examples],
+            axis=0,
+        )
+        return eye[batch_tokens], batch_y
+
+
+class LanguageModelingCollator(Collator):
+    """
+    Builds the full LM trainer batch tuple from token sequences and loss masks.
+
+    Examples:
+        >>> collator = LanguageModelingCollator(
+        ...     max_tokens=4,
+        ...     pad_idx=0,
+        ...     sos_idx=1,
+        ...     include_decoder_input=True,
+        ...     create_padding_masks=False,
+        ... )
+        >>> batch = collator(
+        ...     [
+        ...         {
+        ...             "tokens": xp.array([1, 2, 3, 4], dtype=xp.int32),
+        ...             "loss_mask": xp.array([1, 1, 1, 1], dtype=xp.int32),
+        ...         }
+        ...     ],
+        ... )
+        >>> len(batch), batch[0].shape, batch[2].shape
+        (6, (1, 3), (1, 3))
+    """
+
+    def __init__(
+        self,
+        max_tokens: int,
+        pad_idx: int,
+        sos_idx: Optional[int] = None,
+        include_decoder_input: bool = True,
+        create_padding_masks: bool = True,
+        packer: Optional[Callable[[Array, int, int], Array]] = None,
+    ) -> None:
+        self.max_tokens = max_tokens
+        self.pad_idx = pad_idx
+        self.sos_idx = sos_idx
+        self.include_decoder_input = include_decoder_input
+        self.create_padding_masks = create_padding_masks
+        self.packer = packer or pack_tokens
+
+    def __call__(
+        self, examples: Sequence[dict[str, Array]]
+    ) -> Tuple[
+        Array, Optional[Array], Array, Optional[Array], Optional[Array], Optional[Array]
+    ]:
+        batch_inputs = []
+        batch_targets = []
+
+        for example in examples:
+            tokens = xp.array(example["tokens"], dtype=xp.int32)
+            loss_mask = xp.array(
+                example.get(
+                    "loss_mask",
+                    xp.ones(tokens.shape, dtype=xp.int32),
+                ),
+                dtype=xp.int32,
+            )
+            if len(tokens) != len(loss_mask):
+                raise ValueError("tokens and loss_mask must have the same length")
+
+            packed_tokens = self.packer(tokens, self.max_tokens, self.pad_idx)
+            packed_loss_mask = self.packer(loss_mask, self.max_tokens, 0)
+            input_tokens = packed_tokens[:-1]
+            target_tokens = xp.array(packed_tokens[1:])
+            target_loss_mask = packed_loss_mask[1:]
+            target_tokens[target_loss_mask == 0] = self.pad_idx
+
+            batch_inputs.append(input_tokens)
+            batch_targets.append(target_tokens)
+
+        X_chunk = xp.stack(batch_inputs, axis=0)
+        Y_chunk = xp.stack(batch_targets, axis=0)
+        batch_size = X_chunk.shape[0]
+        seq_len = X_chunk.shape[1]
+
+        if self.include_decoder_input:
+            assert self.sos_idx is not None
+            sos_column = xp.full((batch_size, 1), self.sos_idx, dtype=Y_chunk.dtype)
+            dec_inp = xp.concatenate([sos_column, Y_chunk[:, :-1]], axis=1)
+        else:
+            dec_inp = None
+
+        causal_mask = text_utils.create_causal_mask(
+            seq_len=seq_len, batch_size=batch_size
+        )
+
+        smask, tmask = None, None
+        if self.create_padding_masks:
+            smask = text_utils.create_padding_mask(X_chunk, self.pad_idx)
+            pmask = text_utils.create_padding_mask(Y_chunk, self.pad_idx)
+            tmask = pmask + causal_mask if causal_mask is not None else pmask
+
+        return (
+            X_chunk,
+            dec_inp,
+            Y_chunk,
+            smask,
+            tmask,
+            causal_mask,
+        )
+
+
+class DataLoader:
+    """
+    Thin generic data loader that batches examples from a dataset and applies a collator.
+
+    Examples:
+        >>> X = xp.arange(6).reshape(3, 2)
+        >>> y = xp.array([0, 1, 2])
+        >>> dataset = PairedIterableDataset(X, y, shuffle=False)
+        >>> loader = DataLoader(dataset, batch_size=2, collate_fn=PairedCollator())
+        >>> batch_X, batch_y = next(iter(loader))
+        >>> batch_X.shape, batch_y.shape
+        ((2, 2), (2,))
+    """
+
+    def __init__(
+        self,
+        dataset: IterableDataset,
+        batch_size: int,
+        collate_fn: Optional[Collator] = None,
+    ) -> None:
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.collate_fn = collate_fn
+        self.pad_idx = getattr(collate_fn, "pad_idx", None)
+
+    def on_epoch_start(self) -> None:
+        self.dataset.on_epoch_start()
+
+    def __iter__(self) -> Iterator[Any]:
+        batch_examples = []
+        for example in self.dataset:
+            batch_examples.append(example)
+            if len(batch_examples) < self.batch_size:
+                continue
+
+            yield self.collate_fn(batch_examples) if self.collate_fn else batch_examples
+            batch_examples = []
+
+        if batch_examples:
+            yield self.collate_fn(batch_examples) if self.collate_fn else batch_examples
+
+    def __len__(self) -> int:
+        return (len(self.dataset) + self.batch_size - 1) // self.batch_size

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -127,6 +127,8 @@ class AbstractTrainer(ABC):
         batch_count = 0
         self.optimizer.zero_grad()
         for batch in tqdm(data_loader, desc="Training Batches", leave=False):
+            if batch_count >= self.config.steps_per_epoch:
+                break
             loss = self.train_step(batch, data_loader)
             total_loss += loss
             # Simulate larger batches by updating weights every N steps
@@ -433,6 +435,8 @@ class SimpleTrainer(AbstractTrainer):
         batch_count = 0
         all_preds, all_targets = [], []
         for batch_data in val_data_loader:
+            if batch_count >= self.config.eval_iters:
+                break
             batch_X, batch_y = batch_data
             y_pred = self.model(batch_X)
             loss = self.loss_fn(y_pred, batch_y)
@@ -650,6 +654,8 @@ class LLMTrainer(AbstractTrainer):
             total_loss = 0.0
             batch_count = 0
             for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
+                if batch_count >= self.config.eval_iters:
+                    break
                 pred_probs, y = self.forward_fn(self.model, batch_data, mode="train")
                 # TODO: Decide whether validation should use the same label_smoothing setting
                 # as training, or intentionally report unsmoothed cross-entropy.

--- a/examples/cifar.py
+++ b/examples/cifar.py
@@ -4,7 +4,12 @@ from openml.datasets import get_dataset  # pyright: ignore[reportMissingImports]
 
 from autograd import functional, nn, optim
 from autograd.tools.config_schema import GenericTrainingConfig
-from autograd.tools.data import SimpleDataLoader, train_test_split
+from autograd.tools.data import (
+    DataLoader,
+    PairedCollator,
+    PairedIterableDataset,
+    train_test_split,
+)
 from autograd.tools.trainer import SimpleTrainer
 
 logger = logging.getLogger(__name__)
@@ -194,8 +199,8 @@ def train_cifar_multiclass_model(
     and testing data loaders.
 
     Args:
-        train_data_loader (SimpleDataLoader): Data loader for training data.
-        test_data_loader (SimpleDataLoader): Data loader for testing data.
+        train_data_loader (DataLoader): Data loader for training data.
+        test_data_loader (DataLoader): Data loader for testing data.
         optimizer_cls: Optimizer class to use (e.g., optim.Adam, optim.SGD).
         model_cls: Neural network model class to instantiate.
         loss_fn: Loss function to optimize.
@@ -223,7 +228,7 @@ if __name__ == "__main__":
       1) Fetch the CIFAR-10 dataset using OpenML, normalize the pixel values to [0, 1],
          and subsample 5000 examples for faster training.
       2) Split the data into training and testing sets using train_test_split.
-      3) Create SimpleDataLoader objects for both training and testing sets.
+      3) Create DataLoader objects for both training and testing sets.
       4) Train three types of models on CIFAR-10:
            - A ResNet-based model using residual blocks.
            - A convolutional classifier.
@@ -257,8 +262,16 @@ if __name__ == "__main__":
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
 
-    train_data_loader = SimpleDataLoader(X_train, y_train, batch_size=256, shuffle=True)
-    test_data_loader = SimpleDataLoader(X_test, y_test, batch_size=256, shuffle=False)
+    train_data_loader = DataLoader(
+        PairedIterableDataset(X_train, y_train, shuffle=True),
+        batch_size=256,
+        collate_fn=PairedCollator(),
+    )
+    test_data_loader = DataLoader(
+        PairedIterableDataset(X_test, y_test, shuffle=False),
+        batch_size=256,
+        collate_fn=PairedCollator(),
+    )
 
     # Train ResNet CIFAR-10 model
     logger.info("Training ResNet CIFAR-10 model")
@@ -328,8 +341,16 @@ if __name__ == "__main__":
     logger.info(f"{X.shape=}, {y.shape=}")
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
-    train_data_loader = SimpleDataLoader(X_train, y_train, batch_size=256, shuffle=True)
-    test_data_loader = SimpleDataLoader(X_test, y_test, batch_size=256, shuffle=False)
+    train_data_loader = DataLoader(
+        PairedIterableDataset(X_train, y_train, shuffle=True),
+        batch_size=256,
+        collate_fn=PairedCollator(),
+    )
+    test_data_loader = DataLoader(
+        PairedIterableDataset(X_test, y_test, shuffle=False),
+        batch_size=256,
+        collate_fn=PairedCollator(),
+    )
 
     # Train ResNet CIFAR-100 model
     logger.info("Training ResNet CIFAR-100 model")

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -12,7 +12,11 @@ from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.tools.callback import sampling_callback, teacher_forcing_callback
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
-from autograd.tools.data import LLMDataLoader
+from autograd.tools.data import (
+    DataLoader,
+    LanguageModelingCollator,
+    TokenSequenceDataset,
+)
 from autograd.tools.trainer import LLMTrainer
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -215,25 +219,40 @@ if __name__ == "__main__":
         eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
-    train_data_loader = LLMDataLoader(
-        data=xp.array(train_data, dtype=xp.int32),
-        bpe=bpe,
+    pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
+    sos_idx = bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+
+    train_data_loader = DataLoader(
+        dataset=TokenSequenceDataset(
+            data=xp.array(train_data, dtype=xp.int32),
+            seq_len=trainer.model.max_seq_len,
+            shuffle=True,
+            random_window=True,
+        ),
         batch_size=CONFIG.batch_size,
-        seq_len=trainer.model.max_seq_len,
-        steps_per_epoch=CONFIG.steps_per_epoch,
-        shuffle=True,
-        include_decoder_input=CONFIG.include_decoder_input,
-        create_padding_masks=CONFIG.create_padding_masks,
+        collate_fn=LanguageModelingCollator(
+            max_tokens=trainer.model.max_seq_len + 1,
+            pad_idx=pad_idx,
+            sos_idx=sos_idx,
+            include_decoder_input=CONFIG.include_decoder_input,
+            create_padding_masks=CONFIG.create_padding_masks,
+        ),
     )
-    test_data_loader = LLMDataLoader(
-        data=xp.array(test_data, dtype=xp.int32),
-        bpe=bpe,
+    test_data_loader = DataLoader(
+        dataset=TokenSequenceDataset(
+            data=xp.array(test_data, dtype=xp.int32),
+            seq_len=trainer.model.max_seq_len,
+            shuffle=False,
+            random_window=True,
+        ),
         batch_size=CONFIG.batch_size // 2,
-        seq_len=trainer.model.max_seq_len,
-        steps_per_epoch=CONFIG.eval_iters,
-        shuffle=False,
-        include_decoder_input=CONFIG.include_decoder_input,
-        create_padding_masks=CONFIG.create_padding_masks,
+        collate_fn=LanguageModelingCollator(
+            max_tokens=trainer.model.max_seq_len + 1,
+            pad_idx=pad_idx,
+            sos_idx=sos_idx,
+            include_decoder_input=CONFIG.include_decoder_input,
+            create_padding_masks=CONFIG.create_padding_masks,
+        ),
     )
 
     trainer.fit(train_data_loader, test_data_loader)

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -10,7 +10,10 @@ from autograd.backend import xp
 from autograd.tensor import Tensor
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
-from autograd.tools.callback import sampling_callback, teacher_forcing_callback
+from autograd.tools.callback import (
+    run_sampling_inference,
+    run_teacher_forcing_inference,
+)
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
 from autograd.tools.data import (
     DataLoader,
@@ -216,7 +219,6 @@ if __name__ == "__main__":
         loss_fn=functional.cross_entropy,
         config=CONFIG,
         forward_fn=GPT1ForwardFn(),
-        eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
     pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
@@ -257,13 +259,22 @@ if __name__ == "__main__":
 
     trainer.fit(train_data_loader, test_data_loader)
 
-    text_utils.inference(
+    if CONFIG.teacher_enforcing:
+        run_teacher_forcing_inference(
+            model=trainer.model,
+            forward_fn=GPT1ForwardFn(),
+            bpe=bpe,
+            groundtruth_data=xp.array(
+                test_data[: trainer.model.max_seq_len // 3], dtype=xp.int32
+            ),
+            max_length=trainer.model.max_seq_len // 3,
+        )
+
+    run_sampling_inference(
         model=trainer.model,
-        prediction_func=GPT1ForwardFn(),
+        forward_fn=GPT1ForwardFn(),
         bpe=bpe,
-        start_tokens="All",  # Dummy token to start the generation
-        max_length=int(
-            trainer.model.max_seq_len * 0.9
-        ),  # this should be shorter than context
-        temperature=1.0,
+        start_tokens="All",
+        max_length=int(trainer.model.max_seq_len * 0.9),
+        top_k=CONFIG.eval_top_k,
     )

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -10,7 +10,10 @@ from autograd.backend import xp
 from autograd.tensor import Tensor
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
-from autograd.tools.callback import sampling_callback, teacher_forcing_callback
+from autograd.tools.callback import (
+    run_sampling_inference,
+    run_teacher_forcing_inference,
+)
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
 from autograd.tools.data import (
     DataLoader,
@@ -324,7 +327,6 @@ if __name__ == "__main__":
         loss_fn=functional.cross_entropy,
         config=CONFIG,
         forward_fn=GPT2ForwardFn(),
-        eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
     pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
@@ -365,15 +367,25 @@ if __name__ == "__main__":
 
     trainer.fit(train_data_loader, test_data_loader)
 
+    if CONFIG.teacher_enforcing:
+        run_teacher_forcing_inference(
+            model=trainer.model,
+            forward_fn=GPT2ForwardFn(),
+            bpe=bpe,
+            groundtruth_data=xp.array(
+                test_data[: trainer.model.max_seq_len // 3], dtype=xp.int32
+            ),
+            max_length=trainer.model.max_seq_len // 3,
+        )
+
     # Inference test
     for k in range(5):
-        text_utils.inference(
+        run_sampling_inference(
             model=trainer.model,
-            prediction_func=GPT2ForwardFn(),
+            forward_fn=GPT2ForwardFn(),
             bpe=bpe,
-            start_tokens="\n",  # Example start token
+            start_tokens="\n",
             max_length=int(trainer.model.max_seq_len),
-            temperature=1.0,
             top_k=200,
         )
         print("\n------------------------\n")

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -12,7 +12,11 @@ from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.tools.callback import sampling_callback, teacher_forcing_callback
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
-from autograd.tools.data import LLMDataLoader
+from autograd.tools.data import (
+    DataLoader,
+    LanguageModelingCollator,
+    TokenSequenceDataset,
+)
 from autograd.tools.trainer import LLMTrainer
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -323,25 +327,40 @@ if __name__ == "__main__":
         eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
-    train_data_loader = LLMDataLoader(
-        data=xp.array(train_data, dtype=xp.int32),
-        bpe=bpe,
+    pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
+    sos_idx = bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+
+    train_data_loader = DataLoader(
+        dataset=TokenSequenceDataset(
+            data=xp.array(train_data, dtype=xp.int32),
+            seq_len=trainer.model.max_seq_len,
+            shuffle=True,
+            random_window=True,
+        ),
         batch_size=CONFIG.batch_size,
-        seq_len=trainer.model.max_seq_len,
-        steps_per_epoch=CONFIG.steps_per_epoch,
-        shuffle=True,
-        include_decoder_input=CONFIG.include_decoder_input,
-        create_padding_masks=CONFIG.create_padding_masks,
+        collate_fn=LanguageModelingCollator(
+            max_tokens=trainer.model.max_seq_len + 1,
+            pad_idx=pad_idx,
+            sos_idx=sos_idx,
+            include_decoder_input=CONFIG.include_decoder_input,
+            create_padding_masks=CONFIG.create_padding_masks,
+        ),
     )
-    test_data_loader = LLMDataLoader(
-        data=xp.array(test_data, dtype=xp.int32),
-        bpe=bpe,
+    test_data_loader = DataLoader(
+        dataset=TokenSequenceDataset(
+            data=xp.array(test_data, dtype=xp.int32),
+            seq_len=trainer.model.max_seq_len,
+            shuffle=False,
+            random_window=True,
+        ),
         batch_size=CONFIG.batch_size // 2,
-        seq_len=trainer.model.max_seq_len,
-        steps_per_epoch=CONFIG.eval_iters,
-        shuffle=False,
-        include_decoder_input=CONFIG.include_decoder_input,
-        create_padding_masks=CONFIG.create_padding_masks,
+        collate_fn=LanguageModelingCollator(
+            max_tokens=trainer.model.max_seq_len + 1,
+            pad_idx=pad_idx,
+            sos_idx=sos_idx,
+            include_decoder_input=CONFIG.include_decoder_input,
+            create_padding_masks=CONFIG.create_padding_masks,
+        ),
     )
 
     trainer.fit(train_data_loader, test_data_loader)

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -5,7 +5,13 @@ from openml.datasets import get_dataset  # pyright: ignore[reportMissingImports]
 from autograd import functional, nn, optim
 from autograd.backend import xp
 from autograd.tools.config_schema import GenericTrainingConfig
-from autograd.tools.data import SimpleDataLoader, train_test_split
+from autograd.tools.data import (
+    DataLoader,
+    PairedCollator,
+    PairedIterableDataset,
+    TransformDataset,
+    train_test_split,
+)
 from autograd.tools.metrics import accuracy, precision
 from autograd.tools.trainer import SimpleTrainer
 
@@ -249,20 +255,20 @@ def train_mnist_with_hinge_loss(
 
     one_vs_rest_models = []
 
-    def preprocess_for_digit(x, y, digit):
+    def target_transform_for_digit(digit):
         # Convert y into {+1, -1}
-        y_bin = 2 * (y == digit).astype(xp.int32) - 1
-        return x, y_bin
+        return lambda y: 2 * (xp.array(y) == digit).astype(xp.int32) - 1
 
     for digit in range(10):
         logger.info(f"Training digit={digit}")
-        train_loader = SimpleDataLoader(X_train, y_train, batch_size, shuffle=True)
-        test_loader = SimpleDataLoader(X_test, y_test, batch_size, shuffle=False)
-
-        # Use a lambda with a default parameter to capture the current digit.
-        train_loader.preprocess(lambda x, y, d=digit: preprocess_for_digit(x, y, d))
-        test_loader.preprocess(lambda x, y, d=digit: preprocess_for_digit(x, y, d))
-
+        train_loader = DataLoader(
+            TransformDataset(
+                PairedIterableDataset(X_train, y_train, shuffle=True),
+                target_transform=target_transform_for_digit(digit),
+            ),
+            batch_size=batch_size,
+            collate_fn=PairedCollator(),
+        )
         # Build a training configuration for the trainer.
         config = GenericTrainingConfig(
             total_epochs=epochs,
@@ -324,21 +330,20 @@ def train_mnist_one_vs_rest_model(
 
     one_vs_rest_models = []
 
-    def preprocess_for_digit(x, y, digit):
+    def target_transform_for_digit(digit):
         # Convert y into {0, 1}
-        y_bin = (y == digit).astype(xp.int32)
-        return x, y_bin
+        return lambda y: (xp.array(y) == digit).astype(xp.int32)
 
     for digit in range(10):
         logger.info(f"Training digit={digit}")
-        # Create fresh data loaders for each digit
-        train_loader = SimpleDataLoader(X_train, y_train, batch_size, shuffle=True)
-        test_loader = SimpleDataLoader(X_test, y_test, batch_size, shuffle=False)
-
-        # Freeze the current digit in the lambda via a default parameter.
-        train_loader.preprocess(lambda x, y, d=digit: preprocess_for_digit(x, y, d))
-        test_loader.preprocess(lambda x, y, d=digit: preprocess_for_digit(x, y, d))
-
+        train_loader = DataLoader(
+            TransformDataset(
+                PairedIterableDataset(X_train, y_train, shuffle=True),
+                target_transform=target_transform_for_digit(digit),
+            ),
+            batch_size=batch_size,
+            collate_fn=PairedCollator(),
+        )
         # Build the training configuration.
         config = GenericTrainingConfig(
             total_epochs=epochs,
@@ -388,8 +393,8 @@ def train_mnist_multiclass_model(
       - Optionally evaluates on test_data_loader if provided.
 
     Args:
-        train_data_loader (SimpleDataLoader): Data loader for training.
-        test_data_loader (SimpleDataLoader): Data loader for evaluation/testing.
+        train_data_loader (DataLoader): Data loader for training.
+        test_data_loader (DataLoader): Data loader for evaluation/testing.
         optimizer_cls: An optimizer class from autograd.optim, e.g., optim.Adam or optim.SGD.
         model_cls: A model class (nn.Module) defining the network architecture.
         loss_fn: A loss function from autograd.functional, e.g., cross_entropy.
@@ -419,7 +424,7 @@ if __name__ == "__main__":
       1) Fetch the 'mnist_784' dataset (ID=554) from OpenML.
       2) Subsample the data to 3000 examples (both X and y).
       3) Split into training (90%) and test (10%) sets.
-      4) Create SimpleDataLoader objects for each split.
+      4) Create DataLoader objects for each split.
       5) Train various model architectures, including:
          - A ResNet-like model using residual blocks.
          - A Multi-layer Perceptron (MLP) with optional batch normalization.
@@ -447,8 +452,16 @@ if __name__ == "__main__":
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
 
     # Create data loaders with a consistent batch size.
-    train_data_loader = SimpleDataLoader(X_train, y_train, batch_size=512, shuffle=True)
-    val_data_loader = SimpleDataLoader(X_test, y_test, batch_size=512, shuffle=False)
+    train_data_loader = DataLoader(
+        PairedIterableDataset(X_train, y_train, shuffle=True),
+        batch_size=512,
+        collate_fn=PairedCollator(),
+    )
+    val_data_loader = DataLoader(
+        PairedIterableDataset(X_test, y_test, shuffle=False),
+        batch_size=512,
+        collate_fn=PairedCollator(),
+    )
 
     # Train several multi-class models.
     train_mnist_multiclass_model(

--- a/examples/movie_sentiment.py
+++ b/examples/movie_sentiment.py
@@ -6,7 +6,9 @@ from autograd.backend import xp
 from autograd.text.utils import create_vocabulary
 from autograd.tools.config_schema import GenericTrainingConfig
 from autograd.tools.data import (
-    SimpleDataLoader,
+    DataLoader,
+    OneHotCollator,
+    PairedIterableDataset,
     load_data,
     train_test_split,
 )
@@ -29,25 +31,6 @@ def reviews_to_token_ids(reviews, vocabulary, max_sequence_length, pad_str="<PAD
         matrix.append(token_ids)
 
     return xp.array(matrix, dtype=xp.int32)
-
-
-class OneHotMovieSentimentDataLoader(SimpleDataLoader):
-    """Keep token IDs in memory and materialize one-hot features per batch."""
-
-    def __init__(self, X, y, vocab_size, batch_size=32, shuffle=True) -> None:
-        super().__init__(X, y, batch_size=batch_size, shuffle=shuffle)
-        self.vocab_size = vocab_size
-
-    def __iter__(self):
-        # TODO: replace batch-time one-hot with direct token-id model inputs.
-        eye = xp.eye(self.vocab_size, dtype=xp.float32)
-        for batch_indices in self._batch_indices():
-            batch_tokens = self.X[batch_indices]
-            yield eye[batch_tokens], self.y[batch_indices]
-
-    def _batch_indices(self):
-        for start in range(0, self.num_samples, self.batch_size):
-            yield self.indices[start : start + self.batch_size]
 
 
 def process_data(data):
@@ -168,8 +151,8 @@ class LSTM(nn.Module):
 
 def main(
     model_cls: type,
-    train_data_loader: SimpleDataLoader,
-    test_data_loader: SimpleDataLoader,
+    train_data_loader: DataLoader,
+    test_data_loader: DataLoader,
     config: GenericTrainingConfig,
 ):
     """
@@ -181,8 +164,8 @@ def main(
 
     Args:
         model_cls (type): The neural network model class to instantiate.
-        train_data_loader (SimpleDataLoader): Data loader for the training data.
-        test_data_loader (SimpleDataLoader): Data loader for the validation/testing data.
+        train_data_loader (DataLoader): Data loader for the training data.
+        test_data_loader (DataLoader): Data loader for the validation/testing data.
         config (GenericTrainingConfig): Configuration for training (epochs, learning rate, etc.).
     """
     logger.info(
@@ -209,7 +192,7 @@ if __name__ == "__main__":
       3) Processes the data by creating a vocabulary from the review texts, converting the texts to token IDs
          (with fixed sequence length), and mapping sentiment labels to binary values.
       4) Splits the processed data into training and testing sets.
-      5) Creates dataloaders that materialize one-hot features lazily per batch.
+      5) Creates datasets plus collators that materialize one-hot features lazily per batch.
       6) Constructs training configurations for both RNN and LSTM models using GenericTrainingConfig.
       7) Trains the RNN model followed by the LSTM model using the main training function.
       8) Logs training progress, checkpoints, and evaluation metrics.
@@ -228,19 +211,15 @@ if __name__ == "__main__":
     data = load_data("training_data/IMDB Dataset.csv", "training_data/IMDB Dataset.csv")
     assert not isinstance(data, str)
     X_train, X_test, y_train, y_test, vocab = process_data(data)
-    train_data_loader = OneHotMovieSentimentDataLoader(
-        X_train,
-        y_train,
-        vocab_size=len(vocab),
+    train_data_loader = DataLoader(
+        PairedIterableDataset(X_train, y_train, shuffle=True),
         batch_size=32,
-        shuffle=True,
+        collate_fn=OneHotCollator(num_classes=len(vocab)),
     )
-    test_data_loader = OneHotMovieSentimentDataLoader(
-        X_test,
-        y_test,
-        vocab_size=len(vocab),
+    test_data_loader = DataLoader(
+        PairedIterableDataset(X_test, y_test, shuffle=False),
         batch_size=32,
-        shuffle=False,
+        collate_fn=OneHotCollator(num_classes=len(vocab)),
     )
 
     # Train the RNN model.

--- a/examples/neural_turing_machine.py
+++ b/examples/neural_turing_machine.py
@@ -573,9 +573,15 @@ if __name__ == "__main__":
     X_val = to_one_hot(X_val, input_size)
 
     print("------------- Neural Turing Machine ---------------")
-    train_data_loader = data.SimpleDataLoader(X, y, batch_size=batch_size, shuffle=True)
-    val_data_loader = data.SimpleDataLoader(
-        X_val, y_val, batch_size=batch_size, shuffle=True
+    train_data_loader = data.DataLoader(
+        data.PairedIterableDataset(X, y, shuffle=True),
+        batch_size=batch_size,
+        collate_fn=data.PairedCollator(),
+    )
+    val_data_loader = data.DataLoader(
+        data.PairedIterableDataset(X_val, y_val, shuffle=True),
+        batch_size=batch_size,
+        collate_fn=data.PairedCollator(),
     )
 
     # Create training configuration for the Neural Turing Machine.

--- a/examples/seq2seq.py
+++ b/examples/seq2seq.py
@@ -1,7 +1,12 @@
 from autograd import functional, nn, optim, tensor
 from autograd.text.utils import create_vocabulary, text_to_one_hot_and_sparse
 from autograd.tools.config_schema import GenericTrainingConfig
-from autograd.tools.data import SimpleDataLoader, load_data
+from autograd.tools.data import (
+    DataLoader,
+    PairedCollator,
+    PairedIterableDataset,
+    load_data,
+)
 from autograd.tools.trainer import SimpleTrainer
 
 """
@@ -137,7 +142,7 @@ def main():
       2. Parses the data into source and target sequences using parse_data_into_xy.
       3. Creates a vocabulary from the combined source and target texts.
       4. Converts the text sequences into one-hot encoded features and integer index matrices.
-      5. Creates SimpleDataLoader objects for training and testing.
+      5. Creates DataLoader objects for training and testing.
       6. Configures the training parameters via a GenericTrainingConfig.
       7. Creates a SimpleTrainer with the Seq2Seq model and trains the model.
 
@@ -171,17 +176,15 @@ def main():
         train_y, vocab, max_sequence_length=60
     )
 
-    train_data_loader = SimpleDataLoader(
-        features,
-        labels_vocab_idx,
+    train_data_loader = DataLoader(
+        PairedIterableDataset(features, labels_vocab_idx, shuffle=True),
         batch_size=32,
-        shuffle=True,
+        collate_fn=PairedCollator(),
     )
-    test_data_loader = SimpleDataLoader(
-        test_features,
-        test_labels_vocab_idx,
+    test_data_loader = DataLoader(
+        PairedIterableDataset(test_features, test_labels_vocab_idx, shuffle=False),
         batch_size=32,
-        shuffle=False,
+        collate_fn=PairedCollator(),
     )
 
     # Build a training configuration for the Seq2Seq model.

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -8,7 +8,11 @@ from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.tools.callback import sampling_callback, teacher_forcing_callback
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
-from autograd.tools.data import LLMDataLoader
+from autograd.tools.data import (
+    DataLoader,
+    LanguageModelingCollator,
+    TokenSequenceDataset,
+)
 from autograd.tools.trainer import LLMTrainer
 
 
@@ -559,7 +563,7 @@ if __name__ == "__main__":
       5) Split the encoded data into training and testing portions.
       6) Update the model configuration with the vocabulary size from the BPE.
       7) Instantiate an LLMTrainer with the Transformer model, optimizer, loss function, and forward function.
-      8) Create LLMDataLoader objects for training and evaluation.
+      8) Create DataLoader objects for training and evaluation.
       9) Train the Transformer model.
       10) Run inference on the trained model to generate output text.
 
@@ -645,25 +649,40 @@ if __name__ == "__main__":
         eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
-    train_data_loader = LLMDataLoader(
-        data=xp.array(train_data, dtype=xp.int32),
-        bpe=bpe,
+    pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
+    sos_idx = bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+
+    train_data_loader = DataLoader(
+        dataset=TokenSequenceDataset(
+            data=xp.array(train_data, dtype=xp.int32),
+            seq_len=trainer.model.max_seq_len,
+            shuffle=True,
+            random_window=True,
+        ),
         batch_size=CONFIG.batch_size,
-        seq_len=trainer.model.max_seq_len,
-        steps_per_epoch=CONFIG.steps_per_epoch,
-        shuffle=True,
-        include_decoder_input=CONFIG.include_decoder_input,
-        create_padding_masks=CONFIG.create_padding_masks,
+        collate_fn=LanguageModelingCollator(
+            max_tokens=trainer.model.max_seq_len + 1,
+            pad_idx=pad_idx,
+            sos_idx=sos_idx,
+            include_decoder_input=CONFIG.include_decoder_input,
+            create_padding_masks=CONFIG.create_padding_masks,
+        ),
     )
-    test_data_loader = LLMDataLoader(
-        data=xp.array(test_data, dtype=xp.int32),
-        bpe=bpe,
+    test_data_loader = DataLoader(
+        dataset=TokenSequenceDataset(
+            data=xp.array(test_data, dtype=xp.int32),
+            seq_len=trainer.model.max_seq_len,
+            shuffle=False,
+            random_window=True,
+        ),
         batch_size=CONFIG.batch_size // 2,
-        seq_len=trainer.model.max_seq_len,
-        steps_per_epoch=CONFIG.eval_iters,
-        shuffle=False,
-        include_decoder_input=CONFIG.include_decoder_input,
-        create_padding_masks=CONFIG.create_padding_masks,
+        collate_fn=LanguageModelingCollator(
+            max_tokens=trainer.model.max_seq_len + 1,
+            pad_idx=pad_idx,
+            sos_idx=sos_idx,
+            include_decoder_input=CONFIG.include_decoder_input,
+            create_padding_masks=CONFIG.create_padding_masks,
+        ),
     )
 
     trainer.fit(train_data_loader, test_data_loader)

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -6,7 +6,10 @@ from autograd.backend import xp
 from autograd.tensor import Tensor
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
-from autograd.tools.callback import sampling_callback, teacher_forcing_callback
+from autograd.tools.callback import (
+    run_sampling_inference,
+    run_teacher_forcing_inference,
+)
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
 from autograd.tools.data import (
     DataLoader,
@@ -646,7 +649,6 @@ if __name__ == "__main__":
         loss_fn=functional.cross_entropy,
         config=CONFIG,
         forward_fn=TransformerForwardFn(),
-        eval_callbacks=[teacher_forcing_callback, sampling_callback],
     )
 
     pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
@@ -687,13 +689,22 @@ if __name__ == "__main__":
 
     trainer.fit(train_data_loader, test_data_loader)
 
-    text_utils.inference(
+    if CONFIG.teacher_enforcing:
+        run_teacher_forcing_inference(
+            model=trainer.model,
+            forward_fn=TransformerForwardFn(),
+            bpe=bpe,
+            groundtruth_data=xp.array(
+                test_data[: trainer.model.max_seq_len // 3], dtype=xp.int32
+            ),
+            max_length=trainer.model.max_seq_len // 3,
+        )
+
+    run_sampling_inference(
         model=trainer.model,
-        prediction_func=TransformerForwardFn(),
+        forward_fn=TransformerForwardFn(),
         bpe=bpe,
-        start_tokens="All",  # Dummy token to start the generation
-        max_length=int(
-            trainer.model.max_seq_len * 0.9
-        ),  # this should be shorter than context
-        temperature=1.0,
+        start_tokens="All",
+        max_length=int(trainer.model.max_seq_len * 0.9),
+        top_k=CONFIG.eval_top_k,
     )

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -7,7 +7,11 @@ from sklearn.datasets import load_breast_cancer, load_diabetes
 from autograd import functional, nn, optim
 from autograd.backend import xp
 from autograd.tools.config_schema import GenericTrainingConfig
-from autograd.tools.data import SimpleDataLoader
+from autograd.tools.data import (
+    DataLoader,
+    PairedCollator,
+    PairedIterableDataset,
+)
 from autograd.tools.metrics import accuracy, mean_squared_error
 from autograd.tools.trainer import SimpleTrainer
 
@@ -81,7 +85,11 @@ class TestTrain(TestCase):
                 "lr": 1e-3,
             },
         )
-        train_data_loader = SimpleDataLoader(X, y, batch_size=32, shuffle=True)
+        train_data_loader = DataLoader(
+            PairedIterableDataset(X, y, shuffle=True),
+            batch_size=32,
+            collate_fn=PairedCollator(),
+        )
         trainer = SimpleTrainer(
             model_cls=Classifier,
             optimizer_cls=optim.SGD,
@@ -127,7 +135,11 @@ class TestTrain(TestCase):
         X = (X - X.mean(axis=0)) / (X.std(axis=0) + eps)
         y = (y - y.mean()) / (y.std() + eps)
 
-        train_data_loader = SimpleDataLoader(X, y, batch_size=32, shuffle=True)
+        train_data_loader = DataLoader(
+            PairedIterableDataset(X, y, shuffle=True),
+            batch_size=32,
+            collate_fn=PairedCollator(),
+        )
 
         trainer = SimpleTrainer(
             model_cls=RegressionModel,

--- a/test/autograd/tools/test_data.py
+++ b/test/autograd/tools/test_data.py
@@ -366,7 +366,7 @@ class TestDataLoaders(unittest.TestCase):
     @patch.object(text_utils, "create_padding_mask", side_effect=mock_padding_mask)
     def test_pretraining_data_loader_length(self, mock_padding, mock_causal):
         loader_infinite = self.make_pretraining_loader()
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             _ = len(loader_infinite)
 
     def test_random_window_token_sequence_dataset_yields_single_example(self):

--- a/test/autograd/tools/test_data.py
+++ b/test/autograd/tools/test_data.py
@@ -3,15 +3,24 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 from autograd.backend import xp
 from autograd.text import utils as text_utils
 from autograd.tools.data import (
-    LLMDataLoader,
-    SimpleDataLoader,
+    DataLoader,
+    LanguageModelingCollator,
+    OneHotCollator,
+    PairedCollator,
+    PairedIterableDataset,
+    TokenSequenceDataset,
+    TransformDataset,
     load_data,
+    openai_chat_to_prompt_completion,
+    pack_tokens,
+    tokenize_prompt_completion,
 )
 
 
@@ -36,8 +45,7 @@ class MockBPE:
                 return [0]
             elif token == "<SOS>":
                 return [1]
-        # Fallback: use the ASCII code of the first character.
-        return [ord(token[0])]
+        return [ord(char) for char in token]
 
 
 class TestDataLoaders(unittest.TestCase):
@@ -45,18 +53,103 @@ class TestDataLoaders(unittest.TestCase):
         self.X = xp.arange(20).reshape(10, 2)
         self.y = xp.arange(10)
         self.data = xp.arange(200)
+        self.chat_examples = [
+            {
+                "messages": [
+                    {"role": "system", "content": "ABC"},
+                    {"role": "assistant", "content": "DE"},
+                ]
+            },
+            {
+                "messages": [
+                    {"role": "user", "content": "Q"},
+                    {"role": "assistant", "content": "RS"},
+                ]
+            },
+        ]
         self.seq_len = 10
         self.batch_size_simple = 3
         self.batch_size_llm = 4
         self.steps = 5
         self.bpe = MockBPE()
 
-    def test_simple_dataloader_no_shuffle(self):
-        loader = SimpleDataLoader(
-            self.X, self.y, batch_size=self.batch_size_simple, shuffle=False
+    def make_pretraining_loader(
+        self,
+        data=None,
+        *,
+        batch_size=None,
+        seq_len=None,
+        shuffle=True,
+        include_decoder_input=True,
+        create_padding_masks=True,
+    ):
+        data = self.data if data is None else data
+        batch_size = self.batch_size_llm if batch_size is None else batch_size
+        seq_len = self.seq_len if seq_len is None else seq_len
+        pad_idx = self.bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
+        sos_idx = self.bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+        dataset = TokenSequenceDataset(
+            data=xp.array(data),
+            seq_len=seq_len,
+            shuffle=shuffle,
+            random_window=True,
+        )
+        return DataLoader(
+            dataset,
+            batch_size=batch_size,
+            collate_fn=LanguageModelingCollator(
+                max_tokens=seq_len + 1,
+                pad_idx=pad_idx,
+                sos_idx=sos_idx,
+                include_decoder_input=include_decoder_input,
+                create_padding_masks=create_padding_masks,
+            ),
+        )
+
+    def make_sft_loader(
+        self,
+        chat_examples=None,
+        *,
+        batch_size=1,
+        seq_len=5,
+        shuffle=False,
+    ):
+        chat_examples = (
+            chat_examples if chat_examples is not None else self.chat_examples
+        )
+        pad_idx = self.bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
+        sos_idx = self.bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+        tokenized_examples = [
+            tokenize_prompt_completion(
+                openai_chat_to_prompt_completion(example), self.bpe
+            )
+            for example in chat_examples
+        ]
+        return DataLoader(
+            dataset=TokenSequenceDataset(
+                token_sequences=[example["tokens"] for example in tokenized_examples],
+                loss_masks=[example["loss_mask"] for example in tokenized_examples],
+                shuffle=shuffle,
+            ),
+            batch_size=batch_size,
+            collate_fn=LanguageModelingCollator(
+                max_tokens=seq_len + 1,
+                pad_idx=pad_idx,
+                sos_idx=sos_idx,
+                include_decoder_input=False,
+                create_padding_masks=False,
+            ),
+        )
+
+    def test_data_loader_no_shuffle(self):
+        dataset = PairedIterableDataset(self.X, self.y, shuffle=False)
+        loader = DataLoader(
+            dataset,
+            batch_size=self.batch_size_simple,
+            collate_fn=PairedCollator(),
         )
         expected_indices = xp.arange(len(self.X))
-        self.assertTrue(xp.array_equal(loader.indices, expected_indices))
+        self.assertTrue(xp.array_equal(dataset.indices, expected_indices))
         batches = list(loader)
         expected_batches = (
             len(self.X) + self.batch_size_simple - 1
@@ -65,47 +158,161 @@ class TestDataLoaders(unittest.TestCase):
         reconstructed_y = xp.concatenate([batch[1] for batch in batches])
         self.assertTrue(xp.array_equal(reconstructed_y, self.y))
 
-    def test_simple_dataloader_shuffle(self):
-        loader = SimpleDataLoader(
-            self.X, self.y, batch_size=self.batch_size_simple, shuffle=True
+    def test_paired_iterable_dataset_shuffle(self):
+        dataset = PairedIterableDataset(self.X, self.y, shuffle=True)
+        dataset.on_epoch_start()
+        self.assertTrue(
+            xp.array_equal(xp.sort(dataset.indices), xp.arange(len(self.X)))
         )
-        loader.on_epoch_start()
-        self.assertTrue(xp.array_equal(xp.sort(loader.indices), xp.arange(len(self.X))))
 
-    def test_simple_dataloader_length(self):
-        loader = SimpleDataLoader(
-            self.X, self.y, batch_size=self.batch_size_simple, shuffle=False
+    def test_data_loader_length(self):
+        loader = DataLoader(
+            PairedIterableDataset(self.X, self.y, shuffle=False),
+            batch_size=self.batch_size_simple,
+            collate_fn=PairedCollator(),
         )
         expected_batches = (
             len(self.X) + self.batch_size_simple - 1
         ) // self.batch_size_simple
         self.assertEqual(len(loader), expected_batches)
 
-    def test_llm_dataloader_on_epoch_start_reseeds_without_crashing(self):
-        loader = LLMDataLoader(
-            self.data,
-            self.bpe,
-            batch_size=self.batch_size_llm,
-            seq_len=self.seq_len,
-            steps_per_epoch=1,
-            shuffle=True,
-        )
+    def test_pretraining_data_loader_on_epoch_start_reseeds_without_crashing(self):
+        loader = self.make_pretraining_loader(shuffle=True)
 
         loader.on_epoch_start()
 
-    def test_simple_dataloader_preprocess(self):
-        X_orig = xp.array([[1, 2], [3, 4]])
-        y_orig = xp.array([10, 20])
-        loader = SimpleDataLoader(
-            xp.array(X_orig), xp.array(y_orig), batch_size=1, shuffle=False
+    def test_transform_dataset_applies_transform_and_target_transform(self):
+        dataset = TransformDataset(
+            PairedIterableDataset(
+                xp.array([[1, 2], [3, 4]]),
+                xp.array([10, 20]),
+                shuffle=False,
+            ),
+            transform=lambda x: x * 2,
+            target_transform=lambda y: y * 3,
         )
 
-        def preprocess_func(X_in, y_in):
-            return X_in * 2, y_in * 3
+        examples = list(dataset)
 
-        loader.preprocess(preprocess_func)
-        assert xp.array_equal(loader.X, X_orig * 2)
-        assert xp.array_equal(loader.y, y_orig * 3)
+        self.assertTrue(xp.array_equal(examples[0]["inputs"], xp.array([2, 4])))
+        self.assertEqual(int(examples[0]["targets"]), 30)
+        self.assertTrue(xp.array_equal(examples[1]["inputs"], xp.array([6, 8])))
+        self.assertEqual(int(examples[1]["targets"]), 60)
+
+    def test_pack_tokens_left_truncates_then_pads(self):
+        packed = pack_tokens(
+            tokens=xp.array([10, 11, 12, 13, 20, 21, 22], dtype=xp.int32),
+            max_tokens=5,
+            pad_idx=0,
+        )
+
+        self.assertTrue(
+            xp.array_equal(packed, xp.array([12, 13, 20, 21, 22], dtype=xp.int32))
+        )
+
+    def test_paired_iterable_dataset_yields_single_example(self):
+        dataset = PairedIterableDataset(self.X, self.y, shuffle=False)
+
+        example = next(iter(dataset))
+
+        self.assertEqual(tuple(example.keys()), ("inputs", "targets"))
+        self.assertTrue(xp.array_equal(example["inputs"], self.X[0]))
+        self.assertEqual(int(example["targets"]), int(self.y[0]))
+
+    def test_transform_dataset_applies_target_transform(self):
+        dataset = TransformDataset(
+            PairedIterableDataset(self.X, self.y, shuffle=False),
+            target_transform=lambda y: xp.array(int(y == 3), dtype=xp.int32),
+        )
+
+        examples = list(dataset)
+
+        self.assertTrue(xp.array_equal(examples[0]["inputs"], self.X[0]))
+        self.assertEqual(int(examples[2]["targets"]), 0)
+        self.assertEqual(int(examples[3]["targets"]), 1)
+
+    def test_paired_collator_batches_examples(self):
+        collator = PairedCollator()
+
+        batch_X, batch_y = collator(
+            [
+                {
+                    "inputs": xp.array([1, 2], dtype=xp.int32),
+                    "targets": xp.array(3, dtype=xp.int32),
+                },
+                {
+                    "inputs": xp.array([4, 5], dtype=xp.int32),
+                    "targets": xp.array(6, dtype=xp.int32),
+                },
+            ]
+        )
+
+        self.assertTrue(
+            xp.array_equal(
+                batch_X,
+                xp.array([[1, 2], [4, 5]], dtype=xp.int32),
+            )
+        )
+        self.assertTrue(xp.array_equal(batch_y, xp.array([3, 6], dtype=xp.int32)))
+
+    def test_paired_collator_accepts_numpy_scalar_targets(self):
+        collator = PairedCollator()
+
+        _, batch_y = collator(
+            [
+                {
+                    "inputs": xp.array([1, 2], dtype=xp.float32),
+                    "targets": np.int64(3),
+                },
+                {
+                    "inputs": xp.array([4, 5], dtype=xp.float32),
+                    "targets": np.int64(6),
+                },
+            ]
+        )
+
+        self.assertTrue(xp.array_equal(batch_y, xp.array([3, 6], dtype=xp.int64)))
+
+    def test_data_loader_batches_supervised_examples(self):
+        dataset = PairedIterableDataset(self.X, self.y, shuffle=False)
+        loader = DataLoader(
+            dataset,
+            batch_size=4,
+            collate_fn=PairedCollator(),
+        )
+
+        batches = list(loader)
+
+        self.assertEqual(len(batches), 3)
+        first_X, first_y = batches[0]
+        self.assertTrue(xp.array_equal(first_X, self.X[:4]))
+        self.assertTrue(xp.array_equal(first_y, self.y[:4]))
+
+    def test_one_hot_collator_materializes_one_hot_inputs(self):
+        collator = OneHotCollator(num_classes=4)
+
+        batch_X, batch_y = collator(
+            [
+                {
+                    "inputs": xp.array([0, 2], dtype=xp.int32),
+                    "targets": xp.array(1, dtype=xp.int32),
+                },
+                {
+                    "inputs": xp.array([1, 3], dtype=xp.int32),
+                    "targets": xp.array(0, dtype=xp.int32),
+                },
+            ]
+        )
+
+        expected_X = xp.array(
+            [
+                [[1, 0, 0, 0], [0, 0, 1, 0]],
+                [[0, 1, 0, 0], [0, 0, 0, 1]],
+            ],
+            dtype=xp.float32,
+        )
+        self.assertTrue(xp.array_equal(batch_X, expected_X))
+        self.assertTrue(xp.array_equal(batch_y, xp.array([1, 0], dtype=xp.int32)))
 
     def test_load_data_reads_parquet_without_pandas(self):
         rows = [
@@ -154,34 +361,98 @@ class TestDataLoaders(unittest.TestCase):
             ],
         )
 
-    # Use decorators to patch the text_utils functions for LLMDataLoader tests.
+    # Use decorators to patch the text_utils functions for LM collator tests.
     @patch.object(text_utils, "create_causal_mask", side_effect=mock_causal_mask)
     @patch.object(text_utils, "create_padding_mask", side_effect=mock_padding_mask)
-    def test_llm_dataloader_length(self, mock_padding, mock_causal):
-        loader = LLMDataLoader(
-            self.data,
-            self.bpe,
-            batch_size=self.batch_size_llm,
-            seq_len=self.seq_len,
-            steps_per_epoch=self.steps,
-        )
-        self.assertEqual(len(loader), self.steps)
-        loader_infinite = LLMDataLoader(
-            self.data,
-            self.bpe,
-            batch_size=self.batch_size_llm,
-            seq_len=self.seq_len,
-            steps_per_epoch=None,
-        )
+    def test_pretraining_data_loader_length(self, mock_padding, mock_causal):
+        loader_infinite = self.make_pretraining_loader()
         with self.assertRaises(NotImplementedError):
             _ = len(loader_infinite)
 
+    def test_random_window_token_sequence_dataset_yields_single_example(self):
+        dataset = TokenSequenceDataset(
+            data=self.data,
+            seq_len=4,
+            shuffle=False,
+            random_window=True,
+        )
+
+        example = next(iter(dataset))
+
+        self.assertEqual(tuple(example.keys()), ("tokens", "loss_mask"))
+        self.assertEqual(example["tokens"].shape, (5,))
+        self.assertTrue(
+            xp.array_equal(example["loss_mask"], xp.ones((5,), dtype=xp.int32))
+        )
+
+    def test_openai_chat_to_prompt_completion_extracts_text(self):
+        example = openai_chat_to_prompt_completion(
+            {
+                "messages": [
+                    {"role": "system", "content": "ABC"},
+                    {"role": "assistant", "content": "DE"},
+                ]
+            }
+        )
+
+        self.assertEqual(example["prompt_text"], "ABC")
+        self.assertEqual(example["completion_text"], "DE")
+
+    def test_tokenize_prompt_completion_builds_tokens_and_loss_mask(self):
+        example = tokenize_prompt_completion(
+            {"prompt_text": "ABC", "completion_text": "DE"},
+            self.bpe,
+        )
+
+        self.assertTrue(
+            xp.array_equal(
+                example["tokens"], xp.array([65, 66, 67, 68, 69], dtype=xp.int32)
+            )
+        )
+        self.assertTrue(
+            xp.array_equal(
+                example["loss_mask"], xp.array([0, 0, 0, 1, 1], dtype=xp.int32)
+            )
+        )
+
+    def test_token_sequence_dataset_holds_tokenized_prompt_completion_examples(self):
+        tokenized_example = tokenize_prompt_completion(
+            openai_chat_to_prompt_completion(
+                {
+                    "messages": [
+                        {"role": "system", "content": "ABC"},
+                        {"role": "assistant", "content": "DE"},
+                    ]
+                }
+            ),
+            self.bpe,
+        )
+        dataset = TokenSequenceDataset(
+            token_sequences=[tokenized_example["tokens"]],
+            loss_masks=[tokenized_example["loss_mask"]],
+            shuffle=False,
+        )
+
+        example = next(iter(dataset))
+
+        self.assertTrue(
+            xp.array_equal(
+                example["tokens"], xp.array([65, 66, 67, 68, 69], dtype=xp.int32)
+            )
+        )
+        self.assertTrue(
+            xp.array_equal(
+                example["loss_mask"], xp.array([0, 0, 0, 1, 1], dtype=xp.int32)
+            )
+        )
+
     @patch.object(text_utils, "create_causal_mask", side_effect=mock_causal_mask)
     @patch.object(text_utils, "create_padding_mask", side_effect=mock_padding_mask)
-    def test_llm_dataloader_small_data(self, mock_padding, mock_causal):
+    def test_pretraining_data_loader_small_data(self, mock_padding, mock_causal):
         data_small = xp.arange(5)
-        loader = LLMDataLoader(
-            data_small, self.bpe, batch_size=2, seq_len=self.seq_len, steps_per_epoch=1
+        loader = self.make_pretraining_loader(
+            data=data_small,
+            batch_size=2,
         )
         it = iter(loader)
         with self.assertRaises(ValueError):
@@ -189,25 +460,21 @@ class TestDataLoaders(unittest.TestCase):
 
     @patch.object(text_utils, "create_causal_mask", side_effect=mock_causal_mask)
     @patch.object(text_utils, "create_padding_mask", side_effect=mock_padding_mask)
-    def test_llm_dataloader_output(self, mock_padding, mock_causal):
-        loader = LLMDataLoader(
-            self.data,
-            self.bpe,
-            batch_size=self.batch_size_llm,
-            seq_len=self.seq_len,
-            steps_per_epoch=1,
-        )
+    def test_pretraining_data_loader_output(self, mock_padding, mock_causal):
+        loader = self.make_pretraining_loader()
         batch = next(iter(loader))
         self.assertEqual(len(batch), 6)
         X_chunk, dec_inp, Y_chunk, smask, tmask, causal_mask = batch
         self.assertEqual(X_chunk.shape, (self.batch_size_llm, self.seq_len))
         self.assertEqual(Y_chunk.shape, (self.batch_size_llm, self.seq_len))
-        if loader.include_decoder_input:
+        if loader.collate_fn.include_decoder_input:
             self.assertEqual(dec_inp.shape, (self.batch_size_llm, self.seq_len))
-            self.assertTrue(xp.all(xp.asarray(dec_inp[:, 0] == loader.sos_idx)))
+            self.assertTrue(
+                xp.all(xp.asarray(dec_inp[:, 0] == loader.collate_fn.sos_idx))
+            )
         else:
             self.assertIsNone(dec_inp)
-        if loader.create_padding_masks:
+        if loader.collate_fn.create_padding_masks:
             self.assertEqual(smask.shape, (self.batch_size_llm, 1, 1, self.seq_len))
             self.assertEqual(
                 tmask.shape, (self.batch_size_llm, 1, self.seq_len, self.seq_len)
@@ -222,14 +489,103 @@ class TestDataLoaders(unittest.TestCase):
 
     @patch.object(text_utils, "create_causal_mask", side_effect=mock_causal_mask)
     @patch.object(text_utils, "create_padding_mask", side_effect=mock_padding_mask)
-    def test_llm_dataloader_no_decoder_input(self, mock_padding, mock_causal):
-        loader = LLMDataLoader(
-            self.data,
-            self.bpe,
-            batch_size=self.batch_size_llm,
-            seq_len=self.seq_len,
-            steps_per_epoch=1,
+    def test_pretraining_data_loader_no_decoder_input(self, mock_padding, mock_causal):
+        loader = self.make_pretraining_loader(
             include_decoder_input=False,
         )
         batch = next(iter(loader))
         self.assertIsNone(batch[1])
+
+    def test_sft_dataloader_length(self):
+        loader = self.make_sft_loader(batch_size=1, seq_len=4, shuffle=False)
+        self.assertEqual(len(loader), 2)
+
+    def test_sft_dataloader_masks_prompt_targets(self):
+        loader = self.make_sft_loader(
+            chat_examples=[
+                {
+                    "messages": [
+                        {"role": "user", "content": "ABC"},
+                        {"role": "assistant", "content": "DE"},
+                    ]
+                }
+            ],
+            batch_size=1,
+            seq_len=5,
+            shuffle=False,
+        )
+
+        X_chunk, dec_inp, Y_chunk, smask, tmask, causal_mask = next(iter(loader))
+
+        self.assertIsNone(dec_inp)
+        self.assertIsNone(smask)
+        self.assertIsNone(tmask)
+        self.assertEqual(X_chunk.shape, (1, 5))
+        self.assertEqual(Y_chunk.shape, (1, 5))
+        self.assertEqual(causal_mask.shape, (1, 1, 5, 5))
+        self.assertTrue(
+            xp.array_equal(
+                Y_chunk[0],
+                xp.array([0, 0, 68, 69, 0], dtype=xp.int32),
+            )
+        )
+
+    def test_data_loader_can_use_sft_batch_and_label_primitives(self):
+        loader = self.make_sft_loader(
+            chat_examples=[
+                {
+                    "messages": [
+                        {"role": "user", "content": "ABC"},
+                        {"role": "assistant", "content": "DE"},
+                    ]
+                }
+            ],
+            batch_size=1,
+            seq_len=5,
+            shuffle=False,
+        )
+
+        X_chunk, dec_inp, Y_chunk, smask, tmask, causal_mask = next(iter(loader))
+
+        self.assertIsNone(dec_inp)
+        self.assertIsNone(smask)
+        self.assertIsNone(tmask)
+        self.assertEqual(X_chunk.shape, (1, 5))
+        self.assertEqual(Y_chunk.shape, (1, 5))
+        self.assertEqual(causal_mask.shape, (1, 1, 5, 5))
+        self.assertTrue(
+            xp.array_equal(
+                X_chunk[0],
+                xp.array([65, 66, 67, 68, 69], dtype=xp.int32),
+            )
+        )
+        self.assertTrue(
+            xp.array_equal(
+                Y_chunk[0],
+                xp.array([0, 0, 68, 69, 0], dtype=xp.int32),
+            )
+        )
+
+    def test_sft_dataloader_left_truncates_to_keep_response_tokens(self):
+        loader = self.make_sft_loader(
+            chat_examples=[
+                {
+                    "messages": [
+                        {"role": "user", "content": "ABCD"},
+                        {"role": "assistant", "content": "EFG"},
+                    ]
+                }
+            ],
+            batch_size=1,
+            seq_len=4,
+            shuffle=False,
+        )
+
+        X_chunk, _, Y_chunk, _, _, _ = next(iter(loader))
+
+        self.assertTrue(
+            xp.array_equal(X_chunk[0], xp.array([67, 68, 69, 70], dtype=xp.int32))
+        )
+        self.assertTrue(
+            xp.array_equal(Y_chunk[0], xp.array([0, 69, 70, 71], dtype=xp.int32))
+        )

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -1,13 +1,17 @@
 import math
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from autograd.backend import xp
 from autograd.functional import cross_entropy
 from autograd.nn import AbstractLLMForwardFn, Module
 from autograd.optim import Optimizer
 from autograd.tensor import Tensor
+from autograd.tools.callback import (
+    run_sampling_inference,
+    run_teacher_forcing_inference,
+)
 from autograd.tools.config_schema import (
     GenericTrainingConfig,
     TransformerTrainingConfig,
@@ -367,6 +371,33 @@ class TestLLMTrainer(BaseTrainerTest):
             trainer.model, trainer.forward_fn, self.val_loader, trainer.config
         )
 
+    @patch("autograd.tools.callback.text_utils.inference")
+    def test_manual_qualitative_inference_helpers_do_not_depend_on_loader(
+        self, mock_inference
+    ):
+        bpe = MockBPE()
+        groundtruth = xp.arange(10, dtype=xp.int32)
+
+        teacher_forcing_text = run_teacher_forcing_inference(
+            model=self.trainer.model,
+            forward_fn=PromptMaskAwareForwardFn(),
+            bpe=bpe,
+            groundtruth_data=groundtruth,
+            max_length=3,
+        )
+        sampled_text = run_sampling_inference(
+            model=self.trainer.model,
+            forward_fn=PromptMaskAwareForwardFn(),
+            bpe=bpe,
+            start_tokens="ABC",
+            max_length=4,
+            top_k=5,
+        )
+
+        self.assertIs(mock_inference.return_value, teacher_forcing_text)
+        self.assertIs(mock_inference.return_value, sampled_text)
+        self.assertEqual(mock_inference.call_count, 2)
+
     def test_llm_evaluate_respects_eval_iters_from_config(self):
         self.config.eval_iters = 1
         val_loader = MockDataLoader(self.val_data * 2, pad_idx=0, seq_len=10)
@@ -433,3 +464,39 @@ class TestLLMTrainer(BaseTrainerTest):
 
         self.assertAlmostEqual(train_loss, float(expected_loss.item()), places=6)
         self.assertAlmostEqual(val_loss, float(expected_loss.item()), places=6)
+
+    def test_fit_supports_unsized_streaming_data_loaders(self):
+        bpe = MockBPE()
+        pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
+        sos_idx = bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+        self.config.total_epochs = 1
+        self.config.steps_per_epoch = 1
+        self.config.eval_iters = 1
+
+        stream_loader = DataLoader(
+            dataset=TokenSequenceDataset(
+                data=xp.arange(100, dtype=xp.int32),
+                seq_len=4,
+                shuffle=False,
+                random_window=True,
+            ),
+            batch_size=2,
+            collate_fn=LanguageModelingCollator(
+                max_tokens=5,
+                pad_idx=pad_idx,
+                sos_idx=sos_idx,
+                include_decoder_input=False,
+                create_padding_masks=False,
+            ),
+        )
+        trainer = LLMTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=cross_entropy,
+            forward_fn=PromptMaskAwareForwardFn(),
+            config=self.config,
+        )
+
+        trainer.fit(stream_loader, stream_loader)
+
+        self.assertEqual(trainer.optimizer.step_call_count, 1)

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -4,12 +4,20 @@ import unittest
 from unittest.mock import MagicMock
 
 from autograd.backend import xp
-from autograd.nn import Module
+from autograd.functional import cross_entropy
+from autograd.nn import AbstractLLMForwardFn, Module
 from autograd.optim import Optimizer
 from autograd.tensor import Tensor
 from autograd.tools.config_schema import (
     GenericTrainingConfig,
     TransformerTrainingConfig,
+)
+from autograd.tools.data import (
+    DataLoader,
+    LanguageModelingCollator,
+    TokenSequenceDataset,
+    openai_chat_to_prompt_completion,
+    tokenize_prompt_completion,
 )
 from autograd.tools.trainer import LLMTrainer, SimpleTrainer
 
@@ -98,6 +106,42 @@ class MockOptimizerClass(Optimizer):
 
     def state_dict(self):
         return {}
+
+
+class MockBPE:
+    def encode(self, token, allowed_special=set()):
+        if token in allowed_special:
+            if token == "<PAD>":
+                return [0]
+            if token == "<SOS>":
+                return [1]
+        return [ord(char) for char in token]
+
+
+class PromptMaskAwareForwardFn(AbstractLLMForwardFn):
+    def __init__(self, vocab_size=512):
+        self.vocab_size = vocab_size
+
+    def _build_logits(self, y):
+        logits = xp.full(
+            (y.shape[0], y.shape[1], self.vocab_size),
+            -6.0,
+            dtype=xp.float32,
+        )
+        for batch_idx in range(y.shape[0]):
+            for token_idx in range(y.shape[1]):
+                target = int(y[batch_idx, token_idx])
+                predicted_class = target if target != 0 else 3
+                logits[batch_idx, token_idx, predicted_class] = 6.0
+        return Tensor(logits, requires_grad=True)
+
+    def train(self, model, batch_data):
+        _, _, y, _, _, _ = batch_data
+        return self._build_logits(y), y
+
+    def sample(self, model, batch_data):
+        _, _, y, _, _, _ = batch_data
+        return self._build_logits(y), None
 
 
 class BaseTrainerTest(unittest.TestCase):
@@ -196,6 +240,23 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         trainer.fit(self.train_loader, self.val_loader)
         self.assertEqual(trainer.optimizer.step_call_count, len(self.train_data))
+
+    def test_fit_respects_steps_per_epoch_from_config(self):
+        self.config.total_epochs = 1
+        self.config.steps_per_epoch = 1
+
+        self.trainer.fit(self.train_loader, self.val_loader)
+
+        self.assertEqual(self.trainer.optimizer.step_call_count, 1)
+
+    def test_evaluate_respects_eval_iters_from_config(self):
+        self.config.eval_iters = 1
+        val_loader = MockDataLoader(self.val_data * 2)
+
+        avg_val_loss = self.trainer.evaluate(val_loader)
+
+        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        self.assertEqual(self.loss_fn.call_count, 1)
 
 
 class TestLLMTrainer(BaseTrainerTest):
@@ -305,3 +366,70 @@ class TestLLMTrainer(BaseTrainerTest):
         callback.assert_called_once_with(
             trainer.model, trainer.forward_fn, self.val_loader, trainer.config
         )
+
+    def test_llm_evaluate_respects_eval_iters_from_config(self):
+        self.config.eval_iters = 1
+        val_loader = MockDataLoader(self.val_data * 2, pad_idx=0, seq_len=10)
+
+        avg_val_loss = self.trainer.evaluate(val_loader)
+
+        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        self.assertEqual(self.loss_fn.call_count, 1)
+
+    def test_train_step_supports_sft_batches_from_generic_data_loader(self):
+        bpe = MockBPE()
+        pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
+        sos_idx = bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+        tokenized_example = tokenize_prompt_completion(
+            openai_chat_to_prompt_completion(
+                {
+                    "messages": [
+                        {"role": "user", "content": "ABC"},
+                        {"role": "assistant", "content": "CB"},
+                    ]
+                }
+            ),
+            bpe,
+        )
+        loader = DataLoader(
+            dataset=TokenSequenceDataset(
+                token_sequences=[tokenized_example["tokens"]],
+                loss_masks=[tokenized_example["loss_mask"]],
+                shuffle=False,
+            ),
+            batch_size=1,
+            collate_fn=LanguageModelingCollator(
+                max_tokens=6,
+                pad_idx=pad_idx,
+                sos_idx=sos_idx,
+                include_decoder_input=False,
+                create_padding_masks=False,
+            ),
+        )
+        trainer = LLMTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=cross_entropy,
+            forward_fn=PromptMaskAwareForwardFn(),
+            config=TransformerTrainingConfig(
+                total_epochs=1,
+                checkpoint_freq=1,
+                model_kwargs={"hidden_size": 128},
+                optimizer_kwargs={"lr": 0.01},
+                resume_epoch=None,
+                label_smoothing=0.0,
+                teacher_enforcing=False,
+                include_decoder_input=False,
+                create_padding_masks=False,
+            ),
+        )
+
+        batch = next(iter(loader))
+        logits, y = trainer.forward_fn(trainer.model, batch, mode="train")
+        expected_loss = cross_entropy(logits, y, pad_idx=loader.pad_idx)
+
+        train_loss = trainer.train_step(batch, loader)
+        val_loss = trainer.evaluate(loader)
+
+        self.assertAlmostEqual(train_loss, float(expected_loss.item()), places=6)
+        self.assertAlmostEqual(val_loss, float(expected_loss.item()), places=6)


### PR DESCRIPTION
## Description
Redesign the data loader related primitive classes and operations. This should allow for a cleaner separation of boundaries between the following responsibilities:

1. Per-sample transforms/tokenization -> dataset / transforms

2. Batch assembly and batch-time shaping -> collate_fn

3. Training-specific logic -> trainer / training loop / model forward

After this redesign, hopefully we can easily add different types of data loading operations like collating functions and sampling strategies etc... without tripping over ourselves.

## Tests
Updated unit tests.

Sample GPT-2 training run:
```
(ml-by-hand) ➜  ml-by-hand git:(dataloader-cleanup) ✗ python -m examples.gpt_2
2026-04-16 00:57:37,879 - INFO - 1115394 characters in the entire dataset. Sample:
First Citizen:
Before we proceed any further, hear me speak.

All:
Speak, speak.

First Citizen:
You
2026-04-16 00:57:37,880 - INFO - Loading the vocabulary from disk.
2026-04-16 00:57:37,882 - INFO - Found existing encoded data at 'training_data/bpe_3000_shakespeare_encoded_data.npz', loading it instead of re-encoding.
2026-04-16 00:57:37,883 - INFO - Vocabulary size: 3260
2026-04-16 00:57:37,883 - INFO - Encoded data length: 356417
Data length: len(train_data)=320775 len(test_data)=35642
2026-04-16 00:57:37,885 - INFO - No resume_epoch given; initializing model & optimizer from scratch.
2026-04-16 00:57:37,892 - INFO - Training GPT2 with 45.11M parameters.
Training:   0%|                    2026-04-16 00:57:53,676 - INFO - [Epoch 0]t/s]
grad_l2_norm = 1.0000
val_loss = 5.5759
train_loss = 6.4134
LR = 0.0010
2026-04-16 00:57:53,678 - INFO - Saved training metrics to training_runs/GPT2_shakespeare_mini.npz

...

2026-04-16 01:00:31,948 - INFO - Saved training metrics to training_runs/GPT2_shakespeare_mini.npz
Training:  90%|████████████████████2026-04-16 01:00:47,886 - INFO - [Epoch 9]/it]
grad_l2_norm = 0.8281
val_loss = 4.7887
train_loss = 5.2267
LR = 0.0001
2026-04-16 01:00:47,887 - INFO - Saved training metrics to training_runs/GPT2_shakespeare_mini.npz


2026-04-16 01:00:48,403 - INFO - Model:

The flisters too of Pam-hearting with a brastard.

His father, they ams a man must not thou haston my leave and the dead is here much such two exvy whater,
But we make some thing I read.

He came I may say good queen's friends,
Yourself for not shove'Tis
The bot and a floughs of the treining.
Second Servingman
```
