### PR TITLE
Performance optimizations

### DIFF
--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -509,7 +509,7 @@ class Linear(Module):
 
         # weight is a matrix of shape (input_size, output_size)
         self._parameters["weight"] = xavier_uniform(
-            Tensor(xp.zeros((input_size, output_size)))
+            Tensor(xp.zeros((input_size, output_size), dtype=xp.float32))
         )
 
         # bias is always 1-dimensional
@@ -611,13 +611,17 @@ class Conv2d(Module):
                         self.in_channels,
                         self.kernel_size,
                         self.kernel_size,
-                    )
+                    ),
+                    dtype=xp.float32,
                 )
             )
         )
         if bias:
             self._parameters["bias"] = Tensor(
-                xp.random.uniform(0.0, 1.0, (self.out_channels,))
+                xp.asarray(
+                    xp.random.uniform(0.0, 1.0, (self.out_channels,)),
+                    dtype=xp.float32,
+                )
             )
 
     def forward(self, x: Union[Tensor, ArrayLike]) -> Tensor:
@@ -881,18 +885,20 @@ class RecurrentBlock(Module):
         self.dropout = Dropout(p=dropout_prob) if dropout_prob else None
 
         self._parameters["W_xh"] = xavier_uniform(
-            Tensor(xp.zeros((input_size, hidden_size)))
+            Tensor(xp.zeros((input_size, hidden_size), dtype=xp.float32))
         )
         self._parameters["W_hh"] = xavier_uniform(
-            Tensor(xp.zeros((hidden_size, hidden_size)))
+            Tensor(xp.zeros((hidden_size, hidden_size), dtype=xp.float32))
         )
-        self._parameters["bias"] = Tensor(xp.zeros((hidden_size,)))
+        self._parameters["bias"] = Tensor(xp.zeros((hidden_size,), dtype=xp.float32))
 
         if output_size:
             self._parameters["W_hy"] = xavier_uniform(
-                Tensor(xp.zeros((hidden_size, output_size)))
+                Tensor(xp.zeros((hidden_size, output_size), dtype=xp.float32))
             )
-            self._parameters["bias_y"] = Tensor(xp.zeros((output_size,)))
+            self._parameters["bias_y"] = Tensor(
+                xp.zeros((output_size,), dtype=xp.float32)
+            )
         else:
             optional_parameters = cast(dict[str, Optional[Tensor]], self._parameters)
             optional_parameters["W_hy"] = None
@@ -920,7 +926,9 @@ class RecurrentBlock(Module):
 
         batch_size = x.shape[0]
         seq_length = x.shape[1]
-        hidden_state = Tensor(xp.zeros((batch_size, self.hidden_size)))
+        hidden_state = Tensor(
+            xp.zeros((batch_size, self.hidden_size), dtype=xp.float32)
+        )
 
         # Iterate through the sequence (or time dimension)
         for t in range(seq_length):
@@ -1006,27 +1014,29 @@ class LongShortTermMemoryBlock(Module):
         self.dropout = Dropout(p=dropout_prob) if dropout_prob else None
 
         self._parameters["W_f"] = xavier_uniform(
-            Tensor(xp.zeros((input_size + hidden_size, hidden_size)))
+            Tensor(xp.zeros((input_size + hidden_size, hidden_size), dtype=xp.float32))
         )
         self._parameters["W_i"] = xavier_uniform(
-            Tensor(xp.zeros((input_size + hidden_size, hidden_size)))
+            Tensor(xp.zeros((input_size + hidden_size, hidden_size), dtype=xp.float32))
         )
         self._parameters["W_c"] = xavier_uniform(
-            Tensor(xp.zeros((input_size + hidden_size, hidden_size)))
+            Tensor(xp.zeros((input_size + hidden_size, hidden_size), dtype=xp.float32))
         )
         self._parameters["W_o"] = xavier_uniform(
-            Tensor(xp.zeros((input_size + hidden_size, hidden_size)))
+            Tensor(xp.zeros((input_size + hidden_size, hidden_size), dtype=xp.float32))
         )
-        self._parameters["bias_f"] = Tensor(xp.zeros((hidden_size,)))
-        self._parameters["bias_i"] = Tensor(xp.zeros((hidden_size,)))
-        self._parameters["bias_c"] = Tensor(xp.zeros((hidden_size,)))
-        self._parameters["bias_o"] = Tensor(xp.zeros((hidden_size,)))
+        self._parameters["bias_f"] = Tensor(xp.zeros((hidden_size,), dtype=xp.float32))
+        self._parameters["bias_i"] = Tensor(xp.zeros((hidden_size,), dtype=xp.float32))
+        self._parameters["bias_c"] = Tensor(xp.zeros((hidden_size,), dtype=xp.float32))
+        self._parameters["bias_o"] = Tensor(xp.zeros((hidden_size,), dtype=xp.float32))
 
         if output_size:
             self._parameters["W_hy"] = xavier_uniform(
-                Tensor(xp.zeros((hidden_size, output_size)))
+                Tensor(xp.zeros((hidden_size, output_size), dtype=xp.float32))
             )
-            self._parameters["bias_y"] = Tensor(xp.zeros((output_size,)))
+            self._parameters["bias_y"] = Tensor(
+                xp.zeros((output_size,), dtype=xp.float32)
+            )
         else:
             optional_parameters = cast(dict[str, Optional[Tensor]], self._parameters)
             optional_parameters["W_hy"] = None
@@ -1066,9 +1076,13 @@ class LongShortTermMemoryBlock(Module):
         hidden_state = (
             hidden_state
             if hidden_state
-            else Tensor(xp.zeros((batch_size, self.hidden_size)))
+            else Tensor(xp.zeros((batch_size, self.hidden_size), dtype=xp.float32))
         )
-        C_t = C_t if C_t else Tensor(xp.zeros((batch_size, self.hidden_size)))
+        C_t = (
+            C_t
+            if C_t
+            else Tensor(xp.zeros((batch_size, self.hidden_size), dtype=xp.float32))
+        )
 
         # Iterate through the sequence (or time dimension)
         for t in range(seq_length):
@@ -1158,7 +1172,10 @@ class Embedding(Module):
 
         # weight.shape: (input_size, embedding_size)
         self._parameters["weight"] = Tensor(
-            xp.random.normal(shape=(input_size, embedding_size), scale=0.01),
+            xp.asarray(
+                xp.random.normal(shape=(input_size, embedding_size), scale=0.01),
+                dtype=xp.float32,
+            ),
             requires_grad=True,
         )
 
@@ -1215,8 +1232,8 @@ class LayerNorm(Module):
         """
         super().__init__(**kwargs)
         self.epsilon = epsilon
-        self._parameters["gain"] = Tensor(xp.ones((input_size,)))
-        self._parameters["bias"] = Tensor(xp.zeros((input_size,)))
+        self._parameters["gain"] = Tensor(xp.ones((input_size,), dtype=xp.float32))
+        self._parameters["bias"] = Tensor(xp.zeros((input_size,), dtype=xp.float32))
 
     def forward(self, x: Tensor) -> Tensor:
         """
@@ -1290,8 +1307,8 @@ class BatchNorm(Module):
         self.epsilon = epsilon  # small constant for numeric stability
 
         # Running stats (used for inference)
-        self.running_mean = xp.zeros(input_size)
-        self.running_var = xp.ones(input_size)
+        self.running_mean = xp.zeros(input_size, dtype=xp.float32)
+        self.running_var = xp.ones(input_size, dtype=xp.float32)
 
         # gamma and beta are learnable parameters
         # gamma is responsible for scaling the normalized input

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -534,8 +534,11 @@ class Linear(Module):
         if not isinstance(x, Tensor):
             x = Tensor(x)
 
-        logger.debug(f"{x.data.shape=}")
-        logger.debug(f"Linear forward {self._parameters['weight'].data.shape=}")
+        logger.debug("x.data.shape=%s", x.data.shape)
+        logger.debug(
+            "Linear forward weight.shape=%s",
+            self._parameters["weight"].data.shape,
+        )
 
         # this is just a linear transformation (dot matrix multiplication)
         return x @ self._parameters["weight"] + self._parameters["bias"]

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -1179,13 +1179,13 @@ class Embedding(Module):
             >>> x = Tensor(xp.array([[0, 1, 2], [3, 4, 5]]))
             >>> y = embed(x)  # Expected: (2, 3, 8)
         """
-        if not isinstance(x, Tensor):
-            x = Tensor(x)
-
         # indices.shape: (batch_size, seq_len)
         # result.shape: (batch_size, seq_len, embedding_size)
+        # Raw integer arrays do not participate in autograd, so avoid wrapping
+        # them in Tensor just to read the index values back out again.
+        indices = x.data if isinstance(x, Tensor) else x
         return self._parameters["weight"].gather(
-            index=cast(Any, cast(Any, x.data).astype(xp.int32))
+            index=cast(Any, xp.asarray(indices, dtype=xp.int32))
         )
 
 

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -23,7 +23,7 @@ from .functional import (
     tanh,
 )
 from .init import xavier_uniform
-from .tensor import Tensor
+from .tensor import Tensor, no_grad
 from .text.utils import prepare_mlx_attention_mask
 
 logger = logging.getLogger(__name__)
@@ -1708,7 +1708,8 @@ class AbstractLLMForwardFn(ABC):
         if mode == "train":
             return self.train(model, batch_data)
         elif mode == "sample":
-            return self.sample(model, batch_data)
+            with no_grad():
+                return self.sample(model, batch_data)
         else:
             raise ValueError(f"mode must be either 'train' or 'sample', got {mode}")
 

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -253,23 +253,19 @@ class Optimizer:
         """
         # Compute the global norm of all gradients
         total_norm = 0.0
-
         for param in self.model_parameters.values():
             if param.grad is not None:
                 grad_data = param.grad.data
-                total_norm += (xp.abs(grad_data) ** norm_type).sum().item()
+                total_norm += (xp.abs(grad_data) ** norm_type).sum()
 
         # Take the appropriate root of the total_norm
         total_norm = total_norm ** (1.0 / norm_type)
 
         # If total_norm is greater than max_norm, scale all gradients
