### PR TITLE
Update data contracts for training and speed up tokenizer building, training and unit tests

### DIFF
--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -81,6 +81,16 @@ class BytePairEncoder:
         """
         return len(self._unicode_to_int_vocab)
 
+    def _should_parallelize(
+        self, *, work_items: int, min_items_per_worker: int
+    ) -> bool:
+        # On small workloads, Pool startup/pickling dominates the actual work,
+        # especially on macOS where multiprocessing uses `spawn`. Only fan out
+        # when each worker has enough items to amortize that fixed overhead.
+        return (
+            self.n_workers > 1 and work_items >= self.n_workers * min_items_per_worker
+        )
+
     def _load_dictionary(self) -> None:
         """Loads the dictionary (vocab + merges) from disk if it exists.
 
@@ -186,14 +196,18 @@ class BytePairEncoder:
             encoded_data = encoded_archive["arr_0"]
         else:
             # 3) Parallel encoding
-            chunk_size = max(1, len(raw_text) // self.n_workers)
-            text_chunks = [
-                raw_text[i : i + chunk_size]
-                for i in range(0, len(raw_text), chunk_size)
-            ]
-
-            with Pool(self.n_workers) as pool:
-                partial_encoded = pool.map(self.encode, text_chunks)
+            if self._should_parallelize(
+                work_items=len(raw_text), min_items_per_worker=8192
+            ):
+                chunk_size = max(1, len(raw_text) // self.n_workers)
+                text_chunks = [
+                    raw_text[i : i + chunk_size]
+                    for i in range(0, len(raw_text), chunk_size)
+                ]
+                with Pool(self.n_workers) as pool:
+                    partial_encoded = pool.map(self.encode, text_chunks)
+            else:
+                partial_encoded = [self.encode(raw_text)]
 
             encoded_data = xp.array([], dtype=xp.int32)
             for part in partial_encoded:
@@ -439,15 +453,17 @@ class BytePairEncoder:
             >>> counts = bpe._get_initial_pair_counts(word_freq) # Displays the frequency counts for each bigram
         """
         items = list(word_freq.items())
-        chunk_size = max(1, len(items) // self.n_workers)
-
-        with Pool(self.n_workers) as pool:
-            chunked_items = [
-                items[i : i + chunk_size] for i in range(0, len(items), chunk_size)
-            ]
-            partial_results = pool.map(
-                BytePairEncoder._local_pair_counts, chunked_items
-            )
+        if self._should_parallelize(work_items=len(items), min_items_per_worker=256):
+            chunk_size = max(1, len(items) // self.n_workers)
+            with Pool(self.n_workers) as pool:
+                chunked_items = [
+                    items[i : i + chunk_size] for i in range(0, len(items), chunk_size)
+                ]
+                partial_results = pool.map(
+                    BytePairEncoder._local_pair_counts, chunked_items
+                )
+        else:
+            partial_results = [BytePairEncoder._local_pair_counts(items)]
 
         total_counts = Counter()
         for c in partial_results:
@@ -498,16 +514,23 @@ class BytePairEncoder:
             del corpus_word_freq[w_tuple]
 
         # Parallel merge
-        chunk_size = max(1, len(items_to_update) // self.n_workers)
-        with Pool(self.n_workers) as pool:
-            chunked_items = [
-                items_to_update[i : i + chunk_size]
-                for i in range(0, len(items_to_update), chunk_size)
+        if self._should_parallelize(
+            work_items=len(items_to_update), min_items_per_worker=256
+        ):
+            chunk_size = max(1, len(items_to_update) // self.n_workers)
+            with Pool(self.n_workers) as pool:
+                chunked_items = [
+                    items_to_update[i : i + chunk_size]
+                    for i in range(0, len(items_to_update), chunk_size)
+                ]
+                partial_results = pool.map(
+                    BytePairEncoder._local_merge_chunk,
+                    [(chunk, pair, new_id) for chunk in chunked_items],
+                )
+        else:
+            partial_results = [
+                BytePairEncoder._local_merge_chunk((items_to_update, pair, new_id))
             ]
-            partial_results = pool.map(
-                BytePairEncoder._local_merge_chunk,
-                [(chunk, pair, new_id) for chunk in chunked_items],
-            )
 
         # Aggregate results
         for local_new_word_freq, local_pair_counts in partial_results:

--- a/autograd/tools/data.py
+++ b/autograd/tools/data.py
@@ -166,16 +166,17 @@ class PairedIterableDataset(IterableDataset):
         self.y = y
         self.shuffle = shuffle
         self.num_samples = len(X)
-        self.indices = xp.arange(self.num_samples)
+        self.indices = range(self.num_samples)
 
     def on_epoch_start(self) -> None:
         if self.shuffle:
-            self.indices = xp.random.permutation(self.num_samples)
+            # Materialize the shuffle order on host once per epoch so iterating
+            # samples does not pay a device->host scalar sync on every example.
+            self.indices = xp.to_numpy(xp.random.permutation(self.num_samples)).tolist()
 
     def __iter__(self) -> Iterator[dict[str, Array]]:
         for sample_idx in self.indices:
-            idx = int(sample_idx)
-            yield {"inputs": self.X[idx], "targets": self.y[idx]}
+            yield {"inputs": self.X[sample_idx], "targets": self.y[sample_idx]}
 
     def __len__(self) -> int:
         return self.num_samples

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -69,6 +69,9 @@ class AbstractTrainer(ABC):
         )
         self.start_epoch = self.config.resume_epoch or 0
         self.global_step = int(self.checkpoint.get("step_count", 0))
+        # Contract: each metric history stores backend scalar arrays or None.
+        # Host conversion happens only at explicit consumption boundaries such
+        # as logging, checkpoint comparison, and persistence.
         self.metrics = defaultdict(list)
 
     def fit(
@@ -189,37 +192,47 @@ class AbstractTrainer(ABC):
         avg_loss = total_loss / max(batch_count, 1)
         return float(xp.to_scalar(avg_loss))
 
-    def _save_checkpoint(self, epoch: int, val_loss: Optional[float]):
+    def _save_checkpoint(self, epoch: int):
         """Saves a model checkpoint if the validation loss improves.
 
         Args:
             epoch (int): Current epoch number.
-            val_loss (Optional[float]): The validation loss at this epoch.
         """
-        if val_loss is not None and epoch % self.config.checkpoint_freq == 0:
-            if self.metrics["val_loss"] and val_loss < min(self.metrics["val_loss"]):
-                checkpoint = {
-                    "epoch": epoch + 1,
-                    "step_count": self.global_step,
-                    "model_state_dict": self.model.state_dict(),
-                    "optimizer_state_dict": self.optimizer.state_dict(),
-                    "model_init_kwargs": self.config.model_kwargs,
-                    "optimizer_init_kwargs": self.config.optimizer_kwargs,
-                    "config": self.config,
-                }
-                os.makedirs(self.CHECKPOINT_DIR, exist_ok=True)
-                cp_path_json = os.path.join(
-                    self.CHECKPOINT_DIR,
-                    f"{self.config.training_run_name}_{self.model.__class__.__name__}_{epoch}.json",
-                )
-                cp_path_npz = os.path.join(
-                    self.CHECKPOINT_DIR,
-                    f"{self.config.training_run_name}_{self.model.__class__.__name__}_{epoch}.npz",
-                )
-                save_checkpoint(
-                    checkpoint, json_path=cp_path_json, npz_path=cp_path_npz
-                )
-                logger.info(f"Saved checkpoint to {cp_path_json} and {cp_path_npz}")
+        if epoch % self.config.checkpoint_freq != 0:
+            return
+
+        val_losses = self.metrics["val_loss"]
+        if not val_losses or val_losses[-1] is None:
+            return
+
+        current_val_loss = float(xp.to_scalar(val_losses[-1]))
+        best_historical_val_loss = min(
+            (float(xp.to_scalar(loss)) for loss in val_losses[:-1] if loss is not None),
+            default=float("inf"),
+        )
+        if current_val_loss >= best_historical_val_loss:
+            return
+
+        checkpoint = {
+            "epoch": epoch + 1,
+            "step_count": self.global_step,
+            "model_state_dict": self.model.state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "model_init_kwargs": self.config.model_kwargs,
+            "optimizer_init_kwargs": self.config.optimizer_kwargs,
+            "config": self.config,
+        }
+        os.makedirs(self.CHECKPOINT_DIR, exist_ok=True)
+        cp_path_json = os.path.join(
+            self.CHECKPOINT_DIR,
+            f"{self.config.training_run_name}_{self.model.__class__.__name__}_{epoch}.json",
+        )
+        cp_path_npz = os.path.join(
+            self.CHECKPOINT_DIR,
+            f"{self.config.training_run_name}_{self.model.__class__.__name__}_{epoch}.npz",
+        )
+        save_checkpoint(checkpoint, json_path=cp_path_json, npz_path=cp_path_npz)
+        logger.info(f"Saved checkpoint to {cp_path_json} and {cp_path_npz}")
 
     def _save_metrics(self):
         """Saves accumulated training metrics to a compressed NPZ file."""
@@ -229,11 +242,13 @@ class AbstractTrainer(ABC):
         path = os.path.join(self.METRICS_DIR, filename)
         metrics_mx = {}
         for key, values in self.metrics.items():
-            if any(value is None for value in values):
-                values = [float("nan") if value is None else value for value in values]
-                metrics_mx[key] = xp.array(values, dtype=xp.float32)
-            else:
-                metrics_mx[key] = xp.array(values)
+            metrics_mx[key] = xp.array(
+                [
+                    float("nan") if value is None else float(xp.to_scalar(value))
+                    for value in values
+                ],
+                dtype=xp.float32,
+            )
         eval(*metrics_mx.values())
         xp.savez_compressed(path, **metrics_mx)
         logger.info(f"Saved training metrics to {path}")
@@ -264,15 +279,29 @@ class AbstractTrainer(ABC):
             train_loss (float): The average training loss for this epoch.
             val_loss (Optional[float]): The validation loss for this epoch, if available.
         """
-        self._save_checkpoint(epoch, val_loss)
-        self.metrics["epoch"].append(epoch)
-        self.metrics["train_loss"].append(train_loss)
-        self.metrics["val_loss"].append(val_loss)
+
+        # The contract is that all the consumers (e.g. log lines below) of
+        # self.metrics will do the sync from GPU to CPU, whereas self.metrics
+        # itself will store GPU/on-device data structures.
+        self.metrics["epoch"].append(xp.array(epoch, dtype=xp.float32))
+        self.metrics["train_loss"].append(xp.array(train_loss, dtype=xp.float32))
+        self.metrics["val_loss"].append(
+            None if val_loss is None else xp.array(val_loss, dtype=xp.float32)
+        )
+        self._save_checkpoint(epoch)
 
         log_msg = f"[Epoch {epoch}]"
+        log_msg += f"\ntrain_loss = {train_loss:.4f}"
+        if val_loss is not None:
+            log_msg += f"\nval_loss = {val_loss:.4f}"
         for key in self.metrics:
-            if key != "epoch" and self.metrics[key][-1] is not None:
-                log_msg += f"\n{key} = {self.metrics[key][-1]:.4f}"
+            if key in {"epoch", "train_loss", "val_loss"}:
+                continue
+            # For other metrics, we will do the sync from GPU to CPU since we're
+            # not passing them in as function args here
+            if self.metrics[key][-1] is not None:
+                metric_value = float(xp.to_scalar(self.metrics[key][-1]))
+                log_msg += f"\n{key} = {metric_value:.4f}"
         log_msg += f"\nLR = {self.optimizer.lr:.4f}"
         logger.info(log_msg)
 
@@ -511,7 +540,9 @@ class SimpleTrainer(AbstractTrainer):
                         xp.array(y_pred_proc).reshape(-1),
                         xp.array(y_true_proc, dtype=xp.int32).reshape(-1),
                     )
-                    self.metrics["val_accuracy"].append(acc_val)
+                    self.metrics["val_accuracy"].append(
+                        xp.array(acc_val, dtype=xp.float32)
+                    )
 
                     if self.sample_predictions:
                         sample_count = min(5, len(y_pred_proc))
@@ -527,7 +558,7 @@ class SimpleTrainer(AbstractTrainer):
 
                 else:
                     mse_val = mean_squared_error(y_pred_full, y_true_full)
-                    self.metrics["val_mse"].append(mse_val)
+                    self.metrics["val_mse"].append(xp.array(mse_val, dtype=xp.float32))
 
                 return avg_val_loss
         finally:
@@ -739,7 +770,7 @@ class LLMTrainer(AbstractTrainer):
             self.model.train()
 
 
-def grad_l2_norm(parameters: Dict[str, Tensor]) -> float:
+def grad_l2_norm(parameters: Dict[str, Tensor]) -> Array:
     """Computes the L2 norm of the gradients for the given model parameters.
 
     Args:
@@ -747,7 +778,7 @@ def grad_l2_norm(parameters: Dict[str, Tensor]) -> float:
             for which to compute the gradient norm.
 
     Returns:
-        float: The L2 norm of all gradients (i.e., sqrt of sum of squared gradient values).
+        Array: Backend scalar containing the L2 norm of all gradients.
 
     Example:
         >>> from autograd.tensor import Tensor
@@ -758,8 +789,8 @@ def grad_l2_norm(parameters: Dict[str, Tensor]) -> float:
         >>> grad_norm
         0.2236068
     """
-    grad_norm = 0.0
+    grad_norm = xp.array(0.0, dtype=xp.float32)
     for p in parameters.values():
         if p.grad is not None:
             grad_norm += (p.grad.data**2).sum()
-    return float(xp.to_scalar(grad_norm**0.5))
+    return xp.sqrt(grad_norm)

--- a/test/autograd/text/test_tokenizer.py
+++ b/test/autograd/text/test_tokenizer.py
@@ -1,6 +1,7 @@
 import os
 from collections import Counter
 from unittest import TestCase
+from unittest.mock import patch
 
 from autograd.text.tokenizer import BytePairEncoder
 from test.helpers import array_equal
@@ -47,6 +48,29 @@ class TestTokenizer(TestCase):
         }
         self.assertEqual(pair_counts, expected)
 