-        if total_norm > max_norm:
-            scale_factor = max_norm / (
-                total_norm + 1e-10
-            )  # add small value for numerical stability
-            for param in self.model_parameters.values():
-                if param.grad is not None:
-                    param.grad.data *= scale_factor
+        scale_factor = xp.minimum(1.0, max_norm / (total_norm + 1e-10))
+        for param in self.model_parameters.values():
+            if param.grad is not None:
+                param.grad.data *= scale_factor
 
     def zero_grad(self) -> None:
         """

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -261,7 +261,10 @@ class Optimizer:
         # Take the appropriate root of the total_norm
         total_norm = total_norm ** (1.0 / norm_type)
 
-        # If total_norm is greater than max_norm, scale all gradients
+        # Clamp the scale factor instead of branching to avoid a device/host
+        # sync on the common no-clip path. This slightly relaxes strict
+        # "only clip if total_norm > max_norm" semantics because the epsilon
+        # can shrink norms that are just below max_norm.
         scale_factor = xp.minimum(1.0, max_norm / (total_norm + 1e-10))
         for param in self.model_parameters.values():
             if param.grad is not None:

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -30,6 +30,9 @@ def is_grad_enabled() -> bool:
 
 @contextmanager
 def no_grad():
+    # This context disables graph construction for Tensor ops routed through
+    # Function.apply. It does not implicitly change the default
+    # requires_grad=True behavior of direct Tensor(...) leaf construction.
     # Entering the context changes the flag for this execution context only,
     # and exiting restores the previous value. The ContextVar captures that
     # previous state so nesting and exception paths both unwind correctly
@@ -215,6 +218,9 @@ class Tensor:
             creator (Optional[Function], optional): The function that created this tensor.
                 Defaults to None if this tensor is a leaf.
             requires_grad (bool, optional): Whether this tensor requires gradients. Defaults to True.
+                Note that this default is independent of the no_grad() context;
+                callers constructing leaf tensors inside no_grad() must still
+                pass requires_grad=False explicitly if they want a non-grad leaf.
 
         Examples:
             >>> x = Tensor([1, 2, 3]) # Expected: xp.array([1., 2., 3.], dtype=float32)

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import abstractmethod
+from contextlib import contextmanager
 from typing import (
     Any,
     List,
@@ -15,6 +16,23 @@ from typing import (
 from autograd.backend import ARRAY_TYPE, Array, ArrayLike, xp
 
 logger = logging.getLogger(__name__)
+
+_grad_enabled = True
+
+
+def is_grad_enabled() -> bool:
+    return _grad_enabled
+
+
+@contextmanager
+def no_grad():
+    global _grad_enabled
+    previous = _grad_enabled
+    _grad_enabled = False
+    try:
+        yield
+    finally:
+        _grad_enabled = previous
 
 
 class Function:
@@ -117,7 +135,7 @@ class Function:
 
         # Constant-only ops never participate in backprop, so avoid retaining
         # the function and its inputs as dead graph state.
-        requires_grad = any(inp.requires_grad for inp in tensors)
+        requires_grad = is_grad_enabled() and any(inp.requires_grad for inp in tensors)
         out = Tensor(
             out_data,
             creator=func if requires_grad else None,

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -203,8 +203,9 @@ class Tensor:
         Initialize a `Tensor`.
 
         Args:
-            data (ArrayLike): The data for this tensor. It will be converted to an mx
-                of type float32.
+            data (ArrayLike): The data for this tensor. Python scalars/sequences are
+                materialized as float32 by default, while explicit backend arrays keep
+                their dtype.
             creator (Optional[Function], optional): The function that created this tensor.
                 Defaults to None if this tensor is a leaf.
             requires_grad (bool, optional): Whether this tensor requires gradients. Defaults to True.
@@ -225,11 +226,10 @@ class Tensor:
     @data.setter
     def data(self, value: ArrayLike) -> None:
         if isinstance(value, ARRAY_TYPE):
-            if getattr(value, "dtype", None) == xp.float32:
-                self._data = value
-                return
-        else:
-            self._data = xp.array(value, dtype=xp.float32)
+            # Preserve explicitly constructed backend array dtypes. This keeps
+            # the default float32 path for Python values while allowing
+            # opt-in lower precision experiments.
+            self._data = value
             return
         self._data = xp.array(value, dtype=xp.float32)
 

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -115,9 +115,14 @@ class Function:
         # Run forward pass with tensor.data already, so we don't need to get it again
         out_data = func.forward(*(inp.data for inp in tensors), **kwargs)
 
-        # Create output tensor
+        # Constant-only ops never participate in backprop, so avoid retaining
+        # the function and its inputs as dead graph state.
         requires_grad = any(inp.requires_grad for inp in tensors)
-        out = Tensor(out_data, creator=func, requires_grad=requires_grad)
+        out = Tensor(
+            out_data,
+            creator=func if requires_grad else None,
+            requires_grad=requires_grad,
+        )
         return out
 
     @staticmethod

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from abc import abstractmethod
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import (
     Any,
     List,
@@ -17,22 +18,27 @@ from autograd.backend import ARRAY_TYPE, Array, ArrayLike, xp
 
 logger = logging.getLogger(__name__)
 
-_grad_enabled = True
+# We have to ensure that this flag doesn't leak across concurrent execution.
+# A ContextVar keeps the API simple while giving each thread / async task its
+# own view of the flag, which matches how users expect nested `with no_grad():`
+_grad_enabled: ContextVar[bool] = ContextVar("grad_enabled", default=True)
 
 
 def is_grad_enabled() -> bool:
-    return _grad_enabled
+    return _grad_enabled.get()
 
 
 @contextmanager
 def no_grad():
-    global _grad_enabled
-    previous = _grad_enabled
-    _grad_enabled = False
+    # Entering the context changes the flag for this execution context only,
+    # and exiting restores the previous value. The ContextVar captures that
+    # previous state so nesting and exception paths both unwind correctly
+    # without manually tracking a stack.
+    token = _grad_enabled.set(False)
     try:
         yield
     finally:
-        _grad_enabled = previous
+        _grad_enabled.reset(token)
 
 
 class Function:
@@ -421,6 +427,10 @@ class Tensor:
         if isinstance(other, int) and other >= 0:
             if other == 0:
                 return Tensor(xp.ones_like(self.data), requires_grad=False)
+            if other == 1:
+                return (
+                    self if is_grad_enabled() and self.requires_grad else self.detach()
+                )
 
             result = self
             for _ in range(other - 1):
@@ -446,7 +456,7 @@ class Tensor:
             Tensor: This tensor, after in-place addition.
         """
         if not isinstance(other, Tensor):
-            other = Tensor(other)
+            other = Tensor(other, requires_grad=False)
 
         # Use expand for broadcasting
         broadcast_shape = xp.broadcast_shapes(self.shape, other.shape)

--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -206,7 +206,7 @@ class BytePairEncoder:
 
         logger.info(f"Vocabulary size: {len(self._unicode_to_int_vocab)}")
         logger.info(f"Encoded data length: {len(encoded_data)}")
-        logger.debug(f"Sample encoded data (first 50 tokens): {encoded_data[:50]}")
+        logger.debug("Sample encoded data (first 50 tokens): %s", encoded_data[:50])
 
         return encoded_data
 
@@ -237,7 +237,7 @@ class BytePairEncoder:
             return self._unicode_to_int_vocab, self._int_to_unicode_vocab
 
         text_chunks = self._pretokenize(input_text)
-        logger.debug(f"Text chunks: {text_chunks[:10]}")
+        logger.debug("Text chunks: %s", text_chunks[:10])
 
         word_freq = Counter()
         for chunk in text_chunks:
@@ -329,7 +329,7 @@ class BytePairEncoder:
             >>> print(token_ids)  # Outputs a list of token IDs
         """
         text_chunks = self._pretokenize(input_text)
-        logger.debug(f"Text chunks: {text_chunks[:20]}")
+        logger.debug("Text chunks: %s", text_chunks[:20])
 
         if not text_chunks:
             return []

--- a/autograd/tools/data.py
+++ b/autograd/tools/data.py
@@ -14,6 +14,7 @@ Data pipeline boundary:
 import csv
 import os
 from abc import ABC, abstractmethod
+from math import prod
 from typing import Any, Callable, Iterator, Optional, Sequence, Tuple, Union
 from urllib.request import urlopen
 
@@ -450,6 +451,9 @@ class Collator(ABC):
     def __call__(self, examples: Sequence[dict[str, Array]]) -> Any:
         pass
 
+    def batch_token_count(self, batch: Any) -> Optional[int]:
+        return None
+
 
 class PairedCollator(Collator):
     """
@@ -616,6 +620,10 @@ class LanguageModelingCollator(Collator):
             causal_mask,
         )
 
+    def batch_token_count(self, batch: Any) -> Optional[int]:
+        X_chunk, _, _, _, _, _ = batch
+        return int(prod(X_chunk.shape))
+
 
 class DataLoader:
     """
@@ -644,6 +652,11 @@ class DataLoader:
 
     def on_epoch_start(self) -> None:
         self.dataset.on_epoch_start()
+
+    def batch_token_count(self, batch: Any) -> Optional[int]:
+        if self.collate_fn is None:
+            return None
+        return self.collate_fn.batch_token_count(batch)
 
     def __iter__(self) -> Iterator[Any]:
         batch_examples = []

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -12,7 +12,7 @@ from autograd.backend import (
     eval,
     xp,
 )
-from autograd.tensor import Tensor
+from autograd.tensor import Tensor, no_grad
 from autograd.tools.config_schema import (
     GenericTrainingConfig,
     TransformerTrainingConfig,
@@ -449,54 +449,57 @@ class SimpleTrainer(AbstractTrainer):
             float: The average validation loss over the entire validation dataset.
         """
         self.model.eval()
-        total_loss: Any = 0.0
-        batch_count = 0
-        all_preds, all_targets = [], []
-        for batch_data in val_data_loader:
-            if self._max_eval_steps_reached(batch_count):
-                break
-            batch_X, batch_y = batch_data
-            y_pred = self.model(batch_X)
-            loss = self.loss_fn(y_pred, batch_y)
-            total_loss += loss.data
-            batch_count += 1
-            all_preds.append(y_pred)
-            all_targets.append(batch_y)
-        avg_val_loss = total_loss / max(batch_count, 1)
-        avg_val_loss = float(xp.to_scalar(avg_val_loss))
+        try:
+            with no_grad():
+                total_loss: Any = 0.0
+                batch_count = 0
+                all_preds, all_targets = [], []
+                for batch_data in val_data_loader:
+                    if self._max_eval_steps_reached(batch_count):
+                        break
+                    batch_X, batch_y = batch_data
+                    y_pred = self.model(batch_X)
+                    loss = self.loss_fn(y_pred, batch_y)
+                    total_loss += loss.data
+                    batch_count += 1
+                    all_preds.append(y_pred)
+                    all_targets.append(batch_y)
+                avg_val_loss = total_loss / max(batch_count, 1)
+                avg_val_loss = float(xp.to_scalar(avg_val_loss))
 
-        # Compute additional metrics for classification or regression
-        y_pred_full = xp.concatenate([p.data for p in all_preds], axis=0)
-        y_true_full = xp.concatenate(all_targets, axis=0)
+                # Compute additional metrics for classification or regression
+                y_pred_full = xp.concatenate([p.data for p in all_preds], axis=0)
+                y_true_full = xp.concatenate(all_targets, axis=0)
 
-        if self.problem_type == "classification":
-            y_pred_proc, y_true_proc = self._post_process_classification(
-                y_pred_full, y_true_full
-            )
-            acc_val = accuracy(
-                xp.array(y_pred_proc).reshape(-1),
-                xp.array(y_true_proc, dtype=xp.int32).reshape(-1),
-            )
-            self.metrics["val_accuracy"].append(acc_val)
-
-            if self.sample_predictions:
-                sample_count = min(5, len(y_pred_proc))
-                if sample_count > 0:
-                    sample_lines = [
-                        f"Predicted: {y_pred_proc[i]}\nActual: {y_true_proc[i]}"
-                        for i in range(sample_count)
-                    ]
-                    logger.info(
-                        "Sample Predictions on Validation Batch:\n"
-                        + "\n".join(sample_lines)
+                if self.problem_type == "classification":
+                    y_pred_proc, y_true_proc = self._post_process_classification(
+                        y_pred_full, y_true_full
                     )
+                    acc_val = accuracy(
+                        xp.array(y_pred_proc).reshape(-1),
+                        xp.array(y_true_proc, dtype=xp.int32).reshape(-1),
+                    )
+                    self.metrics["val_accuracy"].append(acc_val)
 
-        else:
-            mse_val = mean_squared_error(y_pred_full, y_true_full)
-            self.metrics["val_mse"].append(mse_val)
+                    if self.sample_predictions:
+                        sample_count = min(5, len(y_pred_proc))
+                        if sample_count > 0:
+                            sample_lines = [
+                                f"Predicted: {y_pred_proc[i]}\nActual: {y_true_proc[i]}"
+                                for i in range(sample_count)
+                            ]
+                            logger.info(
+                                "Sample Predictions on Validation Batch:\n"
+                                + "\n".join(sample_lines)
+                            )
 
-        self.model.train()
-        return avg_val_loss
+                else:
+                    mse_val = mean_squared_error(y_pred_full, y_true_full)
+                    self.metrics["val_mse"].append(mse_val)
+
+                return avg_val_loss
+        finally:
+            self.model.train()
 
     def _post_process_classification(
         self, y_pred: Array, y_true: Array
@@ -671,22 +674,25 @@ class LLMTrainer(AbstractTrainer):
         """
         self.model.eval()
         try:
-            total_loss: Any = 0.0
-            batch_count = 0
-            for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
-                if self._max_eval_steps_reached(batch_count):
-                    break
-                pred_probs, y = self.forward_fn(self.model, batch_data, mode="train")
-                # TODO: Decide whether validation should use the same label_smoothing setting
-                # as training, or intentionally report unsmoothed cross-entropy.
-                loss = self.loss_fn(pred_probs, y, pad_idx=val_data_loader.pad_idx)
-                total_loss += loss.data
-                batch_count += 1
-            avg_val_loss = total_loss / max(batch_count, 1)
-            avg_val_loss = float(xp.to_scalar(avg_val_loss))
-            for callback in self.eval_callbacks:
-                callback(self.model, self.forward_fn, val_data_loader, self.config)
-            return avg_val_loss
+            with no_grad():
+                total_loss: Any = 0.0
+                batch_count = 0
+                for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
+                    if self._max_eval_steps_reached(batch_count):
+                        break
+                    pred_probs, y = self.forward_fn(
+                        self.model, batch_data, mode="train"
+                    )
+                    # TODO: Decide whether validation should use the same label_smoothing setting
+                    # as training, or intentionally report unsmoothed cross-entropy.
+                    loss = self.loss_fn(pred_probs, y, pad_idx=val_data_loader.pad_idx)
+                    total_loss += loss.data
+                    batch_count += 1
+                avg_val_loss = total_loss / max(batch_count, 1)
+                avg_val_loss = float(xp.to_scalar(avg_val_loss))
+                for callback in self.eval_callbacks:
+                    callback(self.model, self.forward_fn, val_data_loader, self.config)
+                return avg_val_loss
         finally:
             self.model.train()
 

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -166,6 +166,9 @@ class AbstractTrainer(ABC):
             if self._max_steps_reached():
                 break
             loss = self.train_step(batch, data_loader)
+            # Internal contract: train_step returns a device-backed loss Tensor so
+            # the epoch loop can accumulate on device and convert to a host float
+            # only once at the end of the epoch.
             total_loss += loss.data
             if (batch_count + 1) % self.config.gradient_accumulation_steps == 0:
                 self.optimizer.step()  # increments .timestep, applies LR scheduler if present
@@ -244,6 +247,8 @@ class AbstractTrainer(ABC):
 
         Returns:
             Tensor: The computed loss tensor for the batch.
+            Note that _train_one_epoch is responsible for
+            reducing epoch loss to a Python float.
         """
         pass
 
@@ -723,6 +728,10 @@ class LLMTrainer(AbstractTrainer):
                     batch_count += 1
                 avg_val_loss = total_loss / max(batch_count, 1)
                 avg_val_loss = float(xp.to_scalar(avg_val_loss))
+                # NOTE: eval callbacks currently run inside no_grad(). That is
+                # intentional for today's qualitative inference hooks, but any
+                # future gradient-based eval callback should be moved outside
+                # this context or given an explicit contract.
                 for callback in self.eval_callbacks:
                     callback(self.model, self.forward_fn, val_data_loader, self.config)
                 return avg_val_loss

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -17,6 +17,7 @@ from autograd.tools.config_schema import (
     GenericTrainingConfig,
     TransformerTrainingConfig,
 )
+from autograd.tools.data import DataLoader
 from autograd.tools.metrics import accuracy, mean_squared_error
 from autograd.tools.model import load_checkpoint, save_checkpoint
 
@@ -70,13 +71,17 @@ class AbstractTrainer(ABC):
         self.global_step = int(self.checkpoint.get("step_count", 0))
         self.metrics = defaultdict(list)
 
-    def fit(self, train_data_loader, val_data_loader=None):
+    def fit(
+        self,
+        train_data_loader: DataLoader,
+        val_data_loader: Optional[DataLoader] = None,
+    ):
         """Performs the main training loop over the given data loaders.
 
         Args:
-            train_data_loader: An iterable or generator that yields training batches.
-            val_data_loader: (Optional) An iterable or generator that yields labeled
-                validation batches.
+            train_data_loader: Training data loader that yields training batches.
+            val_data_loader: (Optional) Validation data loader yielding validation
+                batches.
         """
         logger.info(
             f"Training {self.model.__class__.__name__} with "
@@ -86,15 +91,13 @@ class AbstractTrainer(ABC):
         while True:
             if self._max_epochs_reached(epoch) or self._max_steps_reached():
                 break
-            if hasattr(train_data_loader, "on_epoch_start"):
-                train_data_loader.on_epoch_start()
+            train_data_loader.on_epoch_start()
 
             self.model.train()
             train_loss = self._train_one_epoch(train_data_loader)
 
             if val_data_loader is not None:
-                if hasattr(val_data_loader, "on_epoch_start"):
-                    val_data_loader.on_epoch_start()
+                val_data_loader.on_epoch_start()
                 val_loss = self.evaluate(val_data_loader)
             else:
                 val_loss = None
@@ -125,7 +128,25 @@ class AbstractTrainer(ABC):
             and batch_count >= self.config.max_eval_steps
         )
 
-    def _train_one_epoch(self, data_loader) -> float:
+    def _update_progress_bar_tokens(
+        self,
+        progress_bar,
+        total_tokens: int,
+        batch_tokens: Optional[int],
+    ) -> int:
+        if batch_tokens is None:
+            return total_tokens
+        total_tokens += batch_tokens
+        if total_tokens <= 0:
+            return total_tokens
+        elapsed_s = float(progress_bar.format_dict.get("elapsed", 0.0) or 0.0)
+        postfix = {"tokens": f"{total_tokens:,}"}
+        if elapsed_s > 0.0:
+            postfix["tok/s"] = f"{total_tokens / elapsed_s:,.1f}"
+        progress_bar.set_postfix(postfix, refresh=False)
+        return total_tokens
+
+    def _train_one_epoch(self, data_loader: DataLoader) -> float:
         """Trains the model for one epoch on the provided data loader.
 
         This method handles gradient accumulation and parameter updates.
@@ -138,8 +159,10 @@ class AbstractTrainer(ABC):
         """
         total_loss: Any = 0.0
         batch_count = 0
+        total_tokens = 0
         self.optimizer.zero_grad()
-        for batch in tqdm(data_loader, desc="Training Batches", leave=False):
+        progress_bar = tqdm(data_loader, desc="Training Batches", leave=False)
+        for batch in progress_bar:
             if self._max_steps_reached():
                 break
             loss = self.train_step(batch, data_loader)
@@ -150,6 +173,10 @@ class AbstractTrainer(ABC):
                     grad_l2_norm(self.optimizer.model_parameters)
                 )
                 self.optimizer.zero_grad()
+            batch_tokens = data_loader.batch_token_count(batch)
+            total_tokens = self._update_progress_bar_tokens(
+                progress_bar, total_tokens, batch_tokens
+            )
             batch_count += 1
             self.global_step += 1
         # TODO: Decide whether to flush leftover accumulated gradients at epoch end when
@@ -245,7 +272,7 @@ class AbstractTrainer(ABC):
         logger.info(log_msg)
 
     @abstractmethod
-    def evaluate(self, val_data_loader) -> float:
+    def evaluate(self, val_data_loader: DataLoader) -> float:
         """Evaluates the model on the validation set.
 
         Args:
@@ -439,11 +466,11 @@ class SimpleTrainer(AbstractTrainer):
         loss.backward()
         return loss
 
-    def evaluate(self, val_data_loader) -> float:
+    def evaluate(self, val_data_loader: DataLoader) -> float:
         """Evaluates the model on the validation data loader.
 
         Args:
-            val_data_loader: An iterable or generator providing validation batches.
+            val_data_loader: Validation data loader providing validation batches.
 
         Returns:
             float: The average validation loss over the entire validation dataset.
@@ -662,7 +689,7 @@ class LLMTrainer(AbstractTrainer):
         loss.backward()
         return loss
 
-    def evaluate(self, val_data_loader) -> float:
+    def evaluate(self, val_data_loader: DataLoader) -> float:
         """Evaluates the model on the validation data loader for language modeling.
 
         Args:
@@ -677,7 +704,9 @@ class LLMTrainer(AbstractTrainer):
             with no_grad():
                 total_loss: Any = 0.0
                 batch_count = 0
-                for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
+                total_tokens = 0
+                progress_bar = tqdm(val_data_loader, desc="Evaluation", leave=False)
+                for batch_data in progress_bar:
                     if self._max_eval_steps_reached(batch_count):
                         break
                     pred_probs, y = self.forward_fn(
@@ -687,6 +716,10 @@ class LLMTrainer(AbstractTrainer):
                     # as training, or intentionally report unsmoothed cross-entropy.
                     loss = self.loss_fn(pred_probs, y, pad_idx=val_data_loader.pad_idx)
                     total_loss += loss.data
+                    batch_tokens = val_data_loader.batch_token_count(batch_data)
+                    total_tokens = self._update_progress_bar_tokens(
+                        progress_bar, total_tokens, batch_tokens
+                    )
                     batch_count += 1
                 avg_val_loss = total_loss / max(batch_count, 1)
                 avg_val_loss = float(xp.to_scalar(avg_val_loss))

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -136,23 +136,28 @@ class AbstractTrainer(ABC):
         Returns:
             float: The average training loss over the epoch.
         """
-        total_loss = 0.0
+        total_loss: Any = 0.0
         batch_count = 0
         self.optimizer.zero_grad()
         for batch in tqdm(data_loader, desc="Training Batches", leave=False):
             if self._max_steps_reached():
                 break
             loss = self.train_step(batch, data_loader)
-            total_loss += loss
+            total_loss += loss.data
             if (batch_count + 1) % self.config.gradient_accumulation_steps == 0:
                 self.optimizer.step()  # increments .timestep, applies LR scheduler if present
-                self.metrics["grad_l2_norm"].append(grad_l2_norm(self.model.parameters))
+                self.metrics["grad_l2_norm"].append(
+                    grad_l2_norm(self.optimizer.model_parameters)
+                )
                 self.optimizer.zero_grad()
             batch_count += 1
             self.global_step += 1
         # TODO: Decide whether to flush leftover accumulated gradients at epoch end when
         # batch_count is not divisible by gradient_accumulation_steps.
-        return total_loss / max(batch_count, 1)
+        if batch_count == 0:
+            return 0.0
+        avg_loss = total_loss / max(batch_count, 1)
+        return float(xp.to_scalar(avg_loss))
 
     def _save_checkpoint(self, epoch: int, val_loss: Optional[float]):
         """Saves a model checkpoint if the validation loss improves.
@@ -204,16 +209,14 @@ class AbstractTrainer(ABC):
         logger.info(f"Saved training metrics to {path}")
 
     @abstractmethod
-    def train_step(self, batch_data, data_loader=None) -> float:
-        """Performs a single training step and returns the loss as a float.
-
-        Subclasses must implement the forward pass, loss computation, and backward pass here.
+    def train_step(self, batch_data, data_loader=None) -> Tensor:
+        """Perform a single training step and return the device loss tensor.
 
         Args:
             batch_data: A single batch of training data.
 
         Returns:
-            float: The computed loss value for the batch.
+            Tensor: The computed loss tensor for the batch.
         """
         pass
 
@@ -418,7 +421,7 @@ class SimpleTrainer(AbstractTrainer):
             else "regression"
         )
 
-    def train_step(self, batch_data, data_loader=None) -> float:
+    def train_step(self, batch_data, data_loader=None) -> Tensor:
         """Performs a forward pass, computes the loss, and backpropagates.
 
         Note that .zero_grad() and .step() calls are in the _train_one_epoch() function
@@ -428,13 +431,13 @@ class SimpleTrainer(AbstractTrainer):
             data_loader: (Optional) The data loader, if additional context is needed.
 
         Returns:
-            float: The computed loss for this batch.
+            Tensor: The computed loss for this batch.
         """
         batch_X, batch_y = batch_data
         y_pred = self.model(batch_X)
         loss = self.loss_fn(y_pred, batch_y)
         loss.backward()
-        return float(loss.item())
+        return loss
 
     def evaluate(self, val_data_loader) -> float:
         """Evaluates the model on the validation data loader.
@@ -446,7 +449,7 @@ class SimpleTrainer(AbstractTrainer):
             float: The average validation loss over the entire validation dataset.
         """
         self.model.eval()
-        total_loss = 0.0
+        total_loss: Any = 0.0
         batch_count = 0
         all_preds, all_targets = [], []
         for batch_data in val_data_loader:
@@ -455,11 +458,12 @@ class SimpleTrainer(AbstractTrainer):
             batch_X, batch_y = batch_data
             y_pred = self.model(batch_X)
             loss = self.loss_fn(y_pred, batch_y)
-            total_loss += float(loss.item())
+            total_loss += loss.data
             batch_count += 1
             all_preds.append(y_pred)
             all_targets.append(batch_y)
         avg_val_loss = total_loss / max(batch_count, 1)
+        avg_val_loss = float(xp.to_scalar(avg_val_loss))
 
         # Compute additional metrics for classification or regression
         y_pred_full = xp.concatenate([p.data for p in all_preds], axis=0)
@@ -630,7 +634,7 @@ class LLMTrainer(AbstractTrainer):
         self.forward_fn = forward_fn
         self.eval_callbacks = list(eval_callbacks or [])
 