+    @patch(
+        "autograd.text.tokenizer.Pool", side_effect=AssertionError("pool not expected")
+    )
+    def test_pair_counting_skips_pool_for_small_corpus(self, _mock_pool):
+        bpe = BytePairEncoder(num_merges=50, n_workers=4)
+        word_freq = Counter(
+            {
+                (10, 11, 12): 3,
+                (11, 12, 12): 2,
+            }
+        )
+
+        pair_counts = bpe._get_initial_pair_counts(word_freq)
+
+        self.assertEqual(
+            pair_counts,
+            {
+                (10, 11): 3,
+                (11, 12): 5,
+                (12, 12): 2,
+            },
+        )
+
     def test_apply_merges_to_corpus(self):
         # Instead of test_merge_pairs, we test _apply_merges_to_corpus
         word_freq = Counter(
@@ -78,6 +102,19 @@ class TestTokenizer(TestCase):
         self.assertTrue((11, 12) in pair_counts)  # still remain in the pair_counts
         self.assertIn((256, 11), pair_counts)
         self.assertIn((11, 12), pair_counts)
+
+    @patch(
+        "autograd.text.tokenizer.Pool", side_effect=AssertionError("pool not expected")
+    )
+    def test_apply_merges_to_corpus_skips_pool_for_small_update_set(self, _mock_pool):
+        bpe = BytePairEncoder(num_merges=50, n_workers=4)
+        word_freq = Counter({(10, 11, 11, 12): 2})
+        pair_counts = {(10, 11): 2, (11, 11): 2, (11, 12): 2}
+
+        bpe._apply_merges_to_corpus((10, 11), 256, word_freq, pair_counts)
+
+        self.assertEqual(word_freq, Counter({(256, 11, 12): 2}))
+        self.assertEqual(pair_counts, {(11, 12): 2, (256, 11): 2})
 
     def test_encode_decode(self):
         input_text = self.original_text + "<|endoftext|>" + self.original_text
@@ -133,3 +170,33 @@ class TestTokenizer(TestCase):
 
         self.assertTrue(os.path.exists(self.bpe.encoded_data_path))
         self.assertTrue(array_equal(first, second))
+
+    @patch(
+        "autograd.text.tokenizer.Pool", side_effect=AssertionError("pool not expected")
+    )
+    def test_prepare_data_skips_pool_for_small_text(self, _mock_pool):
+        bpe = BytePairEncoder(
+            num_merges=2,
+            vocab_file_path="small_vocab.pkl",
+            encoded_data_path="small_encoded_data.npz",
+            n_workers=4,
+        )
+        self.addCleanup(
+            lambda: (
+                os.path.exists(bpe.vocab_file_path) and os.remove(bpe.vocab_file_path)
+            )
+        )
+        self.addCleanup(
+            lambda: (
+                os.path.exists(bpe.encoded_data_path)
+                and os.remove(bpe.encoded_data_path)
+            )
+        )
+
+        encoded = bpe.prepare_data(
+            "hello hello",
+            overwrite_vocabulary_file=True,
+            overwrite_encoded_data=True,
+        )
+
+        self.assertGreater(len(encoded), 0)

--- a/test/autograd/tools/test_data.py
+++ b/test/autograd/tools/test_data.py
@@ -148,8 +148,7 @@ class TestDataLoaders(unittest.TestCase):
             batch_size=self.batch_size_simple,
             collate_fn=PairedCollator(),
         )
-        expected_indices = xp.arange(len(self.X))
-        self.assertTrue(xp.array_equal(dataset.indices, expected_indices))
+        self.assertEqual(list(dataset.indices), list(range(len(self.X))))
         batches = list(loader)
         expected_batches = (
             len(self.X) + self.batch_size_simple - 1
@@ -161,9 +160,8 @@ class TestDataLoaders(unittest.TestCase):
     def test_paired_iterable_dataset_shuffle(self):
         dataset = PairedIterableDataset(self.X, self.y, shuffle=True)
         dataset.on_epoch_start()
-        self.assertTrue(
-            xp.array_equal(xp.sort(dataset.indices), xp.arange(len(self.X)))
-        )
+        self.assertIsInstance(dataset.indices, list)
+        self.assertEqual(sorted(dataset.indices), list(range(len(self.X))))
 
     def test_data_loader_length(self):
         loader = DataLoader(

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -23,7 +23,7 @@ from autograd.tools.data import (
     openai_chat_to_prompt_completion,
     tokenize_prompt_completion,
 )
-from autograd.tools.trainer import LLMTrainer, SimpleTrainer
+from autograd.tools.trainer import LLMTrainer, SimpleTrainer, grad_l2_norm
 
 
 class MockDataLoader(DataLoader):
@@ -240,8 +240,8 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertAlmostEqual(float(loss_val.item()), 1.23, places=5)
 
     def test_save_metrics_persists_none_as_nan(self):
-        self.trainer.metrics["epoch"] = [0]
-        self.trainer.metrics["train_loss"] = [1.23]
+        self.trainer.metrics["epoch"] = [xp.array(0.0, dtype=xp.float32)]
+        self.trainer.metrics["train_loss"] = [xp.array(1.23, dtype=xp.float32)]
         self.trainer.metrics["val_loss"] = [None]
 
         self.trainer._save_metrics()
@@ -401,6 +401,63 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertFalse(trainer.loss_fn.last_loss.requires_grad)
         self.assertIsNone(trainer.loss_fn.last_loss.creator)
         self.assertGreaterEqual(avg_val_loss, 0.0)
+
+    def test_grad_l2_norm_returns_backend_scalar(self):
+        param = Tensor(xp.array([1.0, 2.0], dtype=xp.float32), requires_grad=True)
+        param.grad = Tensor(xp.array([3.0, 4.0], dtype=xp.float32), requires_grad=False)
+
+        grad_norm = grad_l2_norm({"weight": param})
+
+        self.assertTrue(xp.isclose(grad_norm, xp.array(5.0, dtype=xp.float32)))
+
+    def test_on_epoch_end_logs_backend_scalar_metrics(self):
+        self.trainer.metrics["grad_l2_norm"].append(xp.array(2.5, dtype=xp.float32))
+
+        self.trainer._on_epoch_end(epoch=0, train_loss=1.23, val_loss=None)
+
+        self.assertTrue(
+            xp.isclose(
+                self.trainer.metrics["epoch"][0],
+                xp.array(0.0, dtype=xp.float32),
+            )
+        )
+
+    def test_save_metrics_persists_backend_scalar_metrics(self):
+        self.trainer.metrics["epoch"] = [xp.array(0.0, dtype=xp.float32)]
+        self.trainer.metrics["train_loss"] = [xp.array(1.23, dtype=xp.float32)]
+        self.trainer.metrics["val_loss"] = [None]
+        self.trainer.metrics["grad_l2_norm"] = [xp.array(2.5, dtype=xp.float32)]
+
+        self.trainer._save_metrics()
+
+        metrics_path = (
+            f"{SimpleTrainer.METRICS_DIR}/{MockModelClass.__name__}_default.npz"
+        )
+        archive = xp.load(metrics_path)
+        grad_norm = xp.to_numpy(archive["grad_l2_norm"])
+
+        self.assertEqual(float(grad_norm[0]), 2.5)
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    def test_save_checkpoint_uses_stored_val_loss_history(self, mock_save_checkpoint):
+        self.trainer.metrics["val_loss"] = [xp.array(0.5, dtype=xp.float32)]
+
+        self.trainer._save_checkpoint(epoch=0)
+
+        mock_save_checkpoint.assert_called_once()
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    def test_save_checkpoint_skips_when_val_loss_does_not_improve(
+        self, mock_save_checkpoint
+    ):
+        self.trainer.metrics["val_loss"] = [
+            xp.array(0.5, dtype=xp.float32),
+            xp.array(0.7, dtype=xp.float32),
+        ]
+
+        self.trainer._save_checkpoint(epoch=1)
+
+        mock_save_checkpoint.assert_not_called()
 
 
 class TestLLMTrainer(BaseTrainerTest):


### PR DESCRIPTION
## Description

- update some contracts around data loader / trainer internals and speed up unit tests
- `BytePairEncoder` now only uses multiprocessing when the workload is large enough to amortize process startup / pickling
overhead
  - small text encoding now stays single-process
  - small pair-counting and merge-update workloads also stay single-process
  - this should help a lot on macOS where `spawn` cold start cost is relatively high
- `PairedIterableDataset` now materializes shuffled indices on the host once per epoch instead of iterating backend scalars one-
by-one, which avoids repeated device-to-host scalar syncs in the sample iteration path
- trainer metric histories now consistently store backend scalar arrays (or `None`) and only sync to host at explicit consumption
boundaries like:
  - logging
  - checkpoint comparison
  - metrics persistence
- simplify checkpoint save logic so it reads the latest stored `val_loss` history directly instead of taking `val_loss` separately
as an argument
- `grad_l2_norm()` now returns a backend scalar instead of eagerly converting to a Python float


## Performance Improvements (2.7x throughput on GPT-2 training)

`main` branch
```
Training Batches: 281it [00:12, 32.99it/s, tokens=107,904, tok/s=8,687.4]
```

This PR
```
Training Batches: 740it [00:12, 59.18it/s, tokens=284,160, tok/s=23,489.6]
```

## Tests (3x speedup with more unit tests)

Updated unit tests and added focused coverage for:
- tokenizer small-workload paths skipping multiprocessing
- `PairedIterableDataset` index contract changes
- trainer metric persistence with backend scalar values
- checkpoint save behavior based on stored validation-loss history
- `grad_l2_norm()` backend-scalar return contract

`main` branch
```
======================================================= test session starts ========================================================
platform darwin -- Python 3.12.2, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/henry/Git/ml-by-hand
configfile: pyproject.toml
testpaths: test
collected 327 items

...

============================================ 327 passed, 1 warning in 63.57s (0:01:03) =============================================
```

This PR
```
======================================================= test session starts ========================================================
platform darwin -- Python 3.12.2, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/henry/Git/ml-by-hand
configfile: pyproject.toml
testpaths: test
collected 335 items

...

================================================= 335 passed, 1 warning in 19.22s ==================================================
```
 