-    def train_step(self, batch_data, data_loader) -> float:
+    def train_step(self, batch_data, data_loader) -> Tensor:
         """Performs a forward pass for language modeling, computes the loss, and backpropagates.
 
         This method expects batch_data in the form:
@@ -643,7 +647,7 @@ class LLMTrainer(AbstractTrainer):
             data_loader: The data loader, used here to get pad_idx (padding index).
 
         Returns:
-            float: The computed loss for this batch.
+            Tensor: The computed loss for this batch.
         """
         pred_probs, y = self.forward_fn(self.model, batch_data, mode="train")
         loss = self.loss_fn(
@@ -653,7 +657,7 @@ class LLMTrainer(AbstractTrainer):
             label_smoothing=self.config.label_smoothing,
         )
         loss.backward()
-        return float(loss.item())
+        return loss
 
     def evaluate(self, val_data_loader) -> float:
         """Evaluates the model on the validation data loader for language modeling.
@@ -667,7 +671,7 @@ class LLMTrainer(AbstractTrainer):
         """
         self.model.eval()
         try:
-            total_loss = 0.0
+            total_loss: Any = 0.0
             batch_count = 0
             for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
                 if self._max_eval_steps_reached(batch_count):
@@ -676,9 +680,10 @@ class LLMTrainer(AbstractTrainer):
                 # TODO: Decide whether validation should use the same label_smoothing setting
                 # as training, or intentionally report unsmoothed cross-entropy.
                 loss = self.loss_fn(pred_probs, y, pad_idx=val_data_loader.pad_idx)
-                total_loss += float(loss.item())
+                total_loss += loss.data
                 batch_count += 1
             avg_val_loss = total_loss / max(batch_count, 1)
+            avg_val_loss = float(xp.to_scalar(avg_val_loss))
             for callback in self.eval_callbacks:
                 callback(self.model, self.forward_fn, val_data_loader, self.config)
             return avg_val_loss

--- a/test/autograd/performance_test.py
+++ b/test/autograd/performance_test.py
@@ -1,4 +1,5 @@
 import gc
+import math
 import os
 import time
 from collections.abc import Callable, Mapping, Sequence
@@ -12,6 +13,7 @@ from autograd import functional, nn, optim
 from autograd.backend import IS_CUPY, NAME, xp
 from autograd.backend import eval as backend_eval
 from autograd.tensor import Tensor
+from autograd.tools.config_schema import TransformerTrainingConfig
 from autograd.tools.data import (
     DataLoader,
     LanguageModelingCollator,
@@ -19,7 +21,8 @@ from autograd.tools.data import (
     PairedIterableDataset,
     TokenSequenceDataset,
 )
-from examples.gpt_2 import GPT2
+from autograd.tools.trainer import LLMTrainer
+from examples.gpt_2 import GPT2, GPT2ForwardFn
 
 
 @dataclass(frozen=True)
@@ -37,6 +40,87 @@ class CallProfile:
     device_active_delta_bytes: Optional[int]
     device_cache_delta_bytes: Optional[int]
     device_peak_delta_bytes: Optional[int]
+
+
+@dataclass(frozen=True)
+class WorkEstimate:
+    node_count: int
+    saved_activation_bytes: int
+    parameter_count: int
+    parameter_bytes: int
+    gradient_bytes: int
+    optimizer_state_bytes: int
+    static_resident_bytes: int
+    logical_flops_per_step: int
+    logical_bytes_per_step: int
+
+
+BENCHMARK_RANDOM_SEED = 42
+
+BENCHMARK_WARMUP_STEPS_ENV = "AUTOGRAD_PERF_WARMUP_STEPS"
+BENCHMARK_MIN_STEPS_ENV = "AUTOGRAD_PERF_MIN_STEPS"
+BENCHMARK_MIN_SECONDS_ENV = "AUTOGRAD_PERF_MIN_SECONDS"
+
+DEFAULT_BENCHMARK_WARMUP_STEPS = 5
+DEFAULT_BENCHMARK_MIN_STEPS = 10
+DEFAULT_BENCHMARK_MIN_SECONDS = 1.0
+
+MLP_CASE_NAME = "Complex MLP Model"
+MLP_MODEL_KWARGS = {
+    "input_size": 1024,
+    "hidden_size": 512,
+    "num_layers": 4,
+    "output_size": 10,
+}
+MLP_BATCH_KWARGS = {
+    "input_shape": (1024, 1024),
+    "num_classes": 10,
+}
+
+CNN_CASE_NAME = "Deep CNN Model"
+CNN_MODEL_KWARGS = {
+    "input_channels": 3,
+    "image_size": 24,
+    "num_classes": 20,
+}
+CNN_BATCH_KWARGS = {
+    "input_shape": (256, 3, 24, 24),
+    "num_classes": 20,
+}
+
+GPT_CASE_NAME = "Mini GPT-2 Model"
+GPT_LOADER_KWARGS = {
+    "batch_size": 16,
+    "seq_len": 768,
+    "vocab_size": 1024 * 10,
+}
+GPT_MODEL_KWARGS = {
+    "vocab_size": 1024 * 10,
+    "hidden_size": 128 * 6,
+    "num_attention_heads": 6,
+    "max_seq_len": 768,
+    "dropout_prob": 0.1,
+    "num_decoder_layers": 6,
+}
+GPT_OPTIMIZER_KWARGS = {
+    "lr": 1e-3,
+    "beta2": 0.99,
+    "max_grad_norm": 1.0,
+    "weight_decay": 0.1,
+}
+GPT_TRAINER_CONFIG_KWARGS = {
+    "max_epochs": 1,
+    "checkpoint_freq": 1,
+    "global_batch_size": 16,
+    "micro_batch_size": 16,
+    "model_kwargs": GPT_MODEL_KWARGS,
+    "optimizer_kwargs": GPT_OPTIMIZER_KWARGS,
+    "resume_epoch": None,
+    "teacher_enforcing": False,
+    "include_decoder_input": False,
+    "create_padding_masks": False,
+    "label_smoothing": 0.1,
+}
 
 
 def _flatten_sync_targets(value):
@@ -150,6 +234,10 @@ def _delta(end, start):
     return end - start
 
 
+def _peak_over_start_bytes(start: MemorySnapshot, end: MemorySnapshot):
+    return _delta(end.device_peak_bytes, start.device_peak_bytes)
+
+
 def measure_call(
     fn: Callable[[], object],
     *,
@@ -198,7 +286,7 @@ def _format_memory_value(num_bytes: int) -> str:
         return f"{num_bytes:.2f} B"
     if abs_bytes < 1024**2:
         return f"{num_bytes / float(1024):.2f} KiB"
-    if abs_bytes < 1000 * 1024**2:
+    if abs_bytes < 1024**3:
         return f"{num_bytes / float(1024**2):.2f} MiB"
     return f"{num_bytes / float(1024**3):.2f} GiB"
 
@@ -208,6 +296,250 @@ def _format_duration_value(duration_s: float) -> str:
     if abs_seconds < 1.0:
         return f"{duration_s * 1000.0:.3f} ms"
     return f"{duration_s:.3f} s"
+
+
+def _format_count_value(count: int) -> str:
+    abs_count = abs(count)
+    if abs_count < 1_000:
+        return str(count)
+    if abs_count < 1_000_000:
+        return f"{count / 1_000.0:.2f} K"
+    if abs_count < 1_000_000_000:
+        return f"{count / 1_000_000.0:.2f} M"
+    if abs_count < 1_000_000_000_000:
+        return f"{count / 1_000_000_000.0:.2f} G"
+    return f"{count / 1_000_000_000_000.0:.2f} T"
+
+
+def _format_ratio_value(value: float) -> str:
+    if value < 10.0:
+        return f"{value:.2f}"
+    if value < 100.0:
+        return f"{value:.1f}"
+    return f"{value:.0f}"
+
+
+def _format_compact_number(value: float) -> str:
+    if math.isnan(value):
+        return "nan"
+
+    abs_value = abs(value)
+    if abs_value >= 1_000:
+        precision = 0
+    elif abs_value >= 100:
+        precision = 1
+    elif abs_value >= 1:
+        precision = 2
+    elif abs_value == 0:
+        precision = 0
+    else:
+        precision = 3
+
+    formatted = f"{value:,.{precision}f}"
+    if precision == 0:
+        return formatted
+    return formatted.rstrip("0").rstrip(".")
+
+
+def _format_compact_measurement_value(text: str) -> str:
+    value_text, separator, unit = text.partition(" ")
+    if not separator:
+        return text
+
+    try:
+        value = float(value_text.replace(",", ""))
+    except ValueError:
+        return text
+    return f"{_format_compact_number(value)} {unit}"
+
+
+def compute_stats(values):
+    vals = [float(value) for value in values if value is not None]
+    if not vals:
+        return {
+            "mean": float("nan"),
+            "std": float("nan"),
+            "min": float("nan"),
+            "max": float("nan"),
+            "median": float("nan"),
+            "p90": float("nan"),
+        }
+
+    vals.sort()
+
+    def _pct(p):
+        if len(vals) == 1:
+            return vals[0]
+        index = (len(vals) - 1) * p
+        low = math.floor(index)
+        high = math.ceil(index)
+        if low == high:
+            return vals[low]
+        weight = index - low
+        return vals[low] + (vals[high] - vals[low]) * weight
+
+    mean = sum(vals) / len(vals)
+    variance = sum((value - mean) ** 2 for value in vals) / len(vals)
+    return {
+        "mean": mean,
+        "std": math.sqrt(variance),
+        "min": vals[0],
+        "max": vals[-1],
+        "median": _pct(0.5),
+        "p90": _pct(0.9),
+    }
+
+
+def _numel(shape: tuple[int, ...]) -> int:
+    total = 1
+    for dim in shape:
+        total *= int(dim)
+    return total
+
+
+def _array_nbytes(array) -> int:
+    nbytes = getattr(array, "nbytes", None)
+    if nbytes is not None:
+        return int(nbytes)
+
+    dtype = getattr(array, "dtype", None)
+    itemsize = getattr(dtype, "itemsize", None)
+    if itemsize is None:
+        itemsize = getattr(array, "itemsize", None)
+    if itemsize is None:
+        return 0
+    return _numel(tuple(getattr(array, "shape", ()))) * int(itemsize)
+
+
+_GRAPH_ALIAS_OPS = {"Expand", "Permute", "Reshape", "Transpose", "View"}
+
+
+def _estimate_matmul_flops(
+    x_shape: tuple[int, ...],
+    y_shape: tuple[int, ...],
+    out_shape: tuple[int, ...],
+) -> int:
+    if not x_shape or not y_shape:
+        return 0
+    reduction_dim = int(x_shape[-1])
+    return 2 * _numel(out_shape) * reduction_dim
+
+
+def _estimate_forward_node_flops(tensor: Tensor) -> int:
+    creator = tensor.creator
+    if creator is None:
+        return 0
+
+    op_name = type(creator).__name__
+    output_numel = _numel(tensor.shape)
+    if op_name in {"Add", "IAdd", "Mul", "Pow", "Relu", "Sigmoid", "Sqrt", "Tanh"}:
+        return output_numel
+    if op_name == "Gelu":
+        return 8 * output_numel
+    if op_name == "Matmul":
+        return _estimate_matmul_flops(
+            creator.tensors[0].shape,
+            creator.tensors[1].shape,
+            tensor.shape,
+        )
+    if op_name in {"Mean", "Sum"}:
+        return _numel(creator.tensors[0].shape)
+    if op_name == "Max":
+        return max(0, _numel(creator.tensors[0].shape) - output_numel)
+    if op_name == "Softmax":
+        return 5 * output_numel
+    if op_name == "CrossEntropy":
+        return 5 * _numel(creator.tensors[0].shape)
+    return 0
+
+
+def _estimate_forward_node_logical_bytes(tensor: Tensor) -> int:
+    creator = tensor.creator
+    if creator is None:
+        return 0
+
+    if type(creator).__name__ in _GRAPH_ALIAS_OPS:
+        return 0
+
+    input_bytes = 0
+    for parent in creator.tensors:
+        if parent is not None:
+            input_bytes += _array_nbytes(parent.data)
+    return input_bytes + _array_nbytes(tensor.data)
+
+
+def estimate_step_work(
+    *,
+    loss: Tensor,
+    model,
+    optimizer,
+) -> WorkEstimate:
+    parameter_tensors = tuple(model.parameters.values())
+    parameter_ids = {id(param) for param in parameter_tensors}
+
+    node_count = 0
+    saved_activation_bytes = 0
+    forward_flops = 0
+    forward_logical_bytes = 0
+    visited: set[Tensor] = set()
+    stack = [loss]
+
+    while stack:
+        tensor = stack.pop()
+        if tensor in visited:
+            continue
+        visited.add(tensor)
+
+        if tensor.creator is not None:
+            node_count += 1
+            forward_flops += _estimate_forward_node_flops(tensor)
+            forward_logical_bytes += _estimate_forward_node_logical_bytes(tensor)
+            if (
+                id(tensor) not in parameter_ids
+                and type(tensor.creator).__name__ not in _GRAPH_ALIAS_OPS
+            ):
+                saved_activation_bytes += _array_nbytes(tensor.data)
+
+            for parent in tensor.creator.tensors:
+                if parent is not None and parent.requires_grad:
+                    stack.append(parent)
+
+    parameter_count = sum(_numel(param.shape) for param in parameter_tensors)
+    parameter_bytes = sum(_array_nbytes(param.data) for param in parameter_tensors)
+    gradient_bytes = parameter_bytes
+    if isinstance(optimizer, optim.SGD):
+        optimizer_state_bytes = 0
+        optimizer_step_bytes = 3 * parameter_bytes
+        optimizer_step_flops = parameter_count
+    elif isinstance(optimizer, optim.Adam):
+        optimizer_state_bytes = 2 * parameter_bytes
+        optimizer_step_bytes = 7 * parameter_bytes
+        optimizer_step_flops = 10 * parameter_count
+    else:
+        optimizer_state_bytes = 0
+        optimizer_step_bytes = 0
+        optimizer_step_flops = 0
+
+    static_resident_bytes = parameter_bytes + gradient_bytes + optimizer_state_bytes
+    backward_logical_bytes = (
+        forward_logical_bytes + saved_activation_bytes + gradient_bytes
+    )
+    logical_bytes_per_step = (
+        forward_logical_bytes + backward_logical_bytes + optimizer_step_bytes
+    )
+    logical_flops_per_step = 3 * forward_flops + optimizer_step_flops
+
+    return WorkEstimate(
+        node_count=node_count,
+        saved_activation_bytes=saved_activation_bytes,
+        parameter_count=parameter_count,
+        parameter_bytes=parameter_bytes,
+        gradient_bytes=gradient_bytes,
+        optimizer_state_bytes=optimizer_state_bytes,
+        static_resident_bytes=static_resident_bytes,
+        logical_flops_per_step=logical_flops_per_step,
+        logical_bytes_per_step=logical_bytes_per_step,
+    )
 
 
 class ComplexMLP(nn.Module):
@@ -288,6 +620,33 @@ class DeepCNN(nn.Module):
 
 
 class CIPipelinePerformanceTest(TestCase):
+    def _estimate_case_work(self, *, model, optimizer, loss_builder):
+        loss = loss_builder()
+        return estimate_step_work(
+            loss=loss,
+            model=model,
+            optimizer=optimizer,
+        )
+
+    def _benchmark_config(self):
+        return {
+            "warmup_steps": int(
+                os.getenv(
+                    BENCHMARK_WARMUP_STEPS_ENV,
+                    str(DEFAULT_BENCHMARK_WARMUP_STEPS),
+                )
+            ),
+            "min_measure_steps": int(
+                os.getenv(BENCHMARK_MIN_STEPS_ENV, str(DEFAULT_BENCHMARK_MIN_STEPS))
+            ),
+            "min_measure_seconds": float(
+                os.getenv(
+                    BENCHMARK_MIN_SECONDS_ENV,
+                    str(DEFAULT_BENCHMARK_MIN_SECONDS),
+                )
+            ),
+        }
+
     def _cleanup_benchmark_case(self):
         synchronize_trees()
         gc.collect()
@@ -303,7 +662,6 @@ class CIPipelinePerformanceTest(TestCase):
         model,
         batch,
         throughput_unit,
-        total_epochs,
         optimizer_lr=0.01,
         loss_fn=functional.cross_entropy,
     ):
@@ -313,7 +671,6 @@ class CIPipelinePerformanceTest(TestCase):
                 model=model,
                 model_inputs=model_inputs,
                 targets=targets,
-                total_epochs=total_epochs,
                 throughput_count=throughput_count,
                 throughput_unit=throughput_unit,
                 optimizer_lr=optimizer_lr,
@@ -351,17 +708,18 @@ class CIPipelinePerformanceTest(TestCase):
             int(batch_inputs.shape[0]),
         )
 
-    def _build_causal_lm_batch(
+    def _build_causal_lm_loader(
         self,
         *,
         batch_size: int,
         seq_len: int,
         vocab_size: int,
+        num_batches: int = 1,
     ):
-        """Materialize one causal LM batch via the repo token dataset/collator path."""
+        """Materialize a causal LM data loader for trainer-path benchmarks."""
         token_sequences = [
             xp.random.randint(2, vocab_size, (seq_len + 1,), dtype=xp.int32)
-            for _ in range(batch_size)
+            for _ in range(batch_size * num_batches)
         ]
         loader = DataLoader(
             dataset=TokenSequenceDataset(
@@ -377,16 +735,9 @@ class CIPipelinePerformanceTest(TestCase):
                 create_padding_masks=False,
             ),
         )
-        inputs, _, targets, _, _, causal_mask = next(iter(loader))
-        return (
-            (
-                # GPT2 expects token IDs plus an additive causal mask.
-                Tensor(inputs, requires_grad=False),
-                Tensor(causal_mask, requires_grad=False),
-            ),
-            targets,
-            int(inputs.shape[0] * inputs.shape[1]),
-        )
+        first_batch = next(iter(loader))
+        inputs = first_batch[0]
+        return loader, first_batch, int(inputs.shape[0] * inputs.shape[1])
 
     def _run_benchmark_case(
         self,
@@ -394,69 +745,117 @@ class CIPipelinePerformanceTest(TestCase):
         model,
         model_inputs,
         targets,
-        total_epochs,
         throughput_count,
         throughput_unit,
         optimizer_lr=0.01,
         loss_fn=functional.cross_entropy,
     ):
+        model.train()
         optimizer = optim.SGD(model.parameters, lr=optimizer_lr)
+        work = self._estimate_case_work(
+            model=model,
+            optimizer=optimizer,
+            loss_builder=lambda: loss_fn(model(*model_inputs), targets),
+        )
+        optimizer.zero_grad()
+
+        def _run_training_step():
+            y_pred = model(*model_inputs)
+            loss = loss_fn(y_pred, targets)
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+            return {"loss": loss, "params": tuple(model.parameters.values())}
+
+        return self._measure_training_step_case(
+            throughput_count=throughput_count,
+            throughput_unit=throughput_unit,
+            benchmark_fn=_run_training_step,
+            sync_targets=lambda result: (result["loss"], result["params"]),
+            work=work,
+        )
+
+    def _run_trainer_benchmark_case(
+        self,
+        *,
+        trainer,
+        batch_data,
+        data_loader,
+        throughput_count,
+        throughput_unit,
+        work,
+    ):
+        trainer.model.train()
+        trainer.optimizer.zero_grad()
+
+        def _run_training_step():
+            trainer.optimizer.zero_grad()
+            loss = trainer.train_step(batch_data, data_loader)
+            trainer.optimizer.step()
+            trainer.optimizer.zero_grad()
+            return {
+                "loss": loss,
+                "params": tuple(trainer.optimizer.model_parameters.values()),
+            }
+
+        return self._measure_training_step_case(
+            throughput_count=throughput_count,
+            throughput_unit=throughput_unit,
+            benchmark_fn=_run_training_step,
+            sync_targets=lambda result: (result["loss"], result["params"]),
+            work=work,
+        )
+
+    def _measure_training_step_case(
+        self,
+        *,
+        throughput_count,
+        throughput_unit,
+        benchmark_fn,
+        sync_targets,
+        work,
+    ):
+        config = self._benchmark_config()
         metrics = {
-            "forward_times": [],
-            "backward_times": [],
-            "update_times": [],
             "step_times": [],
             "throughput_per_second": [],
+            "achieved_gflops": [],
+            "achieved_gbps": [],
             "rss_deltas": [],
             "device_active_deltas": [],
             "device_cache_deltas": [],
-            "device_peak_deltas": [],
+            "device_peaks": [],
+            "device_peak_over_start_deltas": [],
         }
 
-        def _loss_and_backward(y_pred):
-            loss = loss_fn(y_pred, targets)
-            loss.backward()
-            grads = [p.grad for p in model.parameters.values() if p.grad is not None]
-            return {"loss": loss, "grads": grads}
+        for _ in range(config["warmup_steps"]):
+            _, _ = measure_call(benchmark_fn, sync_trees=sync_targets)
 
-        def _optimizer_step():
-            optimizer.step()
-            optimizer.zero_grad()
-            return tuple(model.parameters.values())
-
-        # Warm-up iterations (not timed)
-        for _ in range(2):
-            y_pred, _ = measure_call(lambda: model(*model_inputs))
-            _, _ = measure_call(
-                lambda: _loss_and_backward(y_pred),
-                sync_trees=lambda result: (result["loss"], result["grads"]),
-            )
-            _, _ = measure_call(_optimizer_step)
-
-        # Actual performance measurements
-        for _ in range(total_epochs):
+        measured_seconds = 0.0
+        while (
+            len(metrics["step_times"]) < config["min_measure_steps"]
+            or measured_seconds < config["min_measure_seconds"]
+        ):
             synchronize_trees()
             reset_device_peak_memory()
             step_start = capture_memory_snapshot()
-            y_pred, forward_profile = measure_call(lambda: model(*model_inputs))
-            _, backward_profile = measure_call(
-                lambda: _loss_and_backward(y_pred),
-                sync_trees=lambda result: (result["loss"], result["grads"]),
-            )
-            _, update_profile = measure_call(_optimizer_step)
+            _, profile = measure_call(benchmark_fn, sync_trees=sync_targets)
             synchronize_trees()
             step_end = capture_memory_snapshot()
 
-            step_elapsed = (
-                forward_profile.elapsed_s
-                + backward_profile.elapsed_s
-                + update_profile.elapsed_s
+            metrics["step_times"].append(profile.elapsed_s)
+            measured_seconds += profile.elapsed_s
+            metrics["throughput_per_second"].append(
+                throughput_count / profile.elapsed_s
             )
-            metrics["forward_times"].append(forward_profile.elapsed_s)
-            metrics["backward_times"].append(backward_profile.elapsed_s)
-            metrics["update_times"].append(update_profile.elapsed_s)
-            metrics["step_times"].append(step_elapsed)
-            metrics["throughput_per_second"].append(throughput_count / step_elapsed)
+            if work.logical_flops_per_step > 0:
+                metrics["achieved_gflops"].append(
+                    work.logical_flops_per_step / profile.elapsed_s / 1e9
+                )
+            if work.logical_bytes_per_step > 0:
+                metrics["achieved_gbps"].append(
+                    work.logical_bytes_per_step / profile.elapsed_s / 1e9
+                )
             metrics["rss_deltas"].append(step_end.rss_bytes - step_start.rss_bytes)
             metrics["device_active_deltas"].append(
                 _delta(step_end.device_active_bytes, step_start.device_active_bytes)
@@ -464,91 +863,133 @@ class CIPipelinePerformanceTest(TestCase):
             metrics["device_cache_deltas"].append(
                 _delta(step_end.device_cache_bytes, step_start.device_cache_bytes)
             )
-            metrics["device_peak_deltas"].append(step_end.device_peak_bytes)
+            metrics["device_peaks"].append(step_end.device_peak_bytes)
+            metrics["device_peak_over_start_deltas"].append(
+                _peak_over_start_bytes(step_start, step_end)
+            )
 
-        return self._summarize_metrics(metrics, throughput_unit)
+        return self._summarize_metrics(
+            metrics=metrics,
+            throughput_unit=throughput_unit,
+            work=work,
+            measured_steps=len(metrics["step_times"]),
+            measured_seconds=measured_seconds,
+        )
 
-    def _compute_stats(self, metrics_list):
-        """Compute mean, std, min, max statistics for a given list of values."""
-        metrics_array = xp.asarray(metrics_list, dtype=xp.float32)
-        return {
-            "mean": float(xp.mean(metrics_array)),
-            "std": float(xp.std(metrics_array)),
-            "min": float(xp.min(metrics_array)),
-            "max": float(xp.max(metrics_array)),
-        }
+    def _scalar_stats(self, values):
+        return compute_stats(values)
 
     def _duration_stats(self, values):
-        stats = self._compute_stats(values)
+        stats = self._scalar_stats(values)
         return {key: _format_duration_value(value) for key, value in stats.items()}
 
     def _byte_stats(self, values):
-        stats = self._compute_stats(values)
+        stats = self._scalar_stats(values)
         return {
             key: _format_memory_value(int(round(value))) for key, value in stats.items()
         }
 
-    def _summarize_metrics(self, metrics, throughput_unit):
-        timing_summary = {
-            "forward": self._duration_stats(metrics["forward_times"]),
-            "backward": self._duration_stats(metrics["backward_times"]),
-            "optimizer_update": self._duration_stats(metrics["update_times"]),
-            "training_step": self._duration_stats(metrics["step_times"]),
+    def _rate_stats(self, values, unit):
+        stats = self._scalar_stats(values)
+        return {
+            "unit": unit,
+            **{
+                key: (round(value, 2) if not math.isnan(value) else value)
+                for key, value in stats.items()
+            },
         }
-        throughput_summary = self._compute_stats(metrics["throughput_per_second"])
-        throughput_summary = {
-            "unit": f"{throughput_unit}/s",
-            "mean": round(throughput_summary["mean"], 2),
-            "std": round(throughput_summary["std"], 2),
-            "min": round(throughput_summary["min"], 2),
-            "max": round(throughput_summary["max"], 2),
+
+    def _format_work_summary(self, work: WorkEstimate):
+        return {
+            "parameters": _format_count_value(work.parameter_count),
+            "parameter_bytes": _format_memory_value(work.parameter_bytes),
+            "gradient_bytes": _format_memory_value(work.gradient_bytes),
+            "optimizer_state_bytes": _format_memory_value(work.optimizer_state_bytes),
+            "static_resident_bytes": _format_memory_value(work.static_resident_bytes),
+            "forward_graph_nodes": str(work.node_count),
+            "saved_activation_bytes": _format_memory_value(work.saved_activation_bytes),
+            "logical_flops_per_step": _format_count_value(work.logical_flops_per_step),
+            "logical_bytes_per_step": _format_memory_value(work.logical_bytes_per_step),
+            "arithmetic_intensity": _format_ratio_value(
+                work.logical_flops_per_step / max(work.logical_bytes_per_step, 1)
+            ),
         }
+
+    def _summarize_metrics(
+        self,
+        *,
+        metrics,
+        throughput_unit,
+        work,
+        measured_steps,
+        measured_seconds,
+    ):
         memory_summary = {
             "host_rss_delta": self._byte_stats(metrics["rss_deltas"]),
         }
         for metric_suffix, values in (
             ("device_active_delta", metrics["device_active_deltas"]),
             ("device_cache_delta", metrics["device_cache_deltas"]),
-            ("device_peak_delta", metrics["device_peak_deltas"]),
+            ("device_peak", metrics["device_peaks"]),
+            ("device_peak_over_start", metrics["device_peak_over_start_deltas"]),
         ):
             values = [value for value in values if value is not None]
             if values:
                 memory_summary[f"{NAME}_{metric_suffix}"] = self._byte_stats(values)
+
         return {
-            "timing": timing_summary,
-            "throughput": throughput_summary,
+            "measurement": {
+                "steps": measured_steps,
+                "seconds": round(measured_seconds, 3),
+            },
+            "timing": {
+                "training_step": self._duration_stats(metrics["step_times"]),
+            },
+            "throughput": self._rate_stats(
+                metrics["throughput_per_second"], f"{throughput_unit}/s"
+            ),
+            "efficiency": {
+                "achieved_gflops": self._rate_stats(
+                    metrics["achieved_gflops"], "GFLOP/s"
+                ),
+                "achieved_gbps": self._rate_stats(metrics["achieved_gbps"], "GB/s"),
+            },
             "memory": memory_summary,
+            "work": self._format_work_summary(work),
         }
 
     def _summary_row(self, case_name, case_metrics):
         row = {
             "case": case_name,
-            "step_mean": case_metrics["timing"]["training_step"]["mean"],
-            "step_std": case_metrics["timing"]["training_step"]["std"],
-            "throughput": (
-                f"{case_metrics['throughput']['mean']} "
-                f"{case_metrics['throughput']['unit']}"
+            "step_p50": _format_compact_measurement_value(
+                case_metrics["timing"]["training_step"]["median"]
             ),
-            "host_rss_delta_mean": case_metrics["memory"]["host_rss_delta"]["mean"],
+            "step_p90": _format_compact_measurement_value(
+                case_metrics["timing"]["training_step"]["p90"]
+            ),
+            "achieved_gflops": (
+                f"{_format_compact_number(case_metrics['efficiency']['achieved_gflops']['median'])} "
+                f"{case_metrics['efficiency']['achieved_gflops']['unit']}"
+            ),
+            "node_count": case_metrics["work"]["forward_graph_nodes"],
+            "static_resident": case_metrics["work"]["static_resident_bytes"],
         }
-        peak_key = f"{NAME}_device_peak_delta"
-        if peak_key in case_metrics["memory"]:
-            row[f"{NAME}_device_peak_delta_mean"] = case_metrics["memory"][peak_key][
-                "mean"
-            ]
+        peak_over_start_key = f"{NAME}_device_peak_over_start"
+        if peak_over_start_key in case_metrics["memory"]:
+            row["peak_over_start"] = case_metrics["memory"][peak_over_start_key]["mean"]
         return row
 
     def _format_summary_table(self, rows):
         columns = [
             ("case", "Case"),
-            ("step_mean", "Step Mean"),
-            ("step_std", "Step Std"),
-            ("throughput", "Throughput"),
-            ("host_rss_delta_mean", "Host RSS Delta"),
+            ("step_p50", "Step P50"),
+            ("step_p90", "Step P90"),
+            ("achieved_gflops", "GFLOP/s"),
+            ("node_count", "Node Counts"),
+            ("static_resident", "Static Memory"),
         ]
-        peak_key = f"{NAME}_device_peak_delta_mean"
-        if any(peak_key in row for row in rows):
-            columns.append((peak_key, f"{NAME} Peak Delta"))
+        if any("peak_over_start" in row for row in rows):
+            columns.append(("peak_over_start", "Memory Peak Over Start"))
 
         widths = {}
         for key, header in columns:
@@ -572,68 +1013,69 @@ class CIPipelinePerformanceTest(TestCase):
         Measure step throughput and memory for representative MLP, CNN, and GPT-2
         training steps on the resolved backend.
         """
-        xp.random.seed(42)
-        total_epochs = 10
+        xp.random.seed(BENCHMARK_RANDOM_SEED)
         results = {
             "backend": NAME,
-            "measurement_epochs": total_epochs,
+            "benchmark_config": self._benchmark_config(),
             "cases": {},
         }
         summary_rows = []
         self._record_benchmark_case(
             results,
             summary_rows,
-            case_name="Complex MLP Model",
-            model=ComplexMLP(
-                input_size=1024,
-                hidden_size=512,
-                num_layers=4,
-                output_size=10,
-            ),
-            batch=self._build_classification_batch(
-                input_shape=(1024, 1024),
-                num_classes=10,
-            ),
-            total_epochs=total_epochs,
+            case_name=MLP_CASE_NAME,
+            model=ComplexMLP(**MLP_MODEL_KWARGS),
+            batch=self._build_classification_batch(**MLP_BATCH_KWARGS),
             throughput_unit="examples",
         )
         self._record_benchmark_case(
             results,
             summary_rows,
-            case_name="Deep CNN Model",
-            model=DeepCNN(
-                input_channels=3,
-                image_size=24,
-                num_classes=20,
-            ),
-            batch=self._build_classification_batch(
-                input_shape=(256, 3, 24, 24),
-                num_classes=20,
-            ),
-            total_epochs=total_epochs,
+            case_name=CNN_CASE_NAME,
+            model=DeepCNN(**CNN_MODEL_KWARGS),
+            batch=self._build_classification_batch(**CNN_BATCH_KWARGS),
             throughput_unit="examples",
         )
-        self._record_benchmark_case(
-            results,
-            summary_rows,
-            case_name="Mini GPT-2 Model",
-            model=GPT2(
-                vocab_size=1024 * 10,
-                hidden_size=128 * 6,
-                num_attention_heads=6,
-                max_seq_len=768,
-                dropout_prob=0.1,
-                num_decoder_layers=6,
-            ),
-            batch=self._build_causal_lm_batch(
-                batch_size=8,
-                seq_len=768,
-                vocab_size=1024 * 10,
-            ),
-            total_epochs=total_epochs,
-            throughput_unit="tokens",
-            optimizer_lr=1e-3,
+        trainer_loader, trainer_batch, trainer_throughput_count = (
+            self._build_causal_lm_loader(**GPT_LOADER_KWARGS)
+        )
+        llm_trainer = LLMTrainer(
+            model_cls=GPT2,
+            optimizer_cls=optim.Adam,
             loss_fn=functional.cross_entropy,
+            forward_fn=GPT2ForwardFn(),
+            config=TransformerTrainingConfig(**GPT_TRAINER_CONFIG_KWARGS),
         )
+        llm_trainer.model.train()
+        trainer_work = self._estimate_case_work(
+            model=llm_trainer.model,
+            optimizer=llm_trainer.optimizer,
+            loss_builder=lambda: llm_trainer.loss_fn(
+                *llm_trainer.forward_fn(
+                    llm_trainer.model,
+                    trainer_batch,
+                    mode="train",
+                ),
+                pad_idx=trainer_loader.pad_idx,
+                label_smoothing=llm_trainer.config.label_smoothing,
+            ),
+        )
+        try:
+            results["cases"][GPT_CASE_NAME] = self._run_trainer_benchmark_case(
+                trainer=llm_trainer,
+                batch_data=trainer_batch,
+                data_loader=trainer_loader,
+                throughput_count=trainer_throughput_count,
+                throughput_unit="tokens",
+                work=trainer_work,
+            )
+            summary_rows.append(
+                self._summary_row(
+                    GPT_CASE_NAME,
+                    results["cases"][GPT_CASE_NAME],
+                )
+            )
+        finally:
+            self._cleanup_benchmark_case()
         print("\n")
         print(self._format_summary_table(summary_rows))

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -10,7 +10,10 @@ from test.helpers import allclose
 
 class TestActivationFunctions(TestCase):
     def setUp(self) -> None:
-        self.X = Tensor(data=xp.array([[1, 1, 1], [2, 2, 2]]), requires_grad=True)
+        self.X = Tensor(
+            data=xp.array([[1, 1, 1], [2, 2, 2]], dtype=xp.float32),
+            requires_grad=True,
+        )
 
     def test_sigmoid_forward(self):
         assert allclose(

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -123,11 +123,11 @@ class TestBinaryCrossEntropy(TestCase):
     def setUp(self) -> None:
         self.y_pred_logits = Tensor(data=xp.array([1.0, 2.0, 3.0]), requires_grad=True)
         self.y_pred_logits_torch = torch.tensor(
-            self.y_pred_logits.data, requires_grad=True
+            self.y_pred_logits.data, dtype=torch.float32, requires_grad=True
         )
         self.y_pred_probs = Tensor(data=xp.array([0.2, 0.3, 0.1]), requires_grad=True)
         self.y_pred_probs_torch = torch.tensor(
-            self.y_pred_probs.data, requires_grad=True
+            self.y_pred_probs.data, dtype=torch.float32, requires_grad=True
         )
         self.y_true = xp.array([0.0, 0.0, 1.0])
 
@@ -161,7 +161,7 @@ class TestBinaryCrossEntropy(TestCase):
             self.y_pred_logits, self.y_true
         )
         torch_bce_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-            self.y_pred_logits_torch, torch.tensor(self.y_true)
+            self.y_pred_logits_torch, torch.tensor(self.y_true, dtype=torch.float32)
         )
         assert allclose(
             bce_loss.data,

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -193,6 +193,15 @@ class TestEmbedding(TestCase):
             output.data, torch_output.detach().numpy(), rtol=1e-5, atol=1e-5
         ), "Embedding output doesn't match PyTorch's output"
 
+    def test_forward_raw_index_array(self):
+        output = self.embedding(self.x_data)
+        torch_output = self.torch_embedding(self.x_torch)
+
+        assert output.shape == (self.batch_size, self.seq_length, self.embedding_size)
+        assert allclose(
+            output.data, torch_output.detach().numpy(), rtol=1e-5, atol=1e-5
+        ), "Embedding output for raw indices doesn't match PyTorch's output"
+
     def test_backward(self):
         # Forward pass
         output = self.embedding(self.x)

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -605,18 +605,20 @@ class TestConv2d(TestCase):
 
         # Create PyTorch tensors and layer
         x_torch = torch.tensor(x.data, requires_grad=True)
+        torch_dtype = x_torch.dtype
         conv_torch = torch.nn.Conv2d(2, 1, 3, padding="same")
+        conv_torch = conv_torch.to(dtype=torch_dtype)
         with torch.no_grad():
             conv_torch.weight.data = torch.tensor(
-                conv._parameters["weight"].data, dtype=torch.float32
+                conv._parameters["weight"].data, dtype=torch_dtype
             )
             conv_torch.bias.data = torch.tensor(
-                conv._parameters["bias"].data, dtype=torch.float32
+                conv._parameters["bias"].data, dtype=torch_dtype
             )
 
         # Forward pass in PyTorch
         output_torch = conv_torch(x_torch)
-        target_torch = torch.tensor(target.data, requires_grad=True)
+        target_torch = torch.tensor(target.data, dtype=torch_dtype, requires_grad=True)
         loss_torch = ((output_torch - target_torch) ** 2).sum()
 
         # Backward pass in PyTorch

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import torch  # for comparison
 
 from autograd.backend import xp
-from autograd.tensor import Tensor
+from autograd.tensor import Tensor, is_grad_enabled, no_grad
 from test.helpers import allclose, array_equal, isclose
 
 
@@ -113,6 +113,23 @@ class TestTensorOps(TestTensor):
         assert self.y_scalar.grad is None  # lazy init until backward is called
         assert self.x_scalar.requires_grad
         assert self.y_scalar.creator is None
+
+    def test_no_grad_context_disables_graph_construction(self):
+        assert is_grad_enabled()
+        with no_grad():
+            z = self.x_scalar + self.y_scalar
+            assert not z.requires_grad
+            assert z.creator is None
+            assert not self.x_scalar.detach().requires_grad
+        assert is_grad_enabled()
+
+    def test_no_grad_context_restores_previous_state(self):
+        with no_grad():
+            assert not is_grad_enabled()
+            with no_grad():
+                assert not is_grad_enabled()
+            assert not is_grad_enabled()
+        assert is_grad_enabled()
 
     def test_tensor_matrix_multiplication(self):
         z = self.x_vector @ self.y_vector

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -405,6 +405,11 @@ class TestTensorSum(TestTensor):
         s = self.x_vector_no_grad.sum()
         assert not s.requires_grad
 
+    def test_no_grad_ops_do_not_retain_creator(self):
+        z = (self.x_vector_no_grad + self.y_vector_no_grad) * 2.0
+        assert not z.requires_grad
+        assert z.creator is None
+
 
 class TestTensorMean(TestTensor):
     def setUp(self) -> None:

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -79,6 +79,11 @@ class TestTensor(TestCase):
 
 
 class TestTensorOps(TestTensor):
+    def test_tensor_preserves_explicit_array_dtype(self):
+        x = Tensor(xp.array([1.0, 2.0], dtype=xp.float16), requires_grad=True)
+
+        assert x.data.dtype == xp.float16
+
     def test_tensor_negation(self):
         assert (-self.x_scalar).data == -2.0
 

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 from unittest import TestCase
 
 import torch  # for comparison
@@ -135,6 +137,65 @@ class TestTensorOps(TestTensor):
                 assert not is_grad_enabled()
             assert not is_grad_enabled()
         assert is_grad_enabled()
+
+    def test_no_grad_context_is_thread_local(self):
+        x = Tensor([1.0], requires_grad=True)
+        ready = threading.Event()
+        release = threading.Event()
+        results = {}
+
+        def thread_with_no_grad():
+            with no_grad():
+                ready.set()
+                release.wait()
+
+        def thread_with_grad():
+            ready.wait()
+            y = x * 2
+            results["requires_grad"] = y.requires_grad
+            results["creator_is_none"] = y.creator is None
+            release.set()
+
+        worker_a = threading.Thread(target=thread_with_no_grad)
+        worker_b = threading.Thread(target=thread_with_grad)
+        worker_a.start()
+        worker_b.start()
+        worker_a.join()
+        worker_b.join()
+
+        assert results == {"requires_grad": True, "creator_is_none": False}
+
+    def test_no_grad_context_is_task_local(self):
+        x = Tensor([1.0], requires_grad=True)
+        results = {}
+        ready = asyncio.Event()
+        release = asyncio.Event()
+
+        async def task_with_no_grad():
+            with no_grad():
+                ready.set()
+                await release.wait()
+
+        async def task_with_grad():
+            await ready.wait()
+            y = x * 2
+            results["requires_grad"] = y.requires_grad
+            results["creator_is_none"] = y.creator is None
+            release.set()
+
+        async def main():
+            await asyncio.gather(task_with_no_grad(), task_with_grad())
+
+        asyncio.run(main())
+
+        assert results == {"requires_grad": True, "creator_is_none": False}
+
+    def test_pow_one_respects_no_grad(self):
+        with no_grad():
+            y = self.x_scalar**1
+
+        assert not y.requires_grad
+        assert y.creator is None
 
     def test_tensor_matrix_multiplication(self):
         z = self.x_vector @ self.y_vector
@@ -1068,6 +1129,15 @@ class TestTensorIAdd(TestTensor):
         assert array_equal(self.x_vector_no_grad.data, [4.0, 6.0])
         self.x_vector_no_grad.backward()
         assert array_equal(self.y_vector.grad.data, [1.0, 1.0])
+
+    def test_iadd_scalar_constant_does_not_enable_grad(self):
+        x = Tensor([1.0, 2.0], requires_grad=False)
+
+        x += 1
+
+        assert not x.requires_grad
+        assert x.creator is None
+        assert array_equal(x.data, [2.0, 3.0])
 
 
 class TestTensorStack(TestTensor):

--- a/test/autograd/tools/test_data.py
+++ b/test/autograd/tools/test_data.py
@@ -288,6 +288,25 @@ class TestDataLoaders(unittest.TestCase):
         self.assertTrue(xp.array_equal(first_X, self.X[:4]))
         self.assertTrue(xp.array_equal(first_y, self.y[:4]))
 
+    def test_data_loader_batch_token_count_defaults_to_none_for_paired_batches(self):
+        dataset = PairedIterableDataset(self.X, self.y, shuffle=False)
+        loader = DataLoader(
+            dataset,
+            batch_size=4,
+            collate_fn=PairedCollator(),
+        )
+
+        batch = next(iter(loader))
+
+        self.assertIsNone(loader.batch_token_count(batch))
+
+    def test_data_loader_batch_token_count_delegates_to_lm_collator(self):
+        loader = self.make_pretraining_loader(batch_size=2, seq_len=4, shuffle=False)
+
+        batch = next(iter(loader))
+
+        self.assertEqual(loader.batch_token_count(batch), 8)
+
     def test_one_hot_collator_materializes_one_hot_inputs(self):
         collator = OneHotCollator(num_classes=4)
 

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -338,6 +338,47 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
         self.assertEqual(self.loss_fn.call_count, 1)
 
+    def test_evaluate_runs_without_grad_tracking(self):
+        class LinearModel(Module):
+            def __init__(self, input_size=5, output_size=3, **kwargs):
+                super().__init__()
+                self.weight = Tensor(
+                    xp.ones((input_size, output_size), dtype=xp.float32),
+                    requires_grad=True,
+                )
+
+            def forward(self, x):
+                return Tensor(x, requires_grad=False) @ self.parameters["weight"]
+
+        class RecordingLoss:
+            def __call__(self, y_pred, y_true, **kwargs):
+                self.last_pred = y_pred
+                self.last_loss = y_pred.sum()
+                return self.last_loss
+
+        trainer = SimpleTrainer(
+            model_cls=LinearModel,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=RecordingLoss(),
+            config=GenericTrainingConfig(
+                max_epochs=1,
+                checkpoint_freq=1,
+                model_kwargs={},
+                optimizer_kwargs={"lr": 0.01},
+                resume_epoch=None,
+            ),
+            output_type="logits",
+        )
+
+        avg_val_loss = trainer.evaluate(MockDataLoader(self.val_data))
+
+        self.assertIsNotNone(trainer.loss_fn.last_pred)
+        self.assertFalse(trainer.loss_fn.last_pred.requires_grad)
+        self.assertIsNone(trainer.loss_fn.last_pred.creator)
+        self.assertFalse(trainer.loss_fn.last_loss.requires_grad)
+        self.assertIsNone(trainer.loss_fn.last_loss.creator)
+        self.assertGreaterEqual(avg_val_loss, 0.0)
+
 
 class TestLLMTrainer(BaseTrainerTest):
     def setUp(self):
@@ -446,6 +487,89 @@ class TestLLMTrainer(BaseTrainerTest):
         callback.assert_called_once_with(
             trainer.model, trainer.forward_fn, self.val_loader, trainer.config
         )
+
+    def test_llm_evaluate_runs_without_grad_tracking(self):
+        class TinyLM(Module):
+            def __init__(self, vocab_size=10, **kwargs):
+                super().__init__()
+                self.logit_bias = Tensor(
+                    xp.arange(vocab_size, dtype=xp.float32), requires_grad=True
+                )
+
+            def forward(self, tokens, mask=None):
+                batch_size, seq_len = tokens.shape
+                logit_bias = self.parameters["logit_bias"]
+                return logit_bias.expand(batch_size, seq_len, logit_bias.shape[0])
+
+        class TinyForwardFn(AbstractLLMForwardFn):
+            def train(self, model, batch_data):
+                X, _, y, _, _, causal_mask = batch_data
+                return model(X, causal_mask), y
+
+            def sample(self, model, batch_data):
+                return model(batch_data, None), None
+
+        class RecordingLoss:
+            def __call__(self, y_pred, y_true, **kwargs):
+                self.last_pred = y_pred
+                self.last_loss = y_pred.sum()
+                return self.last_loss
+
+        trainer = LLMTrainer(
+            model_cls=TinyLM,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=RecordingLoss(),
+            forward_fn=TinyForwardFn(),
+            config=TransformerTrainingConfig(
+                max_epochs=1,
+                checkpoint_freq=1,
+                model_kwargs={},
+                optimizer_kwargs={"lr": 0.01},
+                resume_epoch=None,
+                label_smoothing=0.0,
+                teacher_enforcing=False,
+                include_decoder_input=False,
+                create_padding_masks=False,
+            ),
+        )
+
+        avg_val_loss = trainer.evaluate(self.val_loader)
+
+        self.assertIsNotNone(trainer.loss_fn.last_pred)
+        self.assertFalse(trainer.loss_fn.last_pred.requires_grad)
+        self.assertIsNone(trainer.loss_fn.last_pred.creator)
+        self.assertFalse(trainer.loss_fn.last_loss.requires_grad)
+        self.assertIsNone(trainer.loss_fn.last_loss.creator)
+        self.assertGreaterEqual(avg_val_loss, 0.0)
+
+    def test_llm_sample_mode_runs_without_grad_tracking(self):
+        class TinyLM(Module):
+            def __init__(self, vocab_size=8, **kwargs):
+                super().__init__()
+                self.logit_bias = Tensor(
+                    xp.arange(vocab_size, dtype=xp.float32), requires_grad=True
+                )
+
+            def forward(self, tokens, mask=None):
+                batch_size, seq_len = tokens.shape
+                logit_bias = self.parameters["logit_bias"]
+                return logit_bias.expand(batch_size, seq_len, logit_bias.shape[0])
+
+        class TinyForwardFn(AbstractLLMForwardFn):
+            def train(self, model, batch_data):
+                return model(batch_data, None), batch_data
+
+            def sample(self, model, batch_data):
+                return model(batch_data, None), None
+
+        model = TinyLM()
+        forward_fn = TinyForwardFn()
+        tokens = xp.zeros((2, 4), dtype=xp.int32)
+
+        logits, _ = forward_fn(model, tokens, mode="sample")
+
+        self.assertFalse(logits.requires_grad)
+        self.assertIsNone(logits.creator)
 
     @patch("autograd.tools.callback.text_utils.inference")
     def test_manual_qualitative_inference_helpers_do_not_depend_on_loader(

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -26,17 +26,18 @@ from autograd.tools.data import (
 from autograd.tools.trainer import LLMTrainer, SimpleTrainer
 
 
-class MockDataLoader:
+class MockDataLoader(DataLoader):
     """
     A simple loader that stores a list of batches in memory.
     Each time __iter__ is called, it yields those same batches again.
     """
 
-    def __init__(self, data, pad_idx=0, seq_len=1):
+    def __init__(self, data, pad_idx=0, seq_len=1, batch_token_count_fn=None):
         self.data = data
         self.pad_idx = pad_idx
         self.seq_len = seq_len
         self.bpe = MagicMock()
+        self.batch_token_count_fn = batch_token_count_fn
 
     def on_epoch_start(self):
         # If you want to shuffle or do something each epoch, do it here
@@ -49,6 +50,11 @@ class MockDataLoader:
         # A fresh iterator every time => each epoch can re-iterate from the start
         print(f"MockDataLoader: yielding {len(self.data)} batch(es)")
         return iter(self.data)
+
+    def batch_token_count(self, batch):
+        if self.batch_token_count_fn is None:
+            return None
+        return self.batch_token_count_fn(batch)
 
 
 class MockModelClass(Module):
@@ -120,6 +126,23 @@ class MockBPE:
             if token == "<SOS>":
                 return [1]
         return [ord(char) for char in token]
+
+
+class RecordingTqdm:
+    def __init__(self, iterable, desc=None, leave=False, elapsed_s=2.0):
+        self.iterable = iterable
+        self.desc = desc
+        self.leave = leave
+        self.format_dict = {"elapsed": elapsed_s}
+        self.postfixes = []
+
+    def __iter__(self):
+        return iter(self.iterable)
+
+    def set_postfix(self, ordered_dict=None, refresh=True, **kwargs):
+        postfix = dict(ordered_dict or {})
+        postfix.update(kwargs)
+        self.postfixes.append(postfix)
 
 
 class PromptMaskAwareForwardFn(AbstractLLMForwardFn):
@@ -412,8 +435,21 @@ class TestLLMTrainer(BaseTrainerTest):
         ]
 
         # Replace MagicMock with a real in-memory loader
-        self.train_loader = MockDataLoader(self.train_data, pad_idx=0, seq_len=seq_len)
-        self.val_loader = MockDataLoader(self.val_data, pad_idx=0, seq_len=seq_len)
+        def batch_token_count_fn(batch):
+            return int(batch[0].shape[0] * batch[0].shape[1])
+
+        self.train_loader = MockDataLoader(
+            self.train_data,
+            pad_idx=0,
+            seq_len=seq_len,
+            batch_token_count_fn=batch_token_count_fn,
+        )
+        self.val_loader = MockDataLoader(
+            self.val_data,
+            pad_idx=0,
+            seq_len=seq_len,
+            batch_token_count_fn=batch_token_count_fn,
+        )
 
         # We'll mock forward_fn to skip real model logic
         self.forward_fn = MagicMock()
@@ -450,25 +486,66 @@ class TestLLMTrainer(BaseTrainerTest):
         # 2 epochs * 2 train batches = 4 steps
         self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
+    @patch("autograd.tools.trainer.tqdm")
+    def test_fit_updates_tqdm_with_cumulative_tokens_and_token_throughput(
+        self, mock_tqdm
+    ):
+        progress_bars = []
+
+        def make_progress_bar(iterable, desc=None, leave=False):
+            progress_bar = RecordingTqdm(iterable, desc=desc, leave=leave)
+            progress_bars.append(progress_bar)
+            return progress_bar
+
+        mock_tqdm.side_effect = make_progress_bar
+        self.config.max_epochs = 1
+
+        self.trainer.fit(self.train_loader, self.val_loader)
+
+        training_bar = next(
+            bar for bar in progress_bars if bar.desc == "Training Batches"
+        )
+        self.assertEqual(
+            training_bar.postfixes,
+            [
+                {"tokens": "20", "tok/s": "10.0"},
+                {"tokens": "40", "tok/s": "20.0"},
+            ],
+        )
+
     def test_train_step_returns_loss(self):
         """Check that a single train step returns the constant loss tensor."""
         batch = next(iter(self.train_data))
         loss_val = self.trainer.train_step(batch, self.train_loader)
         self.assertAlmostEqual(float(loss_val.item()), 1.23, places=5)
 
-    def test_evaluate_does_not_require_loader_metadata(self):
-        class MinimalLoader:
-            pad_idx = 0
-
-            def __init__(self, data):
-                self.data = data
-
-            def __iter__(self):
-                return iter(self.data)
-
-        avg_val_loss = self.trainer.evaluate(MinimalLoader(self.val_data))
+    def test_evaluate_supports_data_loader_without_token_count(self):
+        avg_val_loss = self.trainer.evaluate(MockDataLoader(self.val_data))
 
         self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+
+    @patch("autograd.tools.trainer.tqdm")
+    def test_evaluate_updates_tqdm_with_cumulative_tokens_and_token_throughput(
+        self, mock_tqdm
+    ):
+        progress_bars = []
+
+        def make_progress_bar(iterable, desc=None, leave=False):
+            progress_bar = RecordingTqdm(iterable, desc=desc, leave=leave)
+            progress_bars.append(progress_bar)
+            return progress_bar
+
+        mock_tqdm.side_effect = make_progress_bar
+
+        avg_val_loss = self.trainer.evaluate(self.val_loader)
+
+        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        self.assertEqual(len(progress_bars), 1)
+        self.assertEqual(progress_bars[0].desc, "Evaluation")
+        self.assertEqual(
+            progress_bars[0].postfixes,
+            [{"tokens": "20", "tok/s": "10.0"}],
+        )
 
     def test_evaluate_runs_eval_callbacks_and_returns_val_loss(self):
         callback = MagicMock()

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -211,10 +211,10 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
     def test_train_step_returns_loss(self):
-        """Check that the train_step returns the expected scalar loss."""
+        """Check that train_step returns the expected loss tensor."""
         batch = next(iter(self.train_data))
         loss_val = self.trainer.train_step(batch)
-        self.assertAlmostEqual(loss_val, 1.23, places=5)
+        self.assertAlmostEqual(float(loss_val.item()), 1.23, places=5)
 
     def test_save_metrics_persists_none_as_nan(self):
         self.trainer.metrics["epoch"] = [0]
@@ -410,10 +410,10 @@ class TestLLMTrainer(BaseTrainerTest):
         self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
     def test_train_step_returns_loss(self):
-        """Check that a single train step returns the constant scalar loss."""
+        """Check that a single train step returns the constant loss tensor."""
         batch = next(iter(self.train_data))
         loss_val = self.trainer.train_step(batch, self.train_loader)
-        self.assertAlmostEqual(loss_val, 1.23, places=5)
+        self.assertAlmostEqual(float(loss_val.item()), 1.23, places=5)
 
     def test_evaluate_does_not_require_loader_metadata(self):
         class MinimalLoader:
@@ -538,7 +538,9 @@ class TestLLMTrainer(BaseTrainerTest):
         train_loss = trainer.train_step(batch, loader)
         val_loss = trainer.evaluate(loader)
 
-        self.assertAlmostEqual(train_loss, float(expected_loss.item()), places=6)
+        self.assertAlmostEqual(
+            float(train_loss.item()), float(expected_loss.item()), places=6
+        )
         self.assertAlmostEqual(val_loss, float(expected_loss.item()), places=6)
 
     def test_fit_supports_unsized_streaming_data_loaders(self):


### PR DESCRIPTION
## Description
* Updated the performance test to be more fine-grain to capture start-to-peak  metrics, not just peak metrics, to avoid being influenced higher start up "baselines". Also, updated summary metrics that's less biased and sensitive to system fluctuations
* Optimize host syncs and extra Python work in the hot path
  * Removes `.item()` and other scalar extractions from the training hot path.
  * `train_step()` now returns a Tensor; loss accumulation uses `loss.data`.
  * Grad clipping avoids `.item()` inside loops.
* Embedding.forward uses raw index arrays directly
  * Avoids wrapping index arrays into `Tensor` only to immediately access `.data`.
  * Applies to token + position embeddings in GPT forward.
  * Removes minor redundant object construction; negligible relative to full training step.
* Avoid retaining function + inputs for constant-only ops
  * `Function.apply()` skips attaching autograd creator when no inputs require grad.
  * Reduces unnecessary graph nodes and Python object churn.
* Introduce `no_grad()` context manager
  * Adds ability to explicitly disable gradient tracking. This is different from the existing `model.eval()` that changes the BatchNorm and Dropout behavior.
* Preserve explicitly constructed backend array dtypes
  * Stops forcing backend arrays to `float32`; keeps original dtype (`int32`, `float16`, etc.).
  * Improves correctness/control over dtype handling.
* add throughput metrics in dataloader/collator and display in trainer tqdm progress bar and clean up dataloader contracts
  ```
  Training Batches: 25it [00:00, 48.72it/s, tokens=19,200, tok/s=27,719.9]
  ```

## Tests

Added unit tests.

## Performance Comparison

Even though some of the optimizations didn't show significant improvements, they're are in-theory worthwhile, so I'm still implementing them.

**Final**

| Case              | Step P50 | Step P90 | GFLOP/s       | Graph Node Counts | Static Memory | Memory Peak Over Start |
|-------------------|----------|----------|---------------|-------------|---------------|------------------------|
| Complex MLP Model | 2.35 ms  | 2.46 ms  | 3,458 GFLOP/s | 39          | 40.08 KiB     | 4.56 GiB               |
| Deep CNN Model    | 19.38 ms | 20.28 ms | 520.4 GFLOP/s | 115         | 5.79 MiB      | 1.75 GiB               |
| Mini GPT-2 Model  | 856.1 ms | 861.2 ms | 4,966 GFLOP/s | 413         | 777.94 MiB    | 10.81 GiB              |

**Baseline**

| Case              | Step P50 | Step P90 | GFLOP/s       | Graph Node Counts | Static Memory | Memory Peak Over Start |
|-------------------|----------|----------|---------------|-------------|---------------|------------------------|
| Complex MLP Model | 2.35 ms  | 2.44 ms  | 3,450 GFLOP/s | 39          | 40.08 KiB     | 4.71 GiB               |
| Deep CNN Model    | 19.35 ms | 22.62 ms | 521.1 GFLOP/s | 115         | 5.79 MiB      | 1.74 GiB               |
| Mini GPT-2 Model  | 873 ms   | 873.4 ms | 4,870 GFLOP/s | 413         | 777.94 MiB    | 11.63 GiB              |


**Delta Improvements**

| Commit | Mini GPT-2 ΔStep P50 | Mini GPT-2 ΔStep P90 | Mini GPT-2 ΔGFLOP/s | Mini GPT-2 ΔNode Counts | Mini GPT-2 ΔStatic Memory | Mini GPT-2 ΔMemory Peak Over Start |
|---|---|---|---|---|---|---|
| Baseline | +0.00 ms | +0.00 ms | +0 | +0 | +0.00 MiB | +0.00 GiB |
| Optimize host syncs and extra Python work in the hot path | -41.30 ms | -38.50 ms | +223 | +0 | +0.00 MiB | +0.79 GiB |
| Embedding.forward now uses raw index arrays directly | +2.30 ms | +0.80 ms | -13 | +0 | +0.00 MiB | +0.00 GiB |
| avoid retaining the function and its inputs for constant-only ops | -1.90 ms | -1.60 ms | +11 | +0 | +0.00 MiB | +0.00 GiB |
| introduce no_grad() context manager for inference and eval | +1.90 ms | -0.50 ms | -11 | +0 | +0.00 MiB | +0.00 GiB |
| Preserve explicitly constructed backend array dtypes | +6.70 ms | +9.80 ms | -38 | +0 | +0.00 MiB | -1.61 GiB |

