### PR TITLE
Activation Checkpointing

### DIFF
--- a/autograd/backend.py
+++ b/autograd/backend.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import importlib
 import os
 from collections.abc import Sequence
-from typing import Any, Union
+from typing import Any
 
 import numpy as _host_np
 
 Array = Any
-ScalarLike = Union[int, float, bool]
-ArrayLike = Union[Array, Sequence[Any], ScalarLike]
+ScalarLike = int | float | bool
+ArrayLike = Array | Sequence[Any] | ScalarLike
+
+_BACKEND_MOD = {"cupy": "cupy", "mlx": "mlx.core"}
 
 
 # ---------------------------------------------------------------------------
@@ -45,39 +47,25 @@ def _discover_backend_name() -> str:
     return "numpy"
 
 
-_env_backend = os.getenv("AUTOGRAD_BACKEND")
-# Important: only call `_discover_backend_name()` when the env var is absent.
-# That lets `AUTOGRAD_BACKEND=numpy` skip MLX/CuPy probing entirely.
-if _env_backend is not None:
-    NAME = _env_backend.lower()
-    if NAME == "cupy":
-        cp = importlib.import_module("cupy")
-        if cp.cuda.runtime.getDeviceCount() <= 0:
-            raise RuntimeError(
-                "AUTOGRAD_BACKEND=cupy requested, but no CUDA device was detected"
-            )
-else:
-    NAME = _discover_backend_name()
-IS_MLX = NAME == "mlx"
-IS_NUMPY = NAME == "numpy"
-IS_CUPY = NAME == "cupy"
+NAME = (os.getenv("AUTOGRAD_BACKEND") or _discover_backend_name()).lower()
 
-
-xp: Any
-if IS_NUMPY:
-    xp = _host_np
-    ARRAY_TYPE = xp.ndarray
-
-elif IS_CUPY:
-    xp = importlib.import_module("cupy")
-    ARRAY_TYPE = xp.ndarray
-
-elif IS_MLX:
-    xp = importlib.import_module("mlx.core")
-    ARRAY_TYPE = type(xp.array(0, dtype=xp.float32))
-
+if NAME == "numpy":
+    xp: Any = _host_np
+elif NAME in _BACKEND_MOD:
+    xp = importlib.import_module(_BACKEND_MOD[NAME])
 else:
     raise ValueError(f"Unknown backend: {NAME}")
+
+IS_MLX = NAME == "mlx"
+IS_CUPY = NAME == "cupy"
+IS_NUMPY = NAME == "numpy"
+
+if IS_CUPY and xp.cuda.runtime.getDeviceCount() <= 0:
+    raise RuntimeError(
+        "AUTOGRAD_BACKEND=cupy requested, but no CUDA device was detected"
+    )
+
+ARRAY_TYPE = type(xp.array(0, dtype=xp.float32)) if IS_MLX else xp.ndarray
 
 
 # ---------------------------------------------------------------------------
@@ -85,41 +73,24 @@ else:
 # ---------------------------------------------------------------------------
 
 
-def _array(obj: Any, dtype: Any | None = None):
-    # We want the API to be `xp.array(...)` everywhere. If a
-    # backend already exposes that, use it directly; otherwise provide the
-    # narrow compatibility shim here instead of spreading backend conditionals
-    # across the codebase.
-    return xp.asarray(obj, dtype=dtype)
-
-
-def _scatter_add(dst: Any, idx: Any, updates: Any):
-    # Contract: return a new array and leave ``dst`` untouched.
-    # MLX already behaves that way; NumPy/CuPy need an explicit copy first.
-    if IS_MLX:
-        return dst.at[idx].add(updates)
-
-    out = xp.array(dst)
-    xp.add.at(out, idx, updates)
-    return out
-
-
 def eval(*xs: Any) -> None:
     if IS_MLX and xs:
         xp.eval(*xs)
 
 
+def _scatter_add(dst: Any, idx: Any, updates: Any):
+    if IS_MLX:
+        return dst.at[idx].add(updates)
+    out = xp.array(dst)
+    xp.add.at(out, idx, updates)
+    return out
+
+
 def _to_scalar(x: Any) -> Any:
-    # Keep this lower-level than `Tensor`: callers should unwrap higher-level
-    # objects before they reach the backend helper.
-    """Convert a backend scalar/0-d array to a plain Python scalar."""
     if hasattr(x, "detach") and hasattr(x, "cpu"):
         return x.detach().cpu().item()
-
     eval(x)
-    if hasattr(x, "item"):
-        return x.item()
-    return x
+    return x.item() if hasattr(x, "item") else x
 
 
 # Focused backend mismatch helpers.
@@ -129,115 +100,243 @@ def _to_scalar(x: Any) -> Any:
 # instead of hiding them behind another abstraction layer.
 
 
-def _as_strided_view(x, *, shape, strides):
-    # Stride units differ across backends, so keep the branch explicit here.
+def _as_strided_view(x: Any, *, shape: Any, strides: Any):
     if IS_MLX:
         return xp.as_strided(x, shape=shape, strides=strides)
-
     return xp.lib.stride_tricks.as_strided(
-        x,
-        shape=shape,
-        strides=tuple(s * x.itemsize for s in strides),
+        x, shape=shape, strides=tuple(s * x.itemsize for s in strides)
     )
 
 
-# ---------------------------------------------------------------------------
-# Random helpers and compatibility
-# ---------------------------------------------------------------------------
-
-
-def _sample_categorical(logits):
-    # This helper intentionally supports only the 1-D logits case used in the
-    # repo. Batched/axis-aware categorical sampling should use the backend API
-    # directly once we need that wider surface.
-    if logits.ndim != 1:
-        raise ValueError("sample_categorical only supports 1-D logits")
-
-    if IS_MLX:
-        return xp.random.categorical(logits)
-
-    shifted = logits - xp.max(logits)
-    probs = xp.exp(shifted)
-    probs = probs / xp.sum(probs)
-    return xp.random.choice(probs.shape[-1], p=probs)
-
-
-# The random namespace exists on every backend, but the signatures do not fully
-# line up. In practice:
-# - `normal` needs a backend branch because MLX requires `shape=...`
-# - `uniform` and `randint` are shared directly at call sites via the positional
-#   shape argument, so they do not need wrapper functions here
-# - `bernoulli` is a real semantic mismatch (`bernoulli` vs `binomial`)
-#
-# Capture the original callables before patching the compatibility wrappers in.
-# That keeps the wrapper implementations simple and avoids recursive self-calls.
-_native_random_normal: Any = xp.random.normal
-_native_random_bernoulli: Any = getattr(xp.random, "bernoulli", None)
-_native_random_binomial: Any = getattr(xp.random, "binomial", None)
-
-
-def _random_normal(
-    loc: float = 0.0,
-    scale: float = 1.0,
-    size: Any | None = None,
-    *,
-    shape: Any | None = None,
-):
-    # NumPy/CuPy use `size=...`, while MLX uses `shape=...`. Accept both names
-    # here and forward only the one the backend actually understands.
-    target_shape = shape if shape is not None else size
-    if IS_MLX:
-        return _native_random_normal(shape=target_shape, loc=loc, scale=scale)
-    return _native_random_normal(loc=loc, scale=scale, size=target_shape)
-
-
-def _random_bernoulli(
-    p: float,
-    size: Any | None = None,
-    *,
-    shape: Any | None = None,
-):
-    # NumPy/CuPy express Bernoulli sampling via `binomial(1, p, ...)`, while
-    # MLX exposes a dedicated `bernoulli(...)`. This wrapper makes the semantic
-    # operation explicit at the call site and hides only that API mismatch.
-    target_shape = shape if shape is not None else size
-    if IS_MLX:
-        return _native_random_bernoulli(p, shape=target_shape)
-    return _native_random_binomial(1, p, size=target_shape)
-
-
-# ---------------------------------------------------------------------------
-# Host conversion
-# ---------------------------------------------------------------------------
-
-
 def _to_numpy(x: Any):
-    # This helper exists only for host-side testing/debugging conversions.
-    # MLX arrays need an explicit evaluation boundary before NumPy conversion,
-    # and CuPy arrays need a device-to-host transfer. NumPy is the trivial path.
-    #
-    # This is intentionally a *host conversion* helper, not a generic "convert
-    # to backend array" helper. The name stays specific so readers know crossing
-    # to NumPy/CPU is exactly what happens here.
     if hasattr(x, "detach") and hasattr(x, "cpu"):
         return x.detach().cpu().numpy()
-
     if IS_MLX:
         eval(x)
         return _host_np.asarray(x)
-
     if IS_CUPY:
         if hasattr(xp, "asnumpy"):
             return xp.asnumpy(x)
         if hasattr(x, "get"):
             return x.get()
-
     return _host_np.asarray(x)
 
 
-# Attach the small compatibility surface we rely on across the repo.
-if not hasattr(xp, "array"):
-    xp.array = _array
+# -----------------------------------------------------------------------------
+# RNG compatibility
+# -----------------------------------------------------------------------------
+
+_backend_random = xp.random
+_native_random_fns = {
+    n: getattr(_backend_random, n, None)
+    for n in (
+        "seed",
+        "uniform",
+        "normal",
+        "randint",
+        "bernoulli",
+        "binomial",
+        "permutation",
+        "categorical",
+        "choice",
+    )
+}
+_backend_random_state: Any | None = _backend_random.key(0) if IS_MLX else None
+
+
+def _shape_or_size_kwargs(shape: Any = None, size: Any = None) -> dict[str, Any]:
+    s = shape if shape is not None else size
+    return {"shape": s} if IS_MLX else {"size": s}
+
+
+def _cast_numpy_random_output(out: Any, dtype: Any):
+    if dtype is None or not IS_NUMPY:
+        return out
+    if hasattr(out, "astype"):
+        return out.astype(dtype)
+    return _host_np.dtype(dtype).type(out)
+
+
+def _seed_backend_random(seed: int) -> None:
+    global _backend_random_state
+    fn = _native_random_fns["seed"]
+    if callable(fn):
+        fn(seed)
+    if IS_MLX:
+        _backend_random_state = _backend_random.key(seed)
+
+
+def _next_mlx_random_key() -> Any:
+    global _backend_random_state
+    if _backend_random_state is None:
+        _backend_random_state = _backend_random.key(0)
+    _backend_random_state, key = _backend_random.split(_backend_random_state, 2)
+    return key
+
+
+def _call_backend_random(name: str, /, *args: Any, **kwargs: Any):
+    fn = _native_random_fns.get(name)
+    if fn is None:
+        raise RuntimeError(f"{name} is not available on backend {NAME}")
+    if IS_MLX and "key" not in kwargs:
+        kwargs["key"] = _next_mlx_random_key()
+    return fn(*args, **kwargs)
+
+
+def _sample_two_parameter_float_distribution(
+    name: str,
+    a: Any,
+    b: Any,
+    k0: str,
+    k1: str,
+    shape: Any = None,
+    *,
+    size: Any = None,
+    dtype: Any = None,
+):
+    kw = {k0: a, k1: b, **_shape_or_size_kwargs(shape, size)}
+    if dtype is not None and not IS_NUMPY:
+        kw["dtype"] = dtype
+    return _cast_numpy_random_output(_call_backend_random(name, **kw), dtype)
+
+
+def _sample_uniform(
+    low: Any = 0.0,
+    high: Any = 1.0,
+    shape: Any = None,
+    *,
+    size: Any = None,
+    dtype: Any = None,
+):
+    return _sample_two_parameter_float_distribution(
+        "uniform", low, high, "low", "high", shape, size=size, dtype=dtype
+    )
+
+
+def _sample_normal(
+    loc: Any = 0.0,
+    scale: Any = 1.0,
+    shape: Any = None,
+    *,
+    size: Any = None,
+    dtype: Any = None,
+):
+    return _sample_two_parameter_float_distribution(
+        "normal", loc, scale, "loc", "scale", shape, size=size, dtype=dtype
+    )
+
+
+def _sample_randint(
+    low: Any,
+    high: Any = None,
+    shape: Any = None,
+    *,
+    size: Any = None,
+    dtype: Any = None,
+):
+    if high is None:
+        low, high = 0, low
+    kw = _shape_or_size_kwargs(shape, size)
+    if dtype is not None:
+        kw["dtype"] = dtype
+    return _call_backend_random("randint", low, high, **kw)
+
+
+def _sample_bernoulli(p: Any = 0.5, shape: Any = None, *, size: Any = None):
+    s = shape if shape is not None else size
+    if IS_MLX and _native_random_fns["bernoulli"] is not None:
+        return _call_backend_random("bernoulli", p, shape=s)
+
+    binomial = _native_random_fns.get("binomial")
+    if binomial is None:
+        raise RuntimeError(f"bernoulli is not available on backend {NAME}")
+    return binomial(1, p, size=s)
+
+
+def _sample_permutation(x: Any, *, axis: int = 0):
+    return _call_backend_random("permutation", x, **({"axis": axis} if IS_MLX else {}))
+
+
+def _sample_categorical(logits: Any):
+    if logits.ndim != 1:
+        raise ValueError("sample_categorical only supports 1-D logits")
+
+    if _native_random_fns["categorical"] is not None:
+        return _call_backend_random("categorical", logits)
+
+    probs = xp.exp(logits - xp.max(logits))
+    probs = probs / xp.sum(probs)
+
+    choice = _native_random_fns.get("choice")
+    if choice is None:
+        raise RuntimeError(f"categorical sampling is not available on backend {NAME}")
+    return choice(probs.shape[-1], p=probs)
+
+
+def _sample_categorical_with_options(
+    logits: Any,
+    *,
+    axis: int = -1,
+    shape: Any = None,
+    num_samples: Any = None,
+):
+    if _native_random_fns["categorical"] is None:
+        if axis != -1 or shape is not None or num_samples is not None:
+            raise RuntimeError(
+                f"categorical options are not available on backend {NAME}"
+            )
+        return _sample_categorical(logits)
+
+    return _call_backend_random(
+        "categorical", logits, axis=axis, shape=shape, num_samples=num_samples
+    )
+
+
+def _clone_random_state(state: Any):
+    if isinstance(state, tuple):
+        return tuple(_clone_random_state(x) for x in state)
+    if isinstance(state, list):
+        return [_clone_random_state(x) for x in state]
+    if isinstance(state, ARRAY_TYPE):
+        return xp.array(state)
+    copy = getattr(state, "copy", None)
+    return copy() if callable(copy) else state
+
+
+def get_random_state() -> Any:
+    if IS_MLX:
+        if _backend_random_state is None:
+            raise RuntimeError("backend random state is not initialized")
+        return _clone_random_state(_backend_random_state)
+
+    get_state = getattr(_backend_random, "get_state", None) or getattr(
+        _backend_random, "get_random_state", None
+    )
+    if callable(get_state):
+        return _clone_random_state(get_state())
+
+    raise RuntimeError(f"Random state capture is not supported on backend {NAME}")
+
+
+def set_random_state(state: Any) -> None:
+    global _backend_random_state
+    if IS_MLX:
+        _backend_random_state = _clone_random_state(state)
+        return
+
+    set_state = getattr(_backend_random, "set_state", None) or getattr(
+        _backend_random, "set_random_state", None
+    )
+    if callable(set_state):
+        set_state(_clone_random_state(state))
+        return
+
+    raise RuntimeError(f"Random state restore is not supported on backend {NAME}")
+
+
+# -----------------------------------------------------------------------------
+# Install repo-level API
+# -----------------------------------------------------------------------------
 
 if not hasattr(xp, "scatter_add"):
     xp.scatter_add = _scatter_add
@@ -245,6 +344,12 @@ if not hasattr(xp, "scatter_add"):
 xp.to_scalar = _to_scalar
 xp.as_strided_view = _as_strided_view
 xp.sample_categorical = _sample_categorical
-xp.random.normal = _random_normal
-xp.random.bernoulli = _random_bernoulli
 xp.to_numpy = _to_numpy
+
+_backend_random.seed = _seed_backend_random
+_backend_random.normal = _sample_normal
+_backend_random.uniform = _sample_uniform
+_backend_random.randint = _sample_randint
+_backend_random.bernoulli = _sample_bernoulli
+_backend_random.permutation = _sample_permutation
+_backend_random.categorical = _sample_categorical_with_options

--- a/autograd/data/data_loader.py
+++ b/autograd/data/data_loader.py
@@ -48,16 +48,26 @@ class DataLoader:
 
     def __iter__(self):
         examples = []
+        yielded_batch = False
 
         for example in self.dataset:
             examples.append(example)
 
             if len(examples) == self.batch_size:
+                yielded_batch = True
                 yield self.collate_fn(examples) if self.collate_fn else examples
                 examples = []
 
         if examples and not self.drop_last:
+            yielded_batch = True
             yield self.collate_fn(examples) if self.collate_fn else examples
+
+        if not yielded_batch:
+            raise ValueError(
+                "DataLoader yielded no batches. The dataset may be empty, may "
+                "have yielded no examples for this pass, or drop_last=True may "
+                "have dropped the only partial batch."
+            )
 
     def __len__(self) -> int:
         n = len(self.dataset)

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -280,6 +280,23 @@ class Optimizer:
 
         self._recursive_param_op(self.model_parameters, update_fn)
 
+    def scale_gradients(self, scale: float) -> None:
+        """Scale all parameter gradients in-place by ``scale``."""
+        if scale == 1.0:
+            return
+
+        for param in self.model_parameters.values():
+            if param.grad is not None:
+                param.grad.data *= scale
+
+    def grad_l2_norm(self) -> float:
+        """Return the L2 norm of all current parameter gradients."""
+        grad_norm = 0.0
+        for param in self.model_parameters.values():
+            if param.grad is not None:
+                grad_norm += (param.grad.data**2).sum()
+        return float(xp.to_scalar(grad_norm**0.5))
+
     def state_dict(self) -> Dict[str, Any]:
         """
         Return a dictionary representing the optimizer's state for checkpointing.

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -14,7 +14,14 @@ from typing import (
     cast,
 )
 
-from autograd.backend import ARRAY_TYPE, Array, ArrayLike, xp
+from autograd.backend import (
+    ARRAY_TYPE,
+    Array,
+    ArrayLike,
+    get_random_state,
+    set_random_state,
+    xp,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1103,6 +1110,75 @@ class Tensor:
 
     def __lt__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
         return self.data < (other.data if isinstance(other, Tensor) else other)
+
+
+class _CheckpointFunction(Function):
+    def __init__(
+        self,
+        run_function,
+        tensors: Tuple[Tensor, ...],
+    ) -> None:
+        super().__init__(*tensors)
+        self.run_function = run_function
+        self.forward_rng_state = get_random_state()
+
+    def backward(self, grad: Tensor):
+        recomputed_inputs = tuple(
+            Tensor(tensor.data, requires_grad=tensor.requires_grad)
+            for tensor in self.tensors
+        )
+        current_rng_state = get_random_state()
+        try:
+            set_random_state(self.forward_rng_state)
+            recomputed_output = self.run_function(*recomputed_inputs)
+        finally:
+            set_random_state(current_rng_state)
+
+        if not isinstance(recomputed_output, Tensor):
+            raise TypeError(
+                "checkpointed function must return a Tensor, "
+                f"got {type(recomputed_output)!r}"
+            )
+        recomputed_output.backward(grad)
+        return tuple(
+            input_tensor.grad.data if input_tensor.grad is not None else None
+            for input_tensor in recomputed_inputs
+        )
+
+
+def checkpoint(
+    run_function: Any,
+    *tensors: Tensor,
+) -> Tensor:
+    if not callable(run_function):
+        raise TypeError(f"run_function must be callable, got {run_function!r}")
+    if not tensors:
+        raise ValueError("checkpoint requires at least one Tensor input")
+    if not all(isinstance(tensor, Tensor) for tensor in tensors):
+        raise TypeError("checkpoint only supports Tensor positional arguments")
+
+    requires_grad = is_grad_enabled() and any(
+        tensor.requires_grad for tensor in tensors
+    )
+    if not requires_grad:
+        output = run_function(*tensors)
+        if not isinstance(output, Tensor):
+            raise TypeError(
+                f"checkpointed function must return a Tensor, got {type(output)!r}"
+            )
+        return output
+
+    creator = _CheckpointFunction(
+        run_function,
+        cast(Tuple[Tensor, ...], tensors),
+    )
+    with no_grad():
+        output = run_function(*tensors)
+    if not isinstance(output, Tensor):
+        raise TypeError(
+            f"checkpointed function must return a Tensor, got {type(output)!r}"
+        )
+    return Tensor(output.data, creator=creator, requires_grad=True)
 
     def __le__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
         return self.data <= (other.data if isinstance(other, Tensor) else other)

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -37,6 +37,8 @@ class GenericTrainingConfig:
     def __post_init__(self) -> None:
         if self.max_epochs is None and self.max_steps is None:
             raise ValueError("At least one of max_epochs or max_steps must be set")
+        if self.max_epochs is not None and self.max_steps is not None:
+            raise ValueError("max_epochs and max_steps are mutually exclusive")
         if self.max_epochs is not None and self.max_epochs < 1:
             raise ValueError(f"max_epochs must be >= 1, got {self.max_epochs}")
         if self.max_steps is not None and self.max_steps < 1:

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -25,6 +25,21 @@ class GenericTrainingConfig:
     max_epochs: Optional[int] = None
     max_steps: Optional[int] = None
     max_eval_steps: Optional[int] = None
+    # Controls how often step-mode training reports/logs/evaluates.
+    # This is intentionally separate from checkpoint_freq: reporting cadence
+    # should not imply checkpoint cadence.
+    #
+    # Important: this is not another batch-size knob. micro_batch_size controls
+    # per-forward/backward memory, and global_batch_size controls gradient
+    # accumulation / optimizer-update cadence. report_every_steps only controls
+    # how long trainer-side reporting state can stay unsynchronized before we
+    # scalarize/log it.
+    #
+    # On MLX, larger values can retain deferred metric/loss accumulation work
+    # for longer before a host sync point, which may show up as bursty sync or
+    # allocator pressure even though the effective training batch size is
+    # unchanged.
+    report_every_steps: Optional[int] = None
     # Whether to load from a checkpoint
     resume_epoch: Optional[int] = None
     training_run_name: str = "default"
@@ -45,6 +60,16 @@ class GenericTrainingConfig:
             raise ValueError(f"max_steps must be >= 1, got {self.max_steps}")
         if self.max_eval_steps is not None and self.max_eval_steps < 1:
             raise ValueError(f"max_eval_steps must be >= 1, got {self.max_eval_steps}")
+        if self.report_every_steps is not None:
+            if not isinstance(self.report_every_steps, int):
+                raise ValueError(
+                    "report_every_steps must be an int, "
+                    f"got {self.report_every_steps!r}"
+                )
+            if self.report_every_steps < 1:
+                raise ValueError(
+                    f"report_every_steps must be >= 1, got {self.report_every_steps}"
+                )
         if not isinstance(self.checkpoint_freq, int):
             raise ValueError(
                 f"checkpoint_freq must be an int, got {self.checkpoint_freq!r}"

--- a/autograd/tools/model.py
+++ b/autograd/tools/model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 from typing import Any, Dict
@@ -14,8 +15,11 @@ SerializedMeta = Dict[str, Any]
 
 
 def save_checkpoint(
-    obj: Any, json_path: str = "checkpoint.json", npz_path: str = "checkpoint.npz"
-) -> None:
+    obj: Any,
+    *,
+    checkpoint_dir: str = ".",
+    checkpoint_name: str = "checkpoint",
+) -> tuple[str, str]:
     """Save a Python object (model state, etc.) into JSON and NPZ files.
 
     This function splits the saved content into:
@@ -25,10 +29,10 @@ def save_checkpoint(
     Args:
         obj: The Python object to serialize, typically a model's state_dict or
             other checkpoint data structure.
-        json_path (str): The file path to save the JSON metadata. Defaults to
-            'checkpoint.json'.
-        npz_path (str): The file path to save the NPZ data. Defaults to
-            'checkpoint.npz'.
+        checkpoint_dir (str): Directory where checkpoint files are written.
+            Defaults to the current directory.
+        checkpoint_name (str): Basename for the checkpoint files written inside
+            `checkpoint_dir`. Defaults to `checkpoint`.
 
     Raises:
         OSError: If there is an error writing to the specified files.
@@ -42,8 +46,11 @@ def save_checkpoint(
         ...     },
         ...     "epoch": 5
         ... }
-        >>> save_checkpoint(obj_to_save, "my_model.json", "my_model.npz")
+        >>> save_checkpoint(obj_to_save, checkpoint_name="my_model")
     """
+    os.makedirs(checkpoint_dir, exist_ok=True)
+    json_path = os.path.join(checkpoint_dir, f"{checkpoint_name}.json")
+    npz_path = os.path.join(checkpoint_dir, f"{checkpoint_name}.npz")
 
     def _serialize(
         obj: Any, arrays: Dict[str, Any], prefix: str = ""
@@ -101,6 +108,13 @@ def save_checkpoint(
         if isinstance(obj, (int, float, str, bool, type(None))):
             return {"_type": "scalar", "value": obj}
 
+        if isinstance(obj, type):
+            return {
+                "_type": "class",
+                "module": obj.__module__,
+                "qualname": obj.__qualname__,
+            }
+
         # Fallback for other types
         return {"_type": "raw", "value": str(obj)}
 
@@ -113,6 +127,7 @@ def save_checkpoint(
 
     # Save arrays to NPZ
     xp.savez_compressed(npz_path, **arrays_dict)
+    return json_path, npz_path
 
 
 def load_checkpoint(
@@ -176,6 +191,13 @@ def load_checkpoint(
 
         if t == "array":
             return data[meta["key"]]
+
+        if t == "class":
+            module = importlib.import_module(meta["module"])
+            resolved = module
+            for attr in meta["qualname"].split("."):
+                resolved = getattr(resolved, attr)
+            return resolved
 
         if "key" in meta and "items" not in meta and "value" not in meta:
             return data[meta["key"]]

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -134,17 +134,27 @@ class TrainingState:
 class TrainingPlan:
     by_epoch: bool
     target_step: int
+    # Note that the reporting frequency also dictates the MLX lazy-to-materialize trigger
+    # Don't set this too high, otherwise, MLX could accumulate a lot of operations and
+    # might directly reach "RuntimeError: [metal::malloc] Resource limit exceeded"
     report_every_steps: int
     checkpoint_every: int
     steps_per_epoch: Optional[int] = None
     metrics_interval: int = 1
 
     @classmethod
-    def for_steps(cls, max_steps: int, checkpoint_every: int) -> "TrainingPlan":
+    def for_steps(
+        cls,
+        max_steps: int,
+        report_every_steps: int,
+        checkpoint_every: int,
+    ) -> "TrainingPlan":
+        if report_every_steps <= 0:
+            raise ValueError("report_every_steps must be > 0 in step mode.")
         return cls(
             by_epoch=False,
             target_step=max_steps,
-            report_every_steps=checkpoint_every,
+            report_every_steps=report_every_steps,
             checkpoint_every=checkpoint_every,
         )
 
@@ -270,8 +280,17 @@ class AbstractTrainer(ABC):
         )
         accumulation_steps = int(self.config.gradient_accumulation_steps)
         if self.config.max_steps is not None:
+            # Step-mode reporting/eval cadence is separate from checkpoint
+            # cadence. A larger report_every_steps does not change the effective
+            # training batch size; it only delays reporting/sync points.
+            # On MLX, delaying those sync points can retain deferred
+            # loss/metric work longer and make the eventual host scalarization
+            # more bursty.
             plan = TrainingPlan.for_steps(
                 max_steps=self.config.max_steps,
+                report_every_steps=(
+                    self.config.report_every_steps or self.config.checkpoint_freq
+                ),
                 checkpoint_every=self.config.checkpoint_freq,
             )
         else:

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -1,8 +1,9 @@
 import logging
 import os
 from abc import ABC, abstractmethod
-from collections import defaultdict
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple, cast
+from dataclasses import dataclass, field
+from pprint import pformat
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, cast
 
 from tqdm import tqdm
 
@@ -12,23 +13,192 @@ from autograd.backend import (
     eval,
     xp,
 )
-from autograd.tensor import Tensor
+from autograd.data.data_loader import DataLoader
+from autograd.tensor import Tensor, no_grad
 from autograd.tools.config_schema import (
     GenericTrainingConfig,
     TransformerTrainingConfig,
 )
-from autograd.tools.metrics import accuracy, mean_squared_error
 from autograd.tools.model import load_checkpoint, save_checkpoint
 
 logger = logging.getLogger(__name__)
+
+
+def _pformat_log_dict(payload: Mapping[str, Any]) -> str:
+    compact_payload = {
+        key: value for key, value in payload.items() if value is not None
+    }
+    return pformat(compact_payload, sort_dicts=False)
+
+
+def _format_log_values(
+    payload: Mapping[str, Any],
+    *,
+    default_precision: int = 4,
+    precision_overrides: Optional[Mapping[str, int]] = None,
+) -> dict[str, Any]:
+    formatted: dict[str, Any] = {}
+    for key, value in payload.items():
+        if value is None:
+            continue
+        if isinstance(value, float):
+            precision = (
+                default_precision
+                if precision_overrides is None
+                else precision_overrides.get(key, default_precision)
+            )
+            formatted[key] = f"{value:.{precision}f}"
+            continue
+        formatted[key] = value
+    return formatted
+
+
+@dataclass
+class TrainingState:
+    report_loss_sum: Optional[float | Array] = None
+    report_batches: int = 0
+    accumulated_batches: int = 0
+    eval_loss_sum: float = 0.0
+    eval_loss_batches: int = 0
+    eval_metric_totals: Dict[str, Dict[str, float]] = field(default_factory=dict)
+
+    def record_loss(self, loss: float | Tensor) -> None:
+        loss_data = loss.data if isinstance(loss, Tensor) else float(loss)
+        if self.report_loss_sum is None:
+            self.report_loss_sum = loss_data
+        else:
+            self.report_loss_sum = self.report_loss_sum + loss_data
+        self.report_batches += 1
+        self.accumulated_batches += 1
+
+    def record_eval_loss(self, loss: float | Tensor) -> None:
+        loss_value = loss.item() if isinstance(loss, Tensor) else float(loss)
+        self.eval_loss_sum += float(loss_value)
+        self.eval_loss_batches += 1
+
+    def record_eval_metric(
+        self,
+        name: str,
+        *,
+        numerator: float,
+        denominator: float,
+    ) -> None:
+        totals = self.eval_metric_totals.setdefault(
+            name,
+            {"numerator": 0.0, "denominator": 0.0},
+        )
+        totals["numerator"] += float(numerator)
+        totals["denominator"] += float(denominator)
+
+    @property
+    def train_loss(self) -> float:
+        if self.report_loss_sum is None:
+            return 0.0
+        return float(xp.to_scalar(self.report_loss_sum / max(self.report_batches, 1)))
+
+    @property
+    def val_loss(self) -> float:
+        return self.eval_loss_sum / max(self.eval_loss_batches, 1)
+
+    @property
+    def eval_metrics(self) -> Mapping[str, float]:
+        return {
+            name: totals["numerator"] / totals["denominator"]
+            for name, totals in self.eval_metric_totals.items()
+            if totals["denominator"] > 0
+        }
+
+    def to_metrics_row(
+        self,
+        *,
+        eval_state: Optional["TrainingState"] = None,
+    ) -> dict[str, Optional[float]]:
+        row: dict[str, Optional[float]] = {
+            "train_loss": self.train_loss,
+            "val_loss": None if eval_state is None else eval_state.val_loss,
+        }
+        if eval_state is not None:
+            for key, value in eval_state.eval_metrics.items():
+                row[f"val_{key}"] = value
+        return row
+
+    def reset_report(self) -> None:
+        self.report_loss_sum = None
+        self.report_batches = 0
+
+    def has_enough_batches(self, accumulation_steps: int):
+        return self.accumulated_batches >= accumulation_steps
+
+
+@dataclass(frozen=True)
+class TrainingPlan:
+    by_epoch: bool
+    target_step: int
+    report_every_steps: int
+    checkpoint_every: int
+    steps_per_epoch: Optional[int] = None
+    metrics_interval: int = 1
+
+    @classmethod
+    def for_steps(cls, max_steps: int, checkpoint_every: int) -> "TrainingPlan":
+        return cls(
+            by_epoch=False,
+            target_step=max_steps,
+            report_every_steps=checkpoint_every,
+            checkpoint_every=checkpoint_every,
+        )
+
+    @classmethod
+    def for_epochs(
+        cls,
+        max_epochs: int,
+        steps_per_epoch: int,
+        checkpoint_every: int,
+    ) -> "TrainingPlan":
+        if steps_per_epoch <= 0:
+            raise ValueError("steps_per_epoch must be > 0 in epoch mode.")
+
+        return cls(
+            by_epoch=True,
+            target_step=max_epochs * steps_per_epoch,
+            report_every_steps=steps_per_epoch,
+            checkpoint_every=checkpoint_every,
+            steps_per_epoch=steps_per_epoch,
+            metrics_interval=max(1, max_epochs // min(20, max_epochs)),
+        )
+
+    def completed_epochs(self, step: int) -> int:
+        if self.steps_per_epoch is None:
+            raise ValueError("steps_per_epoch is required in epoch mode.")
+        return step // self.steps_per_epoch
+
+    def progress_value(self, step: int) -> int:
+        return self.completed_epochs(step) if self.by_epoch else step
+
+    def progress_label(self) -> str:
+        return "Epoch" if self.by_epoch else "Step"
+
+    def is_done(self, step: int) -> bool:
+        return step >= self.target_step
+
+    def should_report(self, step: int) -> bool:
+        return self.is_done(step) or step % self.report_every_steps == 0
+
+    def should_checkpoint(self, step: int) -> bool:
+        return self.progress_value(step) % self.checkpoint_every == 0
+
+    def should_save_metrics(self, step: int) -> bool:
+        if not self.by_epoch:
+            return True
+        return self.progress_value(step) % self.metrics_interval == 0
 
 
 class AbstractTrainer(ABC):
     """Base trainer that defines a high-level training loop.
 
     Subclasses should implement domain-specific steps such as:
-    - forward pass and loss computation in `train_step`
-    - evaluation logic in `evaluate`
+    - forward pass and loss computation in `_compute_loss`
+    - evaluation logic in `_evaluate`
 
     Attributes:
         CHECKPOINT_DIR (str): Default directory for checkpoints.
@@ -55,9 +225,10 @@ class AbstractTrainer(ABC):
             config (GenericTrainingConfig): Training configuration object.
             **kwargs: Additional arguments for specialized trainers (e.g., checkpoint paths).
         """
-        self.config = config or {}
+        self.config = config
         self.loss_fn = loss_fn
-        self.kwargs = kwargs
+        # `resume_epoch` is only a checkpoint lookup hint here. Runtime training
+        # progress comes from the loaded checkpoint metadata, especially step_count.
         self.model, self.optimizer, self.checkpoint = self._load_model_and_optimizer(
             model_class=model_cls,
             optimizer_class=optimizer_cls,
@@ -66,166 +237,260 @@ class AbstractTrainer(ABC):
             resume_epoch=config.resume_epoch,
             checkpoint_path=kwargs.get("checkpoint_path"),
         )
-        self.start_epoch = self.config.resume_epoch or 0
+        # `global_step` counts consumed training batches / microbatches,
+        # not optimizer updates. Under gradient accumulation, multiple
+        # microbatches can contribute to one optimizer step.
         self.global_step = int(self.checkpoint.get("step_count", 0))
-        self.metrics = defaultdict(list)
+        self.metric_rows: list[dict[str, Optional[float]]] = []
+        self.best_val_loss: Optional[float] = self.checkpoint.get("best_val_loss")
+        self.last_grad_l2_norm: Optional[float] = None
 
-    def fit(self, train_data_loader, val_data_loader=None):
+    def fit(
+        self,
+        train_data_loader: DataLoader,
+        val_data_loader: Optional[DataLoader] = None,
+    ):
         """Performs the main training loop over the given data loaders.
 
         Args:
             train_data_loader: An iterable or generator that yields training batches.
             val_data_loader: (Optional) An iterable or generator that yields labeled
                 validation batches.
+
+        Notes:
+            `global_step` counts consumed training batches / microbatches.
+            It does not count optimizer updates when gradient accumulation is enabled.
         """
+
+        self._validate_fit_inputs(train_data_loader)
+
         logger.info(
             f"Training {self.model.__class__.__name__} with "
             f"{(self.model.num_parameters() / 1e6):.2f}M parameters."
         )
-        if self.config.max_steps is None:
-            try:
-                len(train_data_loader)
-            except TypeError as exc:
-                raise ValueError(
-                    "Infinite training loaders require max_steps. "
-                    "Set max_steps or give the dataset examples_per_epoch."
-                ) from exc
-        epoch = self.start_epoch
-        while True:
-            if self._max_epochs_reached(epoch) or self._max_steps_reached():
-                break
-            if hasattr(train_data_loader, "on_epoch_start"):
+        accumulation_steps = int(self.config.gradient_accumulation_steps)
+        if self.config.max_steps is not None:
+            plan = TrainingPlan.for_steps(
+                max_steps=self.config.max_steps,
+                checkpoint_every=self.config.checkpoint_freq,
+            )
+        else:
+            plan = TrainingPlan.for_epochs(
+                max_epochs=cast(int, self.config.max_epochs),
+                steps_per_epoch=len(train_data_loader),
+                checkpoint_every=self.config.checkpoint_freq,
+            )
+
+        self._log_fit_start(plan)
+
+        state = TrainingState()
+        if self.global_step >= plan.target_step:
+            return
+
+        self.model.train()
+        self.optimizer.zero_grad()
+
+        with tqdm(
+            total=plan.target_step,
+            initial=self.global_step,
+            desc="Training",
+            leave=False,
+        ) as progress_bar:
+            while not plan.is_done(self.global_step):
                 train_data_loader.on_epoch_start()
+                batches_this_pass = 0
 
-            self.model.train()
-            train_loss = self._train_one_epoch(train_data_loader)
+                for batch in train_data_loader:
+                    batches_this_pass += 1
 
-            if val_data_loader is not None:
-                if hasattr(val_data_loader, "on_epoch_start"):
-                    val_data_loader.on_epoch_start()
-                val_loss = self.evaluate(val_data_loader)
+                    loss = self._compute_loss(batch)
+                    loss.backward()
+                    state.record_loss(loss)
+
+                    self.global_step += 1
+                    progress_bar.update(1)
+
+                    # whether we should flush
+                    if state.has_enough_batches(
+                        accumulation_steps
+                    ) or plan.should_report(self.global_step):
+                        self.optimizer_step(
+                            state,
+                            record_grad_norm=plan.should_report(self.global_step),
+                        )
+
+                    if plan.should_report(self.global_step):
+                        eval_state = (
+                            self.evaluate(val_data_loader)
+                            if val_data_loader is not None
+                            else None
+                        )
+                        self.report(state, plan, eval_state)
+
+                    if plan.is_done(self.global_step):
+                        break
+
+                if (
+                    plan.by_epoch
+                    and plan.steps_per_epoch is not None
+                    and batches_this_pass != plan.steps_per_epoch
+                ):
+                    raise ValueError(
+                        "In epoch mode, len(train_data_loader) must match the actual "
+                        "number of batches yielded per loader pass."
+                    )
+
+                # This is after all the batches in the data loader
+                self.optimizer_step(
+                    state,
+                    record_grad_norm=False,
+                )
+
+    def optimizer_step(
+        self, state: TrainingState, *, record_grad_norm: bool = True
+    ) -> None:
+        if state.accumulated_batches == 0:
+            return
+
+        self.optimizer.scale_gradients(1.0 / state.accumulated_batches)
+
+        if record_grad_norm:
+            self.last_grad_l2_norm = self.optimizer.grad_l2_norm()
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+        state.accumulated_batches = 0
+
+    def evaluate(self, val_data_loader: DataLoader) -> TrainingState:
+        val_data_loader.on_epoch_start()
+        was_training = getattr(self.model, "_is_training", None)
+        self.model.eval()
+        try:
+            with no_grad():
+                return self._evaluate(val_data_loader)
+        finally:
+            if was_training is False:
+                self.model.eval()
             else:
-                val_loss = None
+                self.model.train()
 
-            self._on_epoch_end(epoch, train_loss, val_loss)
+    def report(
+        self,
+        state: TrainingState,
+        plan: TrainingPlan,
+        eval_state: Optional[TrainingState],
+    ) -> None:
+        completed_epochs = (
+            plan.completed_epochs(self.global_step) if plan.by_epoch else None
+        )
+        progress_value = plan.progress_value(self.global_step)
+        row: dict[str, Optional[float]] = {
+            "epoch": completed_epochs,
+            "step": float(self.global_step),
+            **state.to_metrics_row(eval_state=eval_state),
+            "grad_l2_norm": self.last_grad_l2_norm,
+        }
 
-            if epoch % self._metrics_save_interval() == 0:
-                self._save_metrics()
-            epoch += 1
+        if plan.should_checkpoint(self.global_step):
+            self._maybe_save_checkpoint(plan=plan, eval_state=eval_state)
 
-    def _max_epochs_reached(self, epoch: int) -> bool:
-        return self.config.max_epochs is not None and epoch >= self.config.max_epochs
-
-    def _metrics_save_interval(self) -> int:
-        if self.config.max_epochs is None:
-            return 1
-        return max(1, self.config.max_epochs // min(20, self.config.max_epochs))
-
-    def _max_steps_reached(self) -> bool:
-        return (
-            self.config.max_steps is not None
-            and self.global_step >= self.config.max_steps
+        self.metric_rows.append(row)
+        log_payload = _format_log_values(
+            {**row, "step": self.global_step, "lr": self.optimizer.lr},
+            precision_overrides={"lr": 6},
+        )
+        logger.info(
+            "[%s %s]\n%s",
+            plan.progress_label(),
+            progress_value,
+            _pformat_log_dict(log_payload),
         )
 
-    def _max_eval_steps_reached(self, batch_count: int) -> bool:
-        return (
-            self.config.max_eval_steps is not None
-            and batch_count >= self.config.max_eval_steps
-        )
+        if plan.should_save_metrics(self.global_step):
+            self._save_metrics()
 
-    def _train_one_epoch(self, data_loader) -> float:
-        """Trains the model for one epoch on the provided data loader.
+        state.reset_report()
 
-        This method handles gradient accumulation and parameter updates.
+    @abstractmethod
+    def _compute_loss(self, batch_data) -> Tensor:
+        """Returns the scalar loss Tensor for a single training batch.
+
+        Subclasses must implement the forward pass and loss computation here.
+        `fit()` owns `.backward()`.
 
         Args:
-            data_loader: An iterable or generator that yields training batches.
+            batch_data: A single batch of training data.
 
         Returns:
-            float: The average training loss over the epoch.
+            Tensor: Scalar loss Tensor for the batch.
         """
-        total_loss = 0.0
-        batch_count = 0
-        accumulation_steps = self.config.gradient_accumulation_steps
-        accumulated_batches = 0
-        self.optimizer.zero_grad()
-        for batch in tqdm(data_loader, desc="Training Batches", leave=False):
-            if self._max_steps_reached():
-                break
-            loss = self.train_step(batch)
-            total_loss += loss
-            accumulated_batches += 1
-            if accumulated_batches == accumulation_steps:
-                self._scale_gradients(1.0 / accumulated_batches)
-                self.optimizer.step()  # increments .timestep, applies LR scheduler if present
-                self.metrics["grad_l2_norm"].append(grad_l2_norm(self.model.parameters))
-                self.optimizer.zero_grad()
-                accumulated_batches = 0
-            batch_count += 1
-            self.global_step += 1
-        if accumulated_batches > 0:
-            self._scale_gradients(1.0 / accumulated_batches)
-            self.optimizer.step()
-            self.metrics["grad_l2_norm"].append(grad_l2_norm(self.model.parameters))
-            self.optimizer.zero_grad()
-        return total_loss / max(batch_count, 1)
+        pass
 
-    def _scale_gradients(self, scale: float) -> None:
-        if scale == 1.0:
-            return
-        # Normalize accumulated gradients so the optimizer step matches the
-        # average gradient over the effective batch, including partial tail groups.
-        for parameter in self.model.parameters.values():
-            if parameter.grad is not None:
-                parameter.grad.data *= scale
-
-    def _save_checkpoint(self, epoch: int, val_loss: Optional[float]):
-        """Saves a model checkpoint if the validation loss improves.
+    @abstractmethod
+    def _evaluate(self, val_data_loader) -> TrainingState:
+        """Evaluates the model on the validation set.
 
         Args:
-            epoch (int): Current epoch number.
-            val_loss (Optional[float]): The validation loss at this epoch.
+            val_data_loader: Validation data loader providing validation batches.
+
+        Returns:
+            TrainingState: Raw validation aggregates for the current report.
         """
-        if val_loss is not None and epoch % self.config.checkpoint_freq == 0:
-            # `val_loss` history can contain `None` from epochs without validation;
-            # exclude those before computing the current best checkpoint threshold.
-            historical_val_losses = [
-                recorded_val_loss
-                for recorded_val_loss in self.metrics["val_loss"]
-                if recorded_val_loss is not None
-            ]
-            if not historical_val_losses or val_loss < min(historical_val_losses):
-                checkpoint = {
-                    "epoch": epoch + 1,
-                    "step_count": self.global_step,
-                    "model_state_dict": self.model.state_dict(),
-                    "optimizer_state_dict": self.optimizer.state_dict(),
-                    "model_init_kwargs": self.config.model_kwargs,
-                    "optimizer_init_kwargs": self.config.optimizer_kwargs,
-                    "config": self.config,
-                }
-                os.makedirs(self.CHECKPOINT_DIR, exist_ok=True)
-                cp_path_json = os.path.join(
-                    self.CHECKPOINT_DIR,
-                    f"{self.config.training_run_name}_{self.model.__class__.__name__}_{epoch}.json",
-                )
-                cp_path_npz = os.path.join(
-                    self.CHECKPOINT_DIR,
-                    f"{self.config.training_run_name}_{self.model.__class__.__name__}_{epoch}.npz",
-                )
-                save_checkpoint(
-                    checkpoint, json_path=cp_path_json, npz_path=cp_path_npz
-                )
-                logger.info(f"Saved checkpoint to {cp_path_json} and {cp_path_npz}")
+        pass
+
+    def _maybe_save_checkpoint(
+        self,
+        *,
+        plan: TrainingPlan,
+        eval_state: Optional[TrainingState],
+    ) -> None:
+        if eval_state is not None:
+            val_loss = eval_state.val_loss
+            if self.best_val_loss is not None and val_loss >= self.best_val_loss:
+                return
+            self.best_val_loss = val_loss
+
+        completed_epochs = (
+            plan.completed_epochs(self.global_step) if plan.by_epoch else 0
+        )
+        checkpoint_index = plan.progress_value(self.global_step)
+
+        checkpoint = {
+            "epoch": completed_epochs,
+            "step_count": self.global_step,
+            "steps_per_epoch": plan.steps_per_epoch,
+            "best_val_loss": self.best_val_loss,
+            "model_state_dict": self.model.state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "model_init_kwargs": self.checkpoint.get(
+                "model_init_kwargs", self.config.model_kwargs
+            ),
+            "optimizer_init_kwargs": self.checkpoint.get(
+                "optimizer_init_kwargs", self.config.optimizer_kwargs
+            ),
+            "config_repr": repr(self.config),
+        }
+        checkpoint_name = (
+            f"{self.config.training_run_name}_"
+            f"{self.model.__class__.__name__}_{checkpoint_index}"
+        )
+        cp_path_json, cp_path_npz = save_checkpoint(
+            checkpoint,
+            checkpoint_dir=self.CHECKPOINT_DIR,
+            checkpoint_name=checkpoint_name,
+        )
+        logger.info(f"Saved checkpoint to {cp_path_json} and {cp_path_npz}")
 
     def _save_metrics(self):
         """Saves accumulated training metrics to a compressed NPZ file."""
+        # TODO: consider moving this to a centralized utility module instead of keeping it here
         os.makedirs(self.METRICS_DIR, exist_ok=True)
         run_name = self.config.training_run_name or "default"
         filename = f"{self.model.__class__.__name__}_{run_name}.npz"
         path = os.path.join(self.METRICS_DIR, filename)
+        keys = sorted({key for row in self.metric_rows for key in row})
         metrics_mx = {}
-        for key, values in self.metrics.items():
+        for key in keys:
+            values = [row.get(key) for row in self.metric_rows]
             if any(value is None for value in values):
                 values = [float("nan") if value is None else value for value in values]
                 metrics_mx[key] = xp.array(values, dtype=xp.float32)
@@ -233,57 +498,44 @@ class AbstractTrainer(ABC):
                 metrics_mx[key] = xp.array(values)
         eval(*metrics_mx.values())
         xp.savez_compressed(path, **metrics_mx)
-        logger.info(f"Saved training metrics to {path}")
 
-    @abstractmethod
-    def train_step(self, batch_data) -> float:
-        """Performs a single training step and returns the loss as a float.
+    def _validate_fit_inputs(self, train_data_loader: DataLoader) -> None:
+        if self.config.max_steps is not None:
+            return
 
-        Subclasses must implement the forward pass, loss computation, and backward pass here.
+        try:
+            steps_per_epoch = len(train_data_loader)
+        except TypeError as exc:
+            raise ValueError(
+                "Infinite training loaders require max_steps. "
+                "Set max_steps or give the dataset examples_per_epoch."
+            ) from exc
 
-        Args:
-            batch_data: A single batch of training data.
+        if steps_per_epoch <= 0:
+            raise ValueError("train_data_loader must yield at least one batch.")
 
-        Returns:
-            float: The computed loss value for the batch.
-        """
-        pass
+        if self.checkpoint:
+            loaded_steps_per_epoch = self.checkpoint.get("steps_per_epoch")
+            if loaded_steps_per_epoch != steps_per_epoch:
+                raise ValueError(
+                    "Cannot resume epoch-mode checkpoint with changed steps_per_epoch."
+                )
 
-    def _on_epoch_end(self, epoch: int, train_loss: float, val_loss: Optional[float]):
-        """Hook called at the end of each epoch to handle checkpointing and logging.
-
-        Note: `save_checkpoint` needs to come first because it compares
-        against historical metrics to determine whether to save
-        the checkpoint
-
-        Args:
-            epoch (int): Current epoch number.
-            train_loss (float): The average training loss for this epoch.
-            val_loss (Optional[float]): The validation loss for this epoch, if available.
-        """
-        self._save_checkpoint(epoch, val_loss)
-        self.metrics["epoch"].append(epoch)
-        self.metrics["train_loss"].append(train_loss)
-        self.metrics["val_loss"].append(val_loss)
-
-        log_msg = f"[Epoch {epoch}]"
-        for key in self.metrics:
-            if key != "epoch" and self.metrics[key][-1] is not None:
-                log_msg += f"\n{key} = {self.metrics[key][-1]:.4f}"
-        log_msg += f"\nLR = {self.optimizer.lr:.6f}"
-        logger.info(log_msg)
-
-    @abstractmethod
-    def evaluate(self, val_data_loader) -> float:
-        """Evaluates the model on the validation set.
-
-        Args:
-            val_data_loader: Validation data loader providing validation batches.
-
-        Returns:
-            float: The average validation loss over the validation set.
-        """
-        pass
+    def _log_fit_start(self, plan: TrainingPlan) -> None:
+        target_label = "steps" if not plan.by_epoch else "epochs"
+        payload = {
+            "mode": target_label,
+            "target_step": plan.target_step,
+            "report_every_steps": plan.report_every_steps,
+            "global_batch_size": self.config.global_batch_size,
+            "micro_batch_size": self.config.micro_batch_size,
+            "gradient_accumulation_steps": self.config.gradient_accumulation_steps,
+            "target_epochs": (
+                cast(int, self.config.max_epochs) if plan.by_epoch else None
+            ),
+            "steps_per_epoch": plan.steps_per_epoch,
+        }
+        logger.info("Fit plan:\n%s", _pformat_log_dict(payload))
 
     def _load_model_and_optimizer(
         self,
@@ -294,9 +546,11 @@ class AbstractTrainer(ABC):
         resume_epoch: Optional[int] = None,
         checkpoint_path: Optional[str] = None,
     ) -> Tuple[Any, Any, dict]:
-        """Loads model & optimizer states from checkpoint if resume_epoch is given.
+        """Loads model & optimizer states from checkpoint if a checkpoint is requested.
 
-        If no checkpoint is found or resume_epoch is None, initializes them from scratch.
+        `resume_epoch` is only a filename lookup hint. Once a checkpoint is loaded,
+        runtime progress comes from checkpoint metadata such as `step_count`.
+        If no checkpoint is requested, initializes from scratch.
 
         Note on configs in checkpoint:
             When we load from checkpoint, the model and optimizer configs are restored from the
@@ -311,7 +565,8 @@ class AbstractTrainer(ABC):
             optimizer_class (type[optim.Optimizer]): Class object for the optimizer.
             model_kwargs (Dict[str, Any]): Keyword arguments for model initialization.
             optimizer_kwargs (Dict[str, Any]): Keyword arguments for optimizer initialization.
-            resume_epoch (Optional[int]): If provided, attempts to load from checkpoint at this epoch.
+            resume_epoch (Optional[int]): Optional checkpoint filename hint used when
+                `checkpoint_path` is not provided.
             checkpoint_path (Optional[str]): If provided, path of the checkpoint file.
 
         Returns:
@@ -338,6 +593,24 @@ class AbstractTrainer(ABC):
 
             logger.info(f"Attempting to load from checkpoint: {ckpt_json}, {ckpt_npz}")
             loaded_ckpt = load_checkpoint(ckpt_json, ckpt_npz)
+            loaded_step_count = int(loaded_ckpt.get("step_count", 0))
+            if (
+                self.config.max_steps is not None
+                and loaded_step_count > self.config.max_steps
+            ):
+                raise ValueError("Checkpoint step exceeds max_steps.")
+
+            if self.config.max_steps is None:
+                loaded_steps_per_epoch = loaded_ckpt.get("steps_per_epoch")
+                if loaded_steps_per_epoch is None:
+                    raise ValueError(
+                        "Epoch-mode resume requires steps_per_epoch metadata in the checkpoint."
+                    )
+                if loaded_step_count % int(loaded_steps_per_epoch) != 0:
+                    raise ValueError(
+                        "Epoch-mode resume requires an epoch-boundary checkpoint. "
+                        "Store dataloader/sampler state if mid-epoch resume is needed."
+                    )
 
             # If your checkpoint has hyperparams or constructor kwargs,
             # you can either override model_kwargs or do a partial merge:
@@ -410,9 +683,9 @@ class SimpleTrainer(AbstractTrainer):
         >>> # Instantiate the trainer.
         >>> trainer = SimpleTrainer(model_cls, optimizer_cls, loss_fn, config, output_type='softmax')
         >>>
-        >>> # Create dummy data loaders (using lists as an example).
-        >>> train_loader = [ (np.random.rand(32, 10), np.random.rand(32, 2)) for _ in range(100) ]
-        >>> val_loader = [ (np.random.rand(32, 10), np.random.rand(32, 2)) for _ in range(20) ]
+        >>> # Create DataLoader instances for train/validation data.
+        >>> train_loader = ...
+        >>> val_loader = ...
         >>>
         >>> # Run the training loop.
         >>> trainer.fit(train_loader, val_loader)
@@ -450,80 +723,67 @@ class SimpleTrainer(AbstractTrainer):
             else "regression"
         )
 
-    def train_step(self, batch_data) -> float:
-        """Performs a forward pass, computes the loss, and backpropagates.
-
-        Note that .zero_grad() and .step() calls are in the _train_one_epoch() function
-
-        Args:
-            batch_data: A tuple (batch_X, batch_y) for supervised learning.
-
-        Returns:
-            float: The computed loss for this batch.
-        """
+    def _compute_loss(self, batch_data) -> Tensor:
         batch_X, batch_y = batch_data
         y_pred = self.model(batch_X)
-        loss = self.loss_fn(y_pred, batch_y)
-        loss.backward()
-        return float(loss.item())
+        return self.loss_fn(y_pred, batch_y)
 
-    def evaluate(self, val_data_loader) -> float:
-        """Evaluates the model on the validation data loader.
-
-        Args:
-            val_data_loader: An iterable or generator providing validation batches.
-
-        Returns:
-            float: The average validation loss over the entire validation dataset.
-        """
-        self.model.eval()
-        total_loss = 0.0
-        batch_count = 0
-        all_preds, all_targets = [], []
+    def _evaluate(self, val_data_loader) -> TrainingState:
+        state = TrainingState()
+        sample_pairs: list[tuple[Any, Any]] = []
         for batch_data in val_data_loader:
-            if self._max_eval_steps_reached(batch_count):
+            if (
+                self.config.max_eval_steps is not None
+                and state.eval_loss_batches >= self.config.max_eval_steps
+            ):
                 break
             batch_X, batch_y = batch_data
             y_pred = self.model(batch_X)
             loss = self.loss_fn(y_pred, batch_y)
-            total_loss += float(loss.item())
-            batch_count += 1
-            all_preds.append(y_pred)
-            all_targets.append(batch_y)
-        avg_val_loss = total_loss / max(batch_count, 1)
+            state.record_eval_loss(loss)
 
-        # Compute additional metrics for classification or regression
-        y_pred_full = xp.concatenate([p.data for p in all_preds], axis=0)
-        y_true_full = xp.concatenate(all_targets, axis=0)
+            if self.problem_type == "classification":
+                y_pred_proc, y_true_proc = self._post_process_classification(
+                    y_pred.data, batch_y
+                )
+                y_pred_flat = xp.array(y_pred_proc).reshape(-1)
+                y_true_flat = xp.array(y_true_proc, dtype=xp.int32).reshape(-1)
+                correct = float(
+                    xp.to_scalar(xp.sum(xp.array(y_pred_flat == y_true_flat)))
+                )
+                state.record_eval_metric(
+                    "accuracy",
+                    numerator=correct,
+                    denominator=float(y_true_flat.size),
+                )
+
+                if self.sample_predictions and len(sample_pairs) < 5:
+                    sample_count = min(5 - len(sample_pairs), len(y_pred_proc))
+                    for i in range(sample_count):
+                        sample_pairs.append((y_pred_proc[i], y_true_proc[i]))
+            else:
+                diff = xp.array(y_pred.data) - xp.array(batch_y)
+                squared_error_sum = float(xp.to_scalar(xp.sum(diff**2)))
+                state.record_eval_metric(
+                    "mse",
+                    numerator=squared_error_sum,
+                    denominator=float(diff.size),
+                )
+
+        if state.eval_loss_batches == 0:
+            raise ValueError("val_data_loader yielded no batches.")
 
         if self.problem_type == "classification":
-            y_pred_proc, y_true_proc = self._post_process_classification(
-                y_pred_full, y_true_full
-            )
-            acc_val = accuracy(
-                xp.array(y_pred_proc).reshape(-1),
-                xp.array(y_true_proc, dtype=xp.int32).reshape(-1),
-            )
-            self.metrics["val_accuracy"].append(acc_val)
-
-            if self.sample_predictions:
-                sample_count = min(5, len(y_pred_proc))
-                if sample_count > 0:
-                    sample_lines = [
-                        f"Predicted: {y_pred_proc[i]}\nActual: {y_true_proc[i]}"
-                        for i in range(sample_count)
-                    ]
-                    logger.info(
-                        "Sample Predictions on Validation Batch:\n"
-                        + "\n".join(sample_lines)
-                    )
-
-        else:
-            mse_val = mean_squared_error(y_pred_full, y_true_full)
-            self.metrics["val_mse"].append(mse_val)
-
-        self.model.train()
-        return avg_val_loss
+            if sample_pairs:
+                sample_lines = [
+                    f"Predicted: {pred}\nActual: {target}"
+                    for pred, target in sample_pairs
+                ]
+                logger.info(
+                    "Sample Predictions on Validation Batch:\n"
+                    + "\n".join(sample_lines)
+                )
+        return state
 
     def _post_process_classification(
         self, y_pred: Array, y_true: Array
@@ -604,13 +864,13 @@ class LLMTrainer(AbstractTrainer):
         >>> # Instantiate the trainer.
         >>> trainer = LLMTrainer(model_cls, optimizer_cls, loss_fn, forward_fn, config)
         >>>
-        >>> # Create dummy data loaders for language modeling.
+        >>> # Create DataLoader instances for language modeling.
         >>> dummy_batch = CausalLMBatch(
         ...     input_ids=np.random.randint(0, 1000, (32, 10)),
         ...     labels=np.random.randint(0, 1000, (32, 10)),
         ... )
-        >>> train_loader = [dummy_batch for _ in range(100)]
-        >>> val_loader = [dummy_batch for _ in range(20)]
+        >>> train_loader = ...
+        >>> val_loader = ...
         >>>
         >>> # Run the training loop.
         >>> trainer.fit(train_loader, val_loader)
@@ -659,81 +919,37 @@ class LLMTrainer(AbstractTrainer):
         self.forward_fn = forward_fn
         self.eval_callbacks = list(eval_callbacks or [])
 
-    def train_step(self, batch_data) -> float:
-        """Performs a forward pass for language modeling, computes the loss, and backpropagates.
-
-        Note that .zero_grad() and .step() calls are in the _train_one_epoch() function
-
-        Args:
-            batch_data: An architecture-specific LM batch object with `labels`.
-
-        Returns:
-            float: The computed loss for this batch.
-        """
+    def _compute_loss(self, batch_data) -> Tensor:
         logits = self.forward_fn.train(self.model, batch_data)
-        loss = self.loss_fn(
+        # TODO: Decide whether validation should use the same label_smoothing
+        # setting as training, or intentionally report unsmoothed cross-entropy.
+        return self.loss_fn(
             logits,
             batch_data.labels,
             label_smoothing=self.config.label_smoothing,
         )
-        loss.backward()
-        return float(loss.item())
 
-    def evaluate(self, val_data_loader) -> float:
+    def _evaluate(self, val_data_loader) -> TrainingState:
         """Evaluates the model on the validation data loader for language modeling.
 
         Args:
             val_data_loader: Validation data loader providing LM batches.
 
         Returns:
-            float: The average validation loss over the language modeling validation set.
+            EvalResult: The average validation loss and derived metrics.
         """
-        self.model.eval()
-        try:
-            total_loss = 0.0
-            batch_count = 0
-            for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
-                if self._max_eval_steps_reached(batch_count):
-                    break
-                logits = self.forward_fn.train(self.model, batch_data)
-                # TODO: Decide whether validation should use the same label_smoothing
-                # setting as training, or intentionally report unsmoothed cross-entropy.
-                loss = self.loss_fn(
-                    logits,
-                    batch_data.labels,
-                    label_smoothing=self.config.label_smoothing,
-                )
-                total_loss += float(loss.item())
-                batch_count += 1
-            avg_val_loss = total_loss / max(batch_count, 1)
-            for callback in self.eval_callbacks:
-                callback(self.model, self.forward_fn, val_data_loader, self.config)
-            return avg_val_loss
-        finally:
-            self.model.train()
+        state = TrainingState()
+        for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
+            if (
+                self.config.max_eval_steps is not None
+                and state.eval_loss_batches >= self.config.max_eval_steps
+            ):
+                break
+            loss = self._compute_loss(batch_data)
+            state.record_eval_loss(loss)
+        if state.eval_loss_batches == 0:
+            raise ValueError("val_data_loader yielded no batches.")
 
-
-def grad_l2_norm(parameters: Dict[str, Tensor]) -> float:
-    """Computes the L2 norm of the gradients for the given model parameters.
-
-    Args:
-        parameters (Dict[str, Tensor]): A dictionary of named parameters (Tensor objects)
-            for which to compute the gradient norm.
-
-    Returns:
-        float: The L2 norm of all gradients (i.e., sqrt of sum of squared gradient values).
-
-    Example:
-        >>> from autograd.tensor import Tensor
-        >>> params = {"weight": Tensor([1, 2], requires_grad=True)}
-        >>> # Suppose weight.grad = Tensor([0.1, -0.2])
-        >>> params["weight"].grad = Tensor([0.1, -0.2])
-        >>> grad_norm = grad_l2_norm(params)
-        >>> grad_norm
-        0.2236068
-    """
-    grad_norm = 0.0
-    for p in parameters.values():
-        if p.grad is not None:
-            grad_norm += (p.grad.data**2).sum()
-    return float(xp.to_scalar(grad_norm**0.5))
+        for callback in self.eval_callbacks:
+            callback(self.model, self.forward_fn, val_data_loader, self.config)
+        return state

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -270,7 +270,7 @@ class AbstractTrainer(ABC):
         for key in self.metrics:
             if key != "epoch" and self.metrics[key][-1] is not None:
                 log_msg += f"\n{key} = {self.metrics[key][-1]:.4f}"
-        log_msg += f"\nLR = {self.optimizer.lr:.4f}"
+        log_msg += f"\nLR = {self.optimizer.lr:.6f}"
         logger.info(log_msg)
 
     @abstractmethod

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -245,17 +245,18 @@ if __name__ == "__main__":
     WIKI_CONFIG = TransformerTrainingConfig(
         training_run_name="wiki",
         dataset_name="wiki_simple_english",
-        max_steps=10000,
+        max_steps=200000,
         max_eval_steps=200,
-        checkpoint_freq=200,
+        checkpoint_freq=10000,
         global_batch_size=32,
         micro_batch_size=1,
         model_kwargs={
-            "num_attention_heads": 6,  # GPT-2 small uses 12
-            "hidden_size": 768,  # GPT-2 small uses 768, must be divisible by num_attention_heads
+            "num_attention_heads": 12,  # GPT-2 small uses 12
+            "hidden_size": 1536,  # GPT-2 small uses 768, must be divisible by num_attention_heads
             "dropout_prob": 0.2,
-            "max_seq_len": 768,  # GPT-2 uses 1024
-            "num_decoder_layers": 6,  # GPT-2 uses 12
+            "max_seq_len": 1024,  # GPT-2 uses 1024
+            "num_decoder_layers": 12,  # GPT-2 uses 12
+            "activation_checkpointing": True,
         },
         optimizer_kwargs={
             "lr": 1e-3,
@@ -264,8 +265,8 @@ if __name__ == "__main__":
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": optim.CosineScheduler,
-                "warmup_steps": 1500,  # 15% of max_steps
-                "lr_decay_iters": 8000,  # 80% of max_steps
+                "warmup_steps": 30000,  # 15% of max_steps
+                "lr_decay_iters": 160000,  # 80% of max_steps
             },
         },
         resume_epoch=None,  # Set this to None if you don't want to load from checkpoint

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -14,7 +14,7 @@ from autograd.data.collator import CausalLMWindowCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import TokenWindowDataset
 from autograd.data.types import CausalLMBatch
-from autograd.tensor import Tensor
+from autograd.tensor import Tensor, checkpoint
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.tools.callback import (
@@ -52,11 +52,13 @@ class GPT2(nn.Module):
         max_seq_len: int = 1024,  # GPT-2 small uses 1024 context window
         dropout_prob: float = 0.1,
         num_decoder_layers: int = 12,  # GPT-2 small has 12 layers
+        activation_checkpointing: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.hidden_size = hidden_size
         self.max_seq_len = max_seq_len
+        self.activation_checkpointing = activation_checkpointing
 
         # Token and positional embeddings
         self.token_embedding = nn.Embedding(vocab_size, hidden_size)
@@ -105,7 +107,10 @@ class GPT2(nn.Module):
 
         # Pass through each Decoder sublayer
         for sublayer in self.sublayers:
-            h_0 = sublayer(h_0)
+            if self._is_training and self.activation_checkpointing:
+                h_0 = checkpoint(sublayer, h_0)
+            else:
+                h_0 = sublayer(h_0)
 
         # Final normalization
         output = self.layer_norm(h_0)

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -248,6 +248,7 @@ if __name__ == "__main__":
         max_steps=200000,
         max_eval_steps=200,
         checkpoint_freq=10000,
+        report_every_steps=200,
         global_batch_size=32,
         micro_batch_size=1,
         model_kwargs={
@@ -269,7 +270,7 @@ if __name__ == "__main__":
                 "lr_decay_iters": 160000,  # 80% of max_steps
             },
         },
-        resume_epoch=None,  # Set this to None if you don't want to load from checkpoint
+        resume_epoch=30000,  # Set this to None if you don't want to load from checkpoint
         teacher_forcing=False,
         label_smoothing=0.1,
         eval_start_string="April is",

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -576,21 +576,21 @@ if __name__ == "__main__":
     No value is returned; training progress and generated outputs are logged.
     """
     train_global_batch_size = 16
-    train_micro_batch_size = train_global_batch_size
+    train_micro_batch_size = 4
     CONFIG = TransformerTrainingConfig(
         training_run_name="wikisum_seq2seq",
         dataset_name="wikisum_seq2seq",
-        max_steps=500,
+        max_steps=2000,
         max_eval_steps=16,
-        checkpoint_freq=2,
+        checkpoint_freq=500,
         global_batch_size=train_global_batch_size,
         micro_batch_size=train_micro_batch_size,
         model_kwargs={
-            "num_attention_heads": 4,
-            "hidden_size": 128,
+            "num_attention_heads": 12,
+            "hidden_size": 768,
             "dropout_prob": 0.1,
-            "max_seq_len": 96,
-            "num_decoder_layers": 4,
+            "max_seq_len": 512,
+            "num_decoder_layers": 12,
         },
         optimizer_kwargs={
             "lr": 1e-3,
@@ -599,8 +599,8 @@ if __name__ == "__main__":
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": optim.CosineScheduler,
-                "warmup_steps": 100,
-                "lr_decay_iters": 500,
+                "warmup_steps": 300,
+                "lr_decay_iters": 2000,
             },
         },
         resume_epoch=None,
@@ -622,8 +622,8 @@ if __name__ == "__main__":
     test_data_url = "https://huggingface.co/datasets/d0rj/wikisum/resolve/main/data/test-00000-of-00001-52a8a7cd640a9fff.parquet"
     train_filename = "training_data/wikisum_train.parquet"
     test_filename = "training_data/wikisum_test.parquet"
-    train_rows = load_parquet_rows(train_data_url, train_filename, max_rows=1024)
-    test_rows = load_parquet_rows(test_data_url, test_filename, max_rows=1024)
+    train_rows = load_parquet_rows(train_data_url, train_filename)
+    test_rows = load_parquet_rows(test_data_url, test_filename)
 
     train_pairs = [(str(row["article"]), str(row["summary"])) for row in train_rows]
     test_pairs = [(str(row["article"]), str(row["summary"])) for row in test_rows]

--- a/test/autograd/data/test_data_loader.py
+++ b/test/autograd/data/test_data_loader.py
@@ -10,6 +10,7 @@ from autograd.data.collator import (
 )
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import (
+    IterableDataset,
     PairedIterableDataset,
     Seq2SeqDataset,
     TokenSequenceDataset,
@@ -36,6 +37,22 @@ class MockBPE:
             if token == "<SOS>":
                 return [1]
         return [ord(char) for char in token]
+
+
+class EmptyDataset(IterableDataset):
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self):
+        return 0
+
+
+class BuggyEmptyPassDataset(IterableDataset):
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self):
+        return 3
 
 
 class TestDataLoader(unittest.TestCase):
@@ -172,6 +189,38 @@ class TestDataLoader(unittest.TestCase):
         ) // self.batch_size_simple
 
         self.assertEqual(len(loader), expected_batches)
+
+    def test_data_loader_rejects_empty_dataset_iteration(self):
+        loader = DataLoader(EmptyDataset(), batch_size=1)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded no batches",
+        ):
+            next(iter(loader))
+
+    def test_data_loader_rejects_dataset_that_yields_nothing_for_pass(self):
+        loader = DataLoader(BuggyEmptyPassDataset(), batch_size=2)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded no batches",
+        ):
+            next(iter(loader))
+
+    def test_data_loader_rejects_drop_last_when_only_partial_batch_exists(self):
+        loader = DataLoader(
+            PairedIterableDataset(self.X[:1], self.y[:1], shuffle=False),
+            batch_size=2,
+            collate_fn=PairedCollator(),
+            drop_last=True,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded no batches",
+        ):
+            next(iter(loader))
 
     def test_pretraining_data_loader_on_epoch_start_reseeds_without_crashing(self):
         loader = self.make_pretraining_loader(shuffle=True)

--- a/test/autograd/performance_test.py
+++ b/test/autograd/performance_test.py
@@ -21,6 +21,7 @@ from examples.gpt_2 import GPT2
 @dataclass(frozen=True)
 class MemorySnapshot:
     rss_bytes: int
+    swap_used_bytes: int
     device_active_bytes: Optional[int] = None
     device_cache_bytes: Optional[int] = None
     device_peak_bytes: Optional[int] = None
@@ -30,6 +31,7 @@ class MemorySnapshot:
 class CallProfile:
     elapsed_s: float
     rss_delta_bytes: int
+    swap_used_delta_bytes: int
     device_active_delta_bytes: Optional[int]
     device_cache_delta_bytes: Optional[int]
     device_peak_delta_bytes: Optional[int]
@@ -132,8 +134,10 @@ def capture_memory_snapshot(process=None):
     if process is None:
         process = psutil.Process(os.getpid())
     rss_bytes = int(process.memory_info().rss)
+    swap_used_bytes = int(psutil.swap_memory().used)
     return MemorySnapshot(
         rss_bytes=rss_bytes,
+        swap_used_bytes=swap_used_bytes,
         device_active_bytes=_device_memory_stat("get_active_memory"),
         device_cache_bytes=_device_memory_stat("get_cache_memory"),
         device_peak_bytes=_device_memory_stat("get_peak_memory"),
@@ -175,6 +179,8 @@ def measure_call(
     profile = CallProfile(
         elapsed_s=elapsed_s,
         rss_delta_bytes=end_snapshot.rss_bytes - start_snapshot.rss_bytes,
+        swap_used_delta_bytes=end_snapshot.swap_used_bytes
+        - start_snapshot.swap_used_bytes,
         device_active_delta_bytes=_delta(
             end_snapshot.device_active_bytes,
             start_snapshot.device_active_bytes,
@@ -391,6 +397,7 @@ class CIPipelinePerformanceTest(TestCase):
         optimizer_lr=0.01,
         loss_fn=functional.cross_entropy,
     ):
+        model.train()
         optimizer = optim.SGD(model.parameters, lr=optimizer_lr)
         metrics = {
             "forward_times": [],
@@ -399,9 +406,10 @@ class CIPipelinePerformanceTest(TestCase):
             "step_times": [],
             "throughput_per_second": [],
             "rss_deltas": [],
+            "swap_used_deltas": [],
             "device_active_deltas": [],
             "device_cache_deltas": [],
-            "device_peak_deltas": [],
+            "device_peak_bytes": [],
         }
 
         def _loss_and_backward(y_pred):
@@ -449,13 +457,16 @@ class CIPipelinePerformanceTest(TestCase):
             metrics["step_times"].append(step_elapsed)
             metrics["throughput_per_second"].append(throughput_count / step_elapsed)
             metrics["rss_deltas"].append(step_end.rss_bytes - step_start.rss_bytes)
+            metrics["swap_used_deltas"].append(
+                step_end.swap_used_bytes - step_start.swap_used_bytes
+            )
             metrics["device_active_deltas"].append(
                 _delta(step_end.device_active_bytes, step_start.device_active_bytes)
             )
             metrics["device_cache_deltas"].append(
                 _delta(step_end.device_cache_bytes, step_start.device_cache_bytes)
             )
-            metrics["device_peak_deltas"].append(step_end.device_peak_bytes)
+            metrics["device_peak_bytes"].append(step_end.device_peak_bytes)
 
         return self._summarize_metrics(metrics, throughput_unit)
 
@@ -495,12 +506,13 @@ class CIPipelinePerformanceTest(TestCase):
             "max": round(throughput_summary["max"], 2),
         }
         memory_summary = {
-            "host_rss_delta": self._byte_stats(metrics["rss_deltas"]),
+            "process_rss_delta": self._byte_stats(metrics["rss_deltas"]),
+            "system_swap_used_delta": self._byte_stats(metrics["swap_used_deltas"]),
         }
         for metric_suffix, values in (
             ("device_active_delta", metrics["device_active_deltas"]),
             ("device_cache_delta", metrics["device_cache_deltas"]),
-            ("device_peak_delta", metrics["device_peak_deltas"]),
+            ("device_peak_allocator", metrics["device_peak_bytes"]),
         ):
             values = [value for value in values if value is not None]
             if values:
@@ -520,26 +532,33 @@ class CIPipelinePerformanceTest(TestCase):
                 f"{case_metrics['throughput']['mean']} "
                 f"{case_metrics['throughput']['unit']}"
             ),
-            "host_rss_delta_mean": case_metrics["memory"]["host_rss_delta"]["mean"],
-        }
-        peak_key = f"{NAME}_device_peak_delta"
-        if peak_key in case_metrics["memory"]:
-            row[f"{NAME}_device_peak_delta_mean"] = case_metrics["memory"][peak_key][
+            "process_rss_delta_mean": case_metrics["memory"]["process_rss_delta"][
                 "mean"
-            ]
+            ],
+            "system_swap_used_delta_mean": case_metrics["memory"][
+                "system_swap_used_delta"
+            ]["mean"],
+        }
+        peak_key = f"{NAME}_device_peak_allocator"
+        if peak_key in case_metrics["memory"]:
+            row[f"{NAME}_device_peak_allocator_mean"] = case_metrics["memory"][
+                peak_key
+            ]["mean"]
         return row
 
     def _format_summary_table(self, rows):
+        backend_label = NAME.upper()
         columns = [
             ("case", "Case"),
             ("step_mean", "Step Mean"),
             ("step_std", "Step Std"),
             ("throughput", "Throughput"),
-            ("host_rss_delta_mean", "Host RSS Delta"),
+            ("process_rss_delta_mean", "Process RSS Delta"),
+            ("system_swap_used_delta_mean", "System Swap Used Delta"),
         ]
-        peak_key = f"{NAME}_device_peak_delta_mean"
+        peak_key = f"{NAME}_device_peak_allocator_mean"
         if any(peak_key in row for row in rows):
-            columns.append((peak_key, f"{NAME} Peak Delta"))
+            columns.append((peak_key, f"{backend_label} Peak Allocator"))
 
         widths = {}
         for key, header in columns:

--- a/test/autograd/test_backend.py
+++ b/test/autograd/test_backend.py
@@ -7,6 +7,8 @@ import numpy as np
 import pytest
 
 from autograd.backend import (
+    get_random_state,
+    set_random_state,
     xp,
 )
 from autograd.nn import extract_windows
@@ -41,8 +43,12 @@ def _load_backend_module(monkeypatch, *, env_backend=None, fake_cupy=None):
 
 def _fake_cupy_module(device_count: int):
     random = SimpleNamespace(
+        seed=np.random.seed,
+        uniform=np.random.uniform,
         normal=np.random.normal,
+        randint=np.random.randint,
         binomial=np.random.binomial,
+        permutation=np.random.permutation,
         choice=np.random.choice,
     )
     return SimpleNamespace(
@@ -123,6 +129,28 @@ def test_random_bernoulli_returns_binary_mask():
     values = set(np.unique(xp.to_numpy(out)).tolist())
 
     assert values.issubset({0, 1, False, True})
+
+
+def test_active_backend_random_state_round_trip_replays_sample():
+    xp.random.seed(123)
+    saved_state = get_random_state()
+    first = xp.random.bernoulli(0.5, shape=(32,))
+    set_random_state(saved_state)
+    second = xp.random.bernoulli(0.5, shape=(32,))
+
+    assert np.array_equal(xp.to_numpy(first), xp.to_numpy(second))
+
+
+def test_numpy_random_state_round_trip_replays_sample(monkeypatch):
+    module = _load_backend_module(monkeypatch, env_backend="numpy")
+
+    module.xp.random.seed(123)
+    saved_state = module.get_random_state()
+    first = module.xp.random.bernoulli(0.5, shape=(32,))
+    module.set_random_state(saved_state)
+    second = module.xp.random.bernoulli(0.5, shape=(32,))
+
+    assert np.array_equal(module.xp.to_numpy(first), module.xp.to_numpy(second))
 
 
 def test_tensor_item_uses_backend_scalar_conversion():

--- a/test/autograd/test_gpt2_checkpointing.py
+++ b/test/autograd/test_gpt2_checkpointing.py
@@ -1,0 +1,287 @@
+from copy import deepcopy
+
+import examples.gpt_2 as gpt2_module
+from autograd import functional, nn
+from autograd.backend import xp
+from autograd.tensor import Tensor, checkpoint, no_grad
+from examples.gpt_2 import GPT2
+from test.helpers import array_equal
+
+
+def _build_tokens(*, batch_size: int, seq_len: int, vocab_size: int):
+    input_ids = xp.random.randint(0, vocab_size, (batch_size, seq_len), dtype=xp.int32)
+    labels = xp.random.randint(0, vocab_size, (batch_size, seq_len), dtype=xp.int32)
+    return input_ids, labels
+
+
+def _record_decoder_outputs(model: GPT2):
+    decoder_outputs = {}
+    original_forwards = []
+
+    for idx, sublayer in enumerate(model.sublayers):
+        original_forward = sublayer.forward
+        original_forwards.append((sublayer, original_forward))
+
+        def _wrapped_forward(x, *, _idx=idx, _forward=original_forward):
+            out = _forward(x)
+            decoder_outputs.setdefault(_idx, xp.array(out.data))
+            return out
+
+        sublayer.forward = _wrapped_forward
+
+    return decoder_outputs, original_forwards
+
+
+def _restore_decoder_forwards(original_forwards):
+    for sublayer, original_forward in original_forwards:
+        sublayer.forward = original_forward
+
+
+def _run_training_step(
+    *,
+    state_dict,
+    input_ids,
+    labels,
+    dropout_prob: float,
+    activation_checkpointing: bool,
+):
+    model = GPT2(
+        vocab_size=32,
+        hidden_size=16,
+        num_attention_heads=4,
+        max_seq_len=input_ids.shape[1],
+        dropout_prob=dropout_prob,
+        num_decoder_layers=3,
+        activation_checkpointing=activation_checkpointing,
+    )
+    model.load_state_dict(deepcopy(state_dict))
+    model.train()
+    decoder_outputs, original_forwards = _record_decoder_outputs(model)
+    try:
+        logits = model(Tensor(input_ids, requires_grad=False))
+        loss = functional.cross_entropy(
+            logits,
+            labels,
+            label_smoothing=0.0,
+        )
+        loss.backward()
+    finally:
+        _restore_decoder_forwards(original_forwards)
+
+    grads = {
+        name: xp.array(param.grad.data)
+        for name, param in model.parameters.items()
+        if param.grad is not None
+    }
+    return {
+        "decoder_outputs": decoder_outputs,
+        "logits": xp.array(logits.data),
+        "loss": xp.array(loss.data),
+        "grads": grads,
+    }
+
+
+def _compare_training_runs(reference, candidate):
+    assert reference["decoder_outputs"].keys() == candidate["decoder_outputs"].keys()
+    for idx in reference["decoder_outputs"]:
+        assert array_equal(
+            reference["decoder_outputs"][idx], candidate["decoder_outputs"][idx]
+        ), f"decoder block {idx} output mismatch"
+
+    assert array_equal(reference["logits"], candidate["logits"])
+    assert array_equal(reference["loss"], candidate["loss"])
+    assert reference["grads"].keys() == candidate["grads"].keys()
+    for name in reference["grads"]:
+        assert array_equal(reference["grads"][name], candidate["grads"][name]), (
+            f"gradient mismatch for {name}"
+        )
+
+
+def test_gpt2_activation_checkpointing_matches_baseline_without_dropout():
+    xp.random.seed(7)
+    input_ids, labels = _build_tokens(batch_size=2, seq_len=8, vocab_size=32)
+    xp.random.seed(11)
+    baseline_model = GPT2(
+        vocab_size=32,
+        hidden_size=16,
+        num_attention_heads=4,
+        max_seq_len=8,
+        dropout_prob=0.0,
+        num_decoder_layers=3,
+        activation_checkpointing=False,
+    )
+    state_dict = deepcopy(baseline_model.state_dict())
+
+    xp.random.seed(17)
+    baseline = _run_training_step(
+        state_dict=state_dict,
+        input_ids=input_ids,
+        labels=labels,
+        dropout_prob=0.0,
+        activation_checkpointing=False,
+    )
+    xp.random.seed(17)
+    checkpointed = _run_training_step(
+        state_dict=state_dict,
+        input_ids=input_ids,
+        labels=labels,
+        dropout_prob=0.0,
+        activation_checkpointing=True,
+    )
+
+    _compare_training_runs(baseline, checkpointed)
+
+
+def test_gpt2_activation_checkpointing_matches_baseline_with_dropout():
+    xp.random.seed(23)
+    input_ids, labels = _build_tokens(batch_size=2, seq_len=8, vocab_size=32)
+    xp.random.seed(29)
+    baseline_model = GPT2(
+        vocab_size=32,
+        hidden_size=16,
+        num_attention_heads=4,
+        max_seq_len=8,
+        dropout_prob=0.2,
+        num_decoder_layers=3,
+        activation_checkpointing=False,
+    )
+    state_dict = deepcopy(baseline_model.state_dict())
+
+    xp.random.seed(31)
+    baseline = _run_training_step(
+        state_dict=state_dict,
+        input_ids=input_ids,
+        labels=labels,
+        dropout_prob=0.2,
+        activation_checkpointing=False,
+    )
+    xp.random.seed(31)
+    checkpointed = _run_training_step(
+        state_dict=state_dict,
+        input_ids=input_ids,
+        labels=labels,
+        dropout_prob=0.2,
+        activation_checkpointing=True,
+    )
+
+    _compare_training_runs(baseline, checkpointed)
+
+
+def test_gpt2_activation_checkpointing_matches_baseline_in_eval_mode():
+    xp.random.seed(37)
+    input_ids, _ = _build_tokens(batch_size=2, seq_len=8, vocab_size=32)
+    xp.random.seed(41)
+    baseline_model = GPT2(
+        vocab_size=32,
+        hidden_size=16,
+        num_attention_heads=4,
+        max_seq_len=8,
+        dropout_prob=0.2,
+        num_decoder_layers=3,
+        activation_checkpointing=False,
+    )
+    state_dict = deepcopy(baseline_model.state_dict())
+
+    baseline = GPT2(
+        vocab_size=32,
+        hidden_size=16,
+        num_attention_heads=4,
+        max_seq_len=8,
+        dropout_prob=0.2,
+        num_decoder_layers=3,
+        activation_checkpointing=False,
+    )
+    baseline.load_state_dict(deepcopy(state_dict))
+    baseline.eval()
+
+    checkpointed = GPT2(
+        vocab_size=32,
+        hidden_size=16,
+        num_attention_heads=4,
+        max_seq_len=8,
+        dropout_prob=0.2,
+        num_decoder_layers=3,
+        activation_checkpointing=True,
+    )
+    checkpointed.load_state_dict(deepcopy(state_dict))
+    checkpointed.eval()
+
+    baseline_logits = baseline(Tensor(input_ids, requires_grad=False))
+    checkpointed_logits = checkpointed(Tensor(input_ids, requires_grad=False))
+
+    assert array_equal(baseline_logits.data, checkpointed_logits.data)
+
+
+def test_checkpoint_helper_matches_baseline_with_dropout():
+    x_data = xp.arange(12, dtype=xp.float32).reshape(3, 4) / 10.0
+    weight_data = xp.arange(16, dtype=xp.float32).reshape(4, 4) / 20.0
+    bias_data = xp.arange(4, dtype=xp.float32) / 30.0
+
+    def build_inputs():
+        x = Tensor(x_data, requires_grad=True)
+        weight = Tensor(weight_data, requires_grad=True)
+        bias = Tensor(bias_data, requires_grad=True)
+        return x, weight, bias
+
+    dropout = nn.Dropout(p=0.25)
+    dropout.train()
+
+    def block(x, weight, bias):
+        out = (x @ weight) + bias
+        return dropout(out)
+
+    xp.random.seed(43)
+    x_ref, weight_ref, bias_ref = build_inputs()
+    ref_out = block(x_ref, weight_ref, bias_ref)
+    ref_loss = ref_out.sum()
+    ref_loss.backward()
+
+    xp.random.seed(43)
+    x_ckpt, weight_ckpt, bias_ckpt = build_inputs()
+    ckpt_out = checkpoint(block, x_ckpt, weight_ckpt, bias_ckpt)
+    ckpt_loss = ckpt_out.sum()
+    ckpt_loss.backward()
+
+    assert array_equal(ref_out.data, ckpt_out.data)
+    assert array_equal(x_ref.grad.data, x_ckpt.grad.data)
+    assert array_equal(weight_ref.grad.data, weight_ckpt.grad.data)
+    assert array_equal(bias_ref.grad.data, bias_ckpt.grad.data)
+
+
+def test_checkpoint_passthrough_when_grad_disabled():
+    x = Tensor(xp.arange(4, dtype=xp.float32), requires_grad=True)
+
+    with no_grad():
+        out = checkpoint(lambda t: t + 1, x)
+
+    assert array_equal(out.data, x.data + 1)
+    assert out.creator is None
+    assert not out.requires_grad
+
+
+def test_gpt2_training_uses_checkpoint_helper_when_enabled(monkeypatch):
+    call_count = 0
+
+    def counting_checkpoint(run_function, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return run_function(*args)
+
+    monkeypatch.setattr(gpt2_module, "checkpoint", counting_checkpoint)
+
+    xp.random.seed(47)
+    model = GPT2(
+        vocab_size=32,
+        hidden_size=16,
+        num_attention_heads=4,
+        max_seq_len=8,
+        dropout_prob=0.0,
+        num_decoder_layers=3,
+        activation_checkpointing=True,
+    )
+    model.train()
+
+    logits = model(Tensor(xp.random.randint(0, 32, (2, 8), dtype=xp.int32)))
+
+    assert logits.shape == (2, 8, 32)
+    assert call_count == 3

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -122,6 +122,29 @@ class TestOptimizer(TestCase):
         self.optimizer.step()
         self.assertEqual(self.optimizer.timestep, initial_ts + 1)
 
+    def test_scale_gradients_scales_all_parameter_gradients(self):
+        self.params["param1"].grad = Tensor(xp.array([1.0, -2.0], dtype=xp.float32))
+        self.params["param2"].grad = Tensor(xp.array([3.0, 4.0], dtype=xp.float32))
+
+        self.optimizer.scale_gradients(0.5)
+
+        assert allclose(
+            self.params["param1"].grad.data,
+            xp.array([0.5, -1.0], dtype=xp.float32),
+        )
+        assert allclose(
+            self.params["param2"].grad.data,
+            xp.array([1.5, 2.0], dtype=xp.float32),
+        )
+
+    def test_grad_l2_norm_matches_expected_value(self):
+        self.params["param1"].grad = Tensor(xp.array([3.0, 4.0], dtype=xp.float32))
+        self.params["param2"].grad = Tensor(xp.array([12.0], dtype=xp.float32))
+
+        grad_norm = self.optimizer.grad_l2_norm()
+
+        self.assertAlmostEqual(grad_norm, 13.0, places=6)
+
     def test_scheduler_accepts_class_object(self):
         optimizer = Optimizer(
             self.params,

--- a/test/autograd/tools/test_model.py
+++ b/test/autograd/tools/test_model.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from autograd.backend import xp
 from autograd.init import xavier_uniform
 from autograd.nn import Module
+from autograd.optim import CosineScheduler
 from autograd.tensor import Tensor
 from autograd.tools.model import load_checkpoint, save_checkpoint
 
@@ -28,8 +29,12 @@ class TestModel(TestCase):
     def setUp(self):
         # Create a test model with some initial arguments
         self.model = MockModule(999, kwarg0="testing_kwarg0")
-        self.json_path = "test_model.json"
-        self.npz_path = "test_model.npz"
+        self.checkpoint_dir = "."
+        self.checkpoint_name = "test_model"
+        self.json_path = os.path.join(
+            self.checkpoint_dir, f"{self.checkpoint_name}.json"
+        )
+        self.npz_path = os.path.join(self.checkpoint_dir, f"{self.checkpoint_name}.npz")
 
     def tearDown(self):
         # Clean up any generated files
@@ -57,7 +62,9 @@ class TestModel(TestCase):
         original_params = deepcopy(self.model.parameters)
 
         save_checkpoint(
-            self.model.state_dict(), json_path=self.json_path, npz_path=self.npz_path
+            self.model.state_dict(),
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
         )
 
         # 2. Perform a forward/backward pass to change the parameters
@@ -105,7 +112,9 @@ class TestModel(TestCase):
         original_params = deepcopy(new_model.parameters)
         # Save the model including the states
         save_checkpoint(
-            self.model.state_dict(), json_path=self.json_path, npz_path=self.npz_path
+            self.model.state_dict(),
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
         )
 
         # Manually change the new model's states from the default
@@ -132,7 +141,9 @@ class TestModel(TestCase):
 
     def test_save_checkpoint_uses_backend_neutral_array_metadata(self):
         save_checkpoint(
-            self.model.state_dict(), json_path=self.json_path, npz_path=self.npz_path
+            self.model.state_dict(),
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
         )
 
         with open(self.json_path, "r", encoding="utf-8") as handle:
@@ -142,9 +153,31 @@ class TestModel(TestCase):
         self.assertIn("array", meta_types)
         self.assertNotIn("np.ndarray", meta_types)
 
+    def test_save_checkpoint_builds_paths_from_checkpoint_name(self):
+        checkpoint_dir = "test_checkpoints"
+        checkpoint_name = "mock_run_MockModule_7"
+        json_path, npz_path = save_checkpoint(
+            self.model.state_dict(),
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_name=checkpoint_name,
+        )
+
+        self.assertEqual(json_path, f"{checkpoint_dir}/{checkpoint_name}.json")
+        self.assertEqual(npz_path, f"{checkpoint_dir}/{checkpoint_name}.npz")
+        self.assertTrue(os.path.exists(json_path))
+        self.assertTrue(os.path.exists(npz_path))
+
+        for path in (json_path, npz_path):
+            if os.path.exists(path):
+                os.remove(path)
+        if os.path.isdir(checkpoint_dir):
+            os.rmdir(checkpoint_dir)
+
     def test_load_checkpoint_accepts_legacy_np_ndarray_metadata(self):
         save_checkpoint(
-            self.model.state_dict(), json_path=self.json_path, npz_path=self.npz_path
+            self.model.state_dict(),
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
         )
 
         with open(self.json_path, "r", encoding="utf-8") as handle:
@@ -174,3 +207,14 @@ class TestModel(TestCase):
             xp.allclose(self.model.stateful_states, xp.array([1, 1, 1])),
             "Legacy array metadata should still deserialize correctly.",
         )
+
+    def test_save_load_preserves_class_objects(self):
+        save_checkpoint(
+            {"lr_scheduler_cls": CosineScheduler},
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
+        )
+
+        loaded = load_checkpoint(json_path=self.json_path, npz_path=self.npz_path)
+
+        self.assertIs(loaded["lr_scheduler_cls"], CosineScheduler)

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -516,6 +516,30 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertEqual(eval_steps, [2, 3])
 
     @patch("autograd.tools.trainer.save_checkpoint")
+    def test_fit_with_max_steps_can_report_before_checkpoint_steps(
+        self, mock_save_checkpoint
+    ):
+        self.config.max_epochs = None
+        self.config.max_steps = 3
+        self.config.checkpoint_freq = 10
+        self.config.report_every_steps = 2
+        train_loader = make_data_loader(self.train_data * 3)
+        eval_steps = []
+
+        def record_eval(_):
+            eval_steps.append(self.trainer.global_step)
+            eval_state = TrainingState()
+            eval_state.record_eval_loss(1.23)
+            return eval_state
+
+        self.trainer._evaluate = MagicMock(side_effect=record_eval)
+
+        self.trainer.fit(train_loader, self.val_loader)
+
+        self.assertEqual(eval_steps, [2, 3])
+        mock_save_checkpoint.assert_not_called()
+
+    @patch("autograd.tools.trainer.save_checkpoint")
     def test_fit_with_max_steps_saves_checkpoint_on_checkpoint_steps(
         self, mock_save_checkpoint
     ):
@@ -723,6 +747,7 @@ class TestSimpleTrainer(BaseTrainerTest):
         trainer.global_step = len(self.train_loader)
         plan = TrainingPlan.for_steps(
             max_steps=config.max_steps,
+            report_every_steps=config.report_every_steps or config.checkpoint_freq,
             checkpoint_every=config.checkpoint_freq,
         )
         eval_state = TrainingState()
@@ -1243,18 +1268,20 @@ class TestSimpleTrainer(BaseTrainerTest):
         config = GenericTrainingConfig(
             max_steps=3,
             checkpoint_freq=2,
+            report_every_steps=1,
             model_kwargs={"hidden_size": 256},
             optimizer_kwargs={"lr": 0.01},
         )
 
         plan = TrainingPlan.for_steps(
             max_steps=config.max_steps,
+            report_every_steps=config.report_every_steps,
             checkpoint_every=config.checkpoint_freq,
         )
 
         self.assertFalse(plan.by_epoch)
         self.assertEqual(plan.target_step, 3)
-        self.assertEqual(plan.report_every_steps, 2)
+        self.assertEqual(plan.report_every_steps, 1)
         self.assertEqual(plan.checkpoint_every, 2)
         self.assertIsNone(plan.steps_per_epoch)
         self.assertEqual(plan.metrics_interval, 1)

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, patch
 from autograd.backend import xp
 from autograd.data.collator import CausalLMCollator, CausalLMWindowCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import TokenSequenceDataset, TokenWindowDataset
+from autograd.data.dataset import (
+    IterableDataset,
+    TokenSequenceDataset,
+    TokenWindowDataset,
+)
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch
 from autograd.data.utils import (
     openai_chat_to_prompt_completion,
@@ -15,7 +19,7 @@ from autograd.data.utils import (
 from autograd.functional import IGNORE_INDEX, cross_entropy
 from autograd.nn import AbstractLLMForwardFn, Module
 from autograd.optim import SGD, Optimizer
-from autograd.tensor import Tensor
+from autograd.tensor import Tensor, is_grad_enabled
 from autograd.tools.callback import (
     run_sampling_inference,
     run_teacher_forcing_inference,
@@ -24,37 +28,34 @@ from autograd.tools.config_schema import (
     GenericTrainingConfig,
     TransformerTrainingConfig,
 )
-from autograd.tools.trainer import LLMTrainer, SimpleTrainer
+from autograd.tools.trainer import (
+    LLMTrainer,
+    SimpleTrainer,
+    TrainingPlan,
+    TrainingState,
+)
 
 
-class MockDataLoader:
-    """
-    A simple loader that stores a list of batches in memory.
-    Each time __iter__ is called, it yields those same batches again.
-    """
+def identity_collate(batch_items):
+    return batch_items[0]
 
-    def __init__(self, data, seq_len=1):
+
+class InMemoryBatchDataset(IterableDataset):
+    def __init__(self, data):
         self.data = data
-        self.seq_len = seq_len
-        self.bpe = MagicMock()
+        self.epoch_start_calls = 0
 
     def on_epoch_start(self):
-        # If you want to shuffle or do something each epoch, do it here
-        pass
+        self.epoch_start_calls += 1
+
+    def __iter__(self):
+        return iter(self.data)
 
     def __len__(self):
         return len(self.data)
 
-    def __iter__(self):
-        # A fresh iterator every time => each epoch can re-iterate from the start
-        print(f"MockDataLoader: yielding {len(self.data)} batch(es)")
-        return iter(self.data)
 
-
-class UnsizedInfiniteLoader:
-    def on_epoch_start(self):
-        pass
-
+class UnsizedInfiniteDataset(IterableDataset):
     def __len__(self):
         raise TypeError("infinite")
 
@@ -62,6 +63,19 @@ class UnsizedInfiniteLoader:
         raise RuntimeError(
             "fit should reject unsized infinite loaders before iterating"
         )
+
+
+class UnsizedEmptyPassDataset(IterableDataset):
+    def __iter__(self):
+        return iter(())
+
+
+def make_data_loader(data):
+    return DataLoader(
+        dataset=InMemoryBatchDataset(data),
+        batch_size=1,
+        collate_fn=identity_collate,
+    )
 
 
 class MockModelClass(Module):
@@ -96,6 +110,18 @@ class MockModelClass(Module):
     def state_dict(self):
         # Return something that can be saved as checkpoint
         return {}
+
+
+class TrackingModeModel(MockModelClass):
+    def __init__(self, hidden_size=128, **kwargs):
+        super().__init__(hidden_size=hidden_size, **kwargs)
+        self.mode_log = []
+
+    def train(self):
+        self.mode_log.append("train")
+
+    def eval(self):
+        self.mode_log.append("eval")
 
 
 class ScalarWeightModel(Module):
@@ -149,6 +175,26 @@ class MockBPE:
             if token == "<SOS>":
                 return [1]
         return [ord(char) for char in token]
+
+
+class FakeTqdm:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.updates = []
+        self.postfixes = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def update(self, n=1):
+        self.updates.append(n)
+
+    def set_postfix(self, *args, **kwargs):
+        self.postfixes.append((args, kwargs))
 
 
 class PromptMaskAwareForwardFn(AbstractLLMForwardFn):
@@ -261,8 +307,8 @@ class TestSimpleTrainer(BaseTrainerTest):
         ]
 
         # Now use our real in-memory loader
-        self.train_loader = MockDataLoader(self.train_data)
-        self.val_loader = MockDataLoader(self.val_data)
+        self.train_loader = make_data_loader(self.train_data)
+        self.val_loader = make_data_loader(self.val_data)
 
         # Create the trainer
         self.trainer = SimpleTrainer(
@@ -279,16 +325,16 @@ class TestSimpleTrainer(BaseTrainerTest):
         # 2 epochs * 2 train batches = 4 steps
         self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
-    def test_train_step_returns_loss(self):
-        """Check that the train_step returns the expected scalar loss."""
+    def test_compute_loss_returns_tensor(self):
+        """Check that compute_loss returns the expected scalar Tensor."""
         batch = next(iter(self.train_data))
-        loss_val = self.trainer.train_step(batch)
-        self.assertAlmostEqual(loss_val, 1.23, places=5)
+        loss = self.trainer._compute_loss(batch)
+        self.assertAlmostEqual(float(loss.item()), 1.23, places=5)
 
     def test_save_metrics_persists_none_as_nan(self):
-        self.trainer.metrics["epoch"] = [0]
-        self.trainer.metrics["train_loss"] = [1.23]
-        self.trainer.metrics["val_loss"] = [None]
+        self.trainer.metric_rows = [
+            {"epoch": 0, "train_loss": 1.23, "val_loss": None},
+        ]
 
         self.trainer._save_metrics()
 
@@ -300,13 +346,66 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         self.assertTrue(math.isnan(float(val_loss[0])))
 
+    def test_metrics_backfills_missing_values_for_late_metric_keys(self):
+        self.trainer.metric_rows = [
+            {"epoch": 1, "train_loss": 1.23},
+            {"epoch": 2, "train_loss": 0.98, "val_accuracy": 0.75},
+        ]
+
+        self.trainer._save_metrics()
+        metrics_path = (
+            f"{SimpleTrainer.METRICS_DIR}/{MockModelClass.__name__}_default.npz"
+        )
+        archive = xp.load(metrics_path)
+
+        self.assertEqual(xp.to_numpy(archive["epoch"]).tolist(), [1, 2])
+        train_loss = xp.to_numpy(archive["train_loss"])
+        self.assertAlmostEqual(float(train_loss[0]), 1.23, places=5)
+        self.assertAlmostEqual(float(train_loss[1]), 0.98, places=5)
+        val_accuracy = xp.to_numpy(archive["val_accuracy"])
+        self.assertTrue(math.isnan(float(val_accuracy[0])))
+        self.assertAlmostEqual(float(val_accuracy[1]), 0.75, places=5)
+
+    def test_training_state_to_metrics_row_includes_eval_metrics(self):
+        state = TrainingState()
+        state.record_loss(1.23)
+        eval_state = TrainingState()
+        eval_state.record_eval_loss(0.5)
+        eval_state.record_eval_metric("accuracy", numerator=3, denominator=4)
+
+        row = state.to_metrics_row(eval_state=eval_state)
+
+        self.assertEqual(
+            row,
+            {
+                "train_loss": 1.23,
+                "val_loss": 0.5,
+                "val_accuracy": 0.75,
+            },
+        )
+
     @patch("autograd.tools.trainer.save_checkpoint")
     def test_save_checkpoint_saves_first_validation_loss(self, mock_save_checkpoint):
-        self.trainer.metrics["val_loss"] = []
-
-        self.trainer._save_checkpoint(epoch=0, val_loss=1.23)
+        mock_save_checkpoint.return_value = (
+            "checkpoints/default_MockModelClass_0.json",
+            "checkpoints/default_MockModelClass_0.npz",
+        )
+        plan = TrainingPlan.for_epochs(
+            max_epochs=self.config.max_epochs,
+            steps_per_epoch=len(self.train_loader),
+            checkpoint_every=self.config.checkpoint_freq,
+        )
+        eval_state = TrainingState()
+        eval_state.record_eval_loss(1.23)
+        self.trainer._maybe_save_checkpoint(
+            plan=plan,
+            eval_state=eval_state,
+        )
 
         mock_save_checkpoint.assert_called_once()
+        checkpoint = mock_save_checkpoint.call_args.args[0]
+        self.assertEqual(checkpoint["config_repr"], repr(self.config))
+        self.assertNotIn("config", checkpoint)
 
     def test_config_requires_integer_checkpoint_frequency(self):
         with self.assertRaisesRegex(
@@ -335,12 +434,369 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertEqual(trainer.optimizer.step_call_count, len(self.train_data))
 
     def test_fit_respects_max_steps_from_config(self):
-        self.config.max_epochs = 3
+        self.config.max_epochs = None
         self.config.max_steps = 1
 
         self.trainer.fit(self.train_loader, self.val_loader)
 
         self.assertEqual(self.trainer.optimizer.step_call_count, 1)
+
+    @patch("autograd.tools.trainer.tqdm")
+    def test_fit_wraps_training_steps_in_tqdm(self, mock_tqdm):
+        self.config.max_epochs = None
+        self.config.max_steps = 3
+        self.config.checkpoint_freq = 10
+        train_loader = make_data_loader(self.train_data * 3)
+        progress_bar = FakeTqdm()
+        mock_tqdm.return_value = progress_bar
+
+        self.trainer.fit(train_loader)
+
+        mock_tqdm.assert_called_once()
+        self.assertEqual(mock_tqdm.call_args.kwargs["total"], 3)
+        self.assertEqual(mock_tqdm.call_args.kwargs["desc"], "Training")
+        self.assertEqual(sum(progress_bar.updates), 3)
+        self.assertEqual(progress_bar.postfixes, [])
+
+    def test_fit_does_not_call_tensor_item_for_train_loss_each_batch(self):
+        self.config.max_epochs = None
+        self.config.max_steps = 3
+        self.config.checkpoint_freq = 10
+        train_loader = make_data_loader(self.train_data * 3)
+        item_call_count = 0
+        original_item = Tensor.item
+
+        def counting_item(tensor):
+            nonlocal item_call_count
+            item_call_count += 1
+            return original_item(tensor)
+
+        with patch.object(Tensor, "item", new=counting_item):
+            self.trainer.fit(train_loader)
+
+        self.assertEqual(item_call_count, 0)
+
+    @patch("autograd.tools.trainer.tqdm")
+    def test_fit_logs_fit_plan_before_first_compute_loss(self, mock_tqdm):
+        self.config.max_epochs = None
+        self.config.max_steps = 3
+        self.config.checkpoint_freq = 10
+        mock_tqdm.return_value = FakeTqdm()
+        self.trainer._compute_loss = MagicMock(side_effect=RuntimeError("boom"))
+
+        with self.assertLogs("autograd.tools.trainer", level="INFO") as captured:
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                self.trainer.fit(self.train_loader)
+
+        joined_logs = "\n".join(captured.output)
+        self.assertIn("Fit plan:", joined_logs)
+        self.assertIn("'mode': 'steps'", joined_logs)
+        self.assertIn("'target_step': 3", joined_logs)
+        self.assertNotIn("Starting first training batch", joined_logs)
+
+    def test_fit_with_max_steps_runs_evaluation_on_checkpoint_steps_and_target_step(
+        self,
+    ):
+        self.config.max_epochs = None
+        self.config.max_steps = 3
+        self.config.checkpoint_freq = 2
+        train_loader = make_data_loader(self.train_data * 3)
+        eval_steps = []
+
+        def record_eval(_):
+            eval_steps.append(self.trainer.global_step)
+            eval_state = TrainingState()
+            eval_state.record_eval_loss(1.23)
+            return eval_state
+
+        self.trainer._evaluate = MagicMock(side_effect=record_eval)
+
+        self.trainer.fit(train_loader, self.val_loader)
+
+        self.assertEqual(eval_steps, [2, 3])
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    def test_fit_with_max_steps_saves_checkpoint_on_checkpoint_steps(
+        self, mock_save_checkpoint
+    ):
+        mock_save_checkpoint.return_value = (
+            "checkpoints/default_MockModelClass_2.json",
+            "checkpoints/default_MockModelClass_2.npz",
+        )
+        self.config.max_epochs = None
+        self.config.max_steps = 3
+        self.config.checkpoint_freq = 2
+        train_loader = make_data_loader(self.train_data * 3)
+
+        self.trainer.fit(train_loader, self.val_loader)
+
+        mock_save_checkpoint.assert_called_once()
+        checkpoint = mock_save_checkpoint.call_args.args[0]
+        self.assertEqual(checkpoint["step_count"], 2)
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    def test_fit_without_val_loader_saves_latest_checkpoint_on_checkpoint_steps(
+        self, mock_save_checkpoint
+    ):
+        mock_save_checkpoint.return_value = (
+            "checkpoints/default_MockModelClass_2.json",
+            "checkpoints/default_MockModelClass_2.npz",
+        )
+        self.config.max_epochs = None
+        self.config.max_steps = 3
+        self.config.checkpoint_freq = 2
+        train_loader = make_data_loader(self.train_data * 3)
+
+        self.trainer.fit(train_loader, None)
+
+        mock_save_checkpoint.assert_called_once()
+        checkpoint = mock_save_checkpoint.call_args.args[0]
+        self.assertEqual(checkpoint["step_count"], 2)
+        self.assertIsNone(checkpoint["best_val_loss"])
+
+    def test_fit_records_completed_epochs_from_global_step(self):
+        self.trainer.fit(self.train_loader, self.val_loader)
+
+        self.assertEqual(
+            [row["epoch"] for row in self.trainer.metric_rows],
+            [1, 2],
+        )
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    def test_fit_uses_completed_epoch_for_checkpoint_index(self, mock_save_checkpoint):
+        mock_save_checkpoint.return_value = (
+            "checkpoints/default_MockModelClass_1.json",
+            "checkpoints/default_MockModelClass_1.npz",
+        )
+        self.config.max_epochs = 1
+
+        self.trainer.fit(self.train_loader, self.val_loader)
+
+        self.assertTrue(
+            mock_save_checkpoint.call_args.kwargs["checkpoint_name"].endswith("_1")
+        )
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    def test_fit_saves_steps_per_epoch_in_epoch_mode_checkpoints(
+        self, mock_save_checkpoint
+    ):
+        mock_save_checkpoint.return_value = (
+            "checkpoints/default_MockModelClass_1.json",
+            "checkpoints/default_MockModelClass_1.npz",
+        )
+        self.config.max_epochs = 1
+
+        self.trainer.fit(self.train_loader, self.val_loader)
+
+        checkpoint = mock_save_checkpoint.call_args.args[0]
+        self.assertEqual(checkpoint["steps_per_epoch"], len(self.train_loader))
+        self.assertAlmostEqual(checkpoint["best_val_loss"], 1.23, places=5)
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    def test_fit_in_epoch_mode_checkpoints_only_on_checkpoint_epochs(
+        self, mock_save_checkpoint
+    ):
+        mock_save_checkpoint.return_value = (
+            "checkpoints/default_MockModelClass_2.json",
+            "checkpoints/default_MockModelClass_2.npz",
+        )
+        self.config.max_epochs = 2
+        self.config.checkpoint_freq = 2
+
+        self.trainer.fit(self.train_loader, self.val_loader)
+
+        mock_save_checkpoint.assert_called_once()
+        self.assertTrue(
+            mock_save_checkpoint.call_args.kwargs["checkpoint_name"].endswith("_2")
+        )
+
+    @patch("autograd.tools.trainer.load_checkpoint")
+    def test_fit_rejects_epoch_mode_mid_epoch_resume(self, mock_load_checkpoint):
+        mock_load_checkpoint.return_value = {
+            "epoch": 0,
+            "step_count": 1,
+            "steps_per_epoch": len(self.train_loader),
+            "model_state_dict": {},
+            "optimizer_state_dict": {},
+            "model_init_kwargs": self.config.model_kwargs,
+            "optimizer_init_kwargs": self.config.optimizer_kwargs,
+        }
+        with self.assertRaisesRegex(
+            ValueError,
+            "Epoch-mode resume requires an epoch-boundary checkpoint",
+        ):
+            SimpleTrainer(
+                model_cls=MockModelClass,
+                optimizer_cls=MockOptimizerClass,
+                loss_fn=self.loss_fn,
+                config=self.config,
+                output_type="logits",
+                checkpoint_path="dummy",
+            )
+
+    @patch("autograd.tools.trainer.load_checkpoint")
+    def test_fit_rejects_epoch_mode_resume_with_changed_steps_per_epoch(
+        self, mock_load_checkpoint
+    ):
+        mock_load_checkpoint.return_value = {
+            "epoch": 1,
+            "step_count": len(self.train_loader) + 1,
+            "steps_per_epoch": len(self.train_loader) + 1,
+            "model_state_dict": {},
+            "optimizer_state_dict": {},
+            "model_init_kwargs": self.config.model_kwargs,
+            "optimizer_init_kwargs": self.config.optimizer_kwargs,
+        }
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=self.config,
+            output_type="logits",
+            checkpoint_path="dummy",
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Cannot resume epoch-mode checkpoint with changed steps_per_epoch",
+        ):
+            trainer.fit(self.train_loader, self.val_loader)
+
+    @patch("autograd.tools.trainer.load_checkpoint")
+    def test_resume_restores_best_val_loss_from_checkpoint(self, mock_load_checkpoint):
+        mock_load_checkpoint.return_value = {
+            "epoch": 1,
+            "step_count": len(self.train_loader),
+            "steps_per_epoch": len(self.train_loader),
+            "best_val_loss": 0.5,
+            "model_state_dict": {},
+            "optimizer_state_dict": {},
+            "model_init_kwargs": self.config.model_kwargs,
+            "optimizer_init_kwargs": self.config.optimizer_kwargs,
+        }
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=self.config,
+            output_type="logits",
+            checkpoint_path="dummy",
+        )
+
+        self.assertEqual(trainer.best_val_loss, 0.5)
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    @patch("autograd.tools.trainer.load_checkpoint")
+    def test_save_checkpoint_reuses_loaded_init_kwargs(
+        self, mock_load_checkpoint, mock_save_checkpoint
+    ):
+        mock_save_checkpoint.return_value = (
+            "checkpoints/default_MockModelClass_1.json",
+            "checkpoints/default_MockModelClass_1.npz",
+        )
+        loaded_model_kwargs = {"hidden_size": 128}
+        loaded_optimizer_kwargs = {"lr": 0.02}
+        mock_load_checkpoint.return_value = {
+            "epoch": 1,
+            "step_count": len(self.train_loader),
+            "steps_per_epoch": len(self.train_loader),
+            "model_state_dict": {},
+            "optimizer_state_dict": {},
+            "model_init_kwargs": loaded_model_kwargs,
+            "optimizer_init_kwargs": loaded_optimizer_kwargs,
+        }
+        config = GenericTrainingConfig(
+            max_epochs=2,
+            checkpoint_freq=1,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            resume_epoch=None,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+            checkpoint_path="dummy",
+        )
+        trainer.global_step = len(self.train_loader)
+        plan = TrainingPlan.for_steps(
+            max_steps=config.max_steps,
+            checkpoint_every=config.checkpoint_freq,
+        )
+        eval_state = TrainingState()
+        eval_state.record_eval_loss(0.4)
+
+        trainer._maybe_save_checkpoint(
+            plan=plan,
+            eval_state=eval_state,
+        )
+
+        checkpoint = mock_save_checkpoint.call_args.args[0]
+        self.assertEqual(checkpoint["model_init_kwargs"], loaded_model_kwargs)
+        self.assertEqual(checkpoint["optimizer_init_kwargs"], loaded_optimizer_kwargs)
+
+    @patch("autograd.tools.trainer.load_checkpoint")
+    def test_checkpoint_path_resume_uses_checkpoint_progress_not_config_hint(
+        self, mock_load_checkpoint
+    ):
+        mock_load_checkpoint.return_value = {
+            "epoch": 99,
+            "step_count": len(self.train_loader),
+            "steps_per_epoch": len(self.train_loader),
+            "model_state_dict": {},
+            "optimizer_state_dict": {},
+            "model_init_kwargs": self.config.model_kwargs,
+            "optimizer_init_kwargs": self.config.optimizer_kwargs,
+        }
+        config = GenericTrainingConfig(
+            max_epochs=1,
+            checkpoint_freq=1,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            resume_epoch=None,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+            checkpoint_path="dummy",
+        )
+
+        trainer.fit(self.train_loader, self.val_loader)
+
+        self.assertEqual(trainer.global_step, len(self.train_loader))
+        self.assertEqual(trainer.optimizer.step_call_count, 0)
+
+    @patch("autograd.tools.trainer.load_checkpoint")
+    def test_fit_rejects_checkpoint_step_beyond_max_steps(self, mock_load_checkpoint):
+        mock_load_checkpoint.return_value = {
+            "epoch": 0,
+            "step_count": 3,
+            "model_state_dict": {},
+            "optimizer_state_dict": {},
+            "model_init_kwargs": self.config.model_kwargs,
+            "optimizer_init_kwargs": self.config.optimizer_kwargs,
+        }
+        config = GenericTrainingConfig(
+            max_steps=2,
+            checkpoint_freq=1,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            resume_epoch=None,
+        )
+        with self.assertRaisesRegex(ValueError, "Checkpoint step exceeds max_steps"):
+            SimpleTrainer(
+                model_cls=MockModelClass,
+                optimizer_cls=MockOptimizerClass,
+                loss_fn=self.loss_fn,
+                config=config,
+                output_type="logits",
+                checkpoint_path="dummy",
+            )
 
     def test_fit_supports_max_steps_without_max_epochs(self):
         step_only_config = GenericTrainingConfig(
@@ -361,6 +817,61 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         self.assertEqual(trainer.optimizer.step_call_count, 3)
 
+    def test_fit_flushes_pending_gradients_before_report_boundary(self):
+        config = GenericTrainingConfig(
+            max_steps=1,
+            checkpoint_freq=1,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=2,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+
+        trainer.fit(self.train_loader, self.val_loader)
+
+        self.assertEqual(trainer.optimizer.step_call_count, 1)
+
+    def test_fit_restarts_epoch_lifecycle_when_step_budget_exhausts_loader(self):
+        self.config.max_epochs = None
+        self.config.max_steps = 3
+
+        self.trainer.fit(self.train_loader, self.val_loader)
+
+        self.assertEqual(self.train_loader.dataset.epoch_start_calls, 2)
+
+    def test_fit_flushes_partial_accumulation_at_finite_loader_boundary_in_step_mode(
+        self,
+    ):
+        config = GenericTrainingConfig(
+            max_steps=3,
+            checkpoint_freq=10,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=8,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+        train_loader = make_data_loader(self.train_data)
+
+        trainer.fit(train_loader)
+
+        self.assertEqual(trainer.global_step, 3)
+        self.assertEqual(trainer.optimizer.step_call_count, 2)
+        self.assertEqual(train_loader.dataset.epoch_start_calls, 2)
+
     def test_fit_requires_max_steps_for_unsized_infinite_train_loader(self):
         self.config.max_epochs = 1
         self.config.max_steps = None
@@ -369,7 +880,29 @@ class TestSimpleTrainer(BaseTrainerTest):
             ValueError,
             "Infinite training loaders require max_steps",
         ):
-            self.trainer.fit(UnsizedInfiniteLoader(), self.val_loader)
+            self.trainer.fit(
+                DataLoader(
+                    dataset=UnsizedInfiniteDataset(),
+                    batch_size=1,
+                    collate_fn=identity_collate,
+                ),
+                self.val_loader,
+            )
+
+    def test_fit_step_mode_rejects_loader_that_yields_no_batches(self):
+        self.config.max_epochs = None
+        self.config.max_steps = 1
+        empty_loader = DataLoader(
+            dataset=UnsizedEmptyPassDataset(),
+            batch_size=1,
+            collate_fn=identity_collate,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded no batches",
+        ):
+            self.trainer.fit(empty_loader)
 
     def test_fit_accumulates_using_global_and_micro_batch_sizes(self):
         config = GenericTrainingConfig(
@@ -408,11 +941,47 @@ class TestSimpleTrainer(BaseTrainerTest):
             config=config,
             output_type="logits",
         )
-        train_loader = MockDataLoader(self.train_data + self.val_data)
+        train_loader = make_data_loader(self.train_data + self.val_data)
 
         trainer.fit(train_loader, self.val_loader)
 
         self.assertEqual(trainer.optimizer.step_call_count, 2)
+
+    def test_optimizer_step_is_no_op_when_no_batches_accumulated(self):
+        state = TrainingState()
+        self.trainer.last_grad_l2_norm = 7.0
+
+        self.trainer.optimizer_step(state, record_grad_norm=False)
+
+        self.assertEqual(self.trainer.optimizer.step_call_count, 0)
+        self.assertEqual(self.trainer.last_grad_l2_norm, 7.0)
+        self.assertEqual(state.accumulated_batches, 0)
+
+    def test_fit_records_grad_norm_only_on_report_steps(self):
+        config = GenericTrainingConfig(
+            max_steps=4,
+            checkpoint_freq=4,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=2,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+        train_loader = make_data_loader(self.train_data * 2)
+
+        with patch.object(
+            trainer.optimizer, "grad_l2_norm", return_value=7.0
+        ) as mock_grad_l2_norm:
+            trainer.fit(train_loader)
+
+        self.assertEqual(mock_grad_l2_norm.call_count, 1)
+        self.assertEqual(trainer.metric_rows[0]["grad_l2_norm"], 7.0)
 
     def _fit_scalar_weight_model(
         self, train_data, *, global_batch_size, micro_batch_size
@@ -434,7 +1003,7 @@ class TestSimpleTrainer(BaseTrainerTest):
             config=config,
         )
 
-        trainer.fit(MockDataLoader(train_data))
+        trainer.fit(make_data_loader(train_data))
 
         return float(xp.to_scalar(trainer.model.parameters["weight"].data[0, 0]))
 
@@ -468,6 +1037,36 @@ class TestSimpleTrainer(BaseTrainerTest):
         )
 
         self.assertAlmostEqual(accumulated_weight, full_batch_weight, places=6)
+
+    def test_grad_l2_norm_records_pre_clip_gradient_norm(self):
+        config = GenericTrainingConfig(
+            max_epochs=1,
+            checkpoint_freq=1,
+            model_kwargs={"initial_weight": 0.0},
+            optimizer_kwargs={"lr": 0.0, "max_grad_norm": 1.0},
+            global_batch_size=1,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=ScalarWeightModel,
+            optimizer_cls=SGD,
+            loss_fn=lambda pred, target: (
+                (pred - Tensor(target, requires_grad=False)) ** 2
+            ).mean(),
+            config=config,
+        )
+        train_loader = make_data_loader(
+            [
+                (
+                    xp.array([[1.0]], dtype=xp.float32),
+                    xp.array([[10.0]], dtype=xp.float32),
+                )
+            ]
+        )
+
+        trainer.fit(train_loader)
+
+        self.assertAlmostEqual(trainer.metric_rows[0]["grad_l2_norm"], 20.0, places=5)
 
     def test_leftover_accumulation_matches_single_batch_update(self):
         single_batch_data = [
@@ -506,6 +1105,18 @@ class TestSimpleTrainer(BaseTrainerTest):
                 optimizer_kwargs={"lr": 0.01},
             )
 
+    def test_config_rejects_both_training_limits(self):
+        with self.assertRaisesRegex(
+            ValueError, "max_epochs and max_steps are mutually exclusive"
+        ):
+            GenericTrainingConfig(
+                max_epochs=1,
+                max_steps=1,
+                checkpoint_freq=1,
+                model_kwargs={"hidden_size": 256},
+                optimizer_kwargs={"lr": 0.01},
+            )
+
     def test_config_requires_global_batch_size_to_be_divisible_by_micro_batch_size(
         self,
     ):
@@ -523,21 +1134,165 @@ class TestSimpleTrainer(BaseTrainerTest):
             )
 
     def test_evaluate_uses_full_loader_when_max_eval_steps_is_none(self):
-        val_loader = MockDataLoader(self.val_data * 2)
+        val_loader = make_data_loader(self.val_data * 2)
 
         avg_val_loss = self.trainer.evaluate(val_loader)
 
-        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        self.assertAlmostEqual(avg_val_loss.val_loss, 1.23, places=5)
         self.assertEqual(self.loss_fn.call_count, 2)
 
     def test_evaluate_respects_max_eval_steps_from_config(self):
         self.config.max_eval_steps = 1
-        val_loader = MockDataLoader(self.val_data * 2)
+        val_loader = make_data_loader(self.val_data * 2)
 
         avg_val_loss = self.trainer.evaluate(val_loader)
 
-        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        self.assertAlmostEqual(avg_val_loss.val_loss, 1.23, places=5)
         self.assertEqual(self.loss_fn.call_count, 1)
+
+    def test_evaluate_rejects_empty_validation_loader(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded no batches.",
+        ):
+            self.trainer.evaluate(make_data_loader([]))
+
+    def test_evaluate_owns_eval_and_train_mode_switching(self):
+        trainer = SimpleTrainer(
+            model_cls=TrackingModeModel,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=self.config,
+            output_type="logits",
+        )
+        eval_state = TrainingState()
+        eval_state.record_eval_loss(1.23)
+        trainer._evaluate = MagicMock(return_value=eval_state)
+
+        trainer.evaluate(self.val_loader)
+
+        self.assertEqual(trainer.model.mode_log, ["eval", "train"])
+
+    def test_evaluate_runs_under_no_grad(self):
+        def assert_no_grad(_):
+            self.assertFalse(is_grad_enabled())
+            eval_state = TrainingState()
+            eval_state.record_eval_loss(1.23)
+            return eval_state
+
+        self.trainer._evaluate = MagicMock(side_effect=assert_no_grad)
+
+        eval_result = self.trainer.evaluate(self.val_loader)
+
+        self.assertAlmostEqual(float(eval_result.val_loss), 1.23, places=5)
+
+    def test_report_prefixes_eval_metrics_with_val(self):
+        self.trainer.global_step = len(self.train_loader)
+        plan = TrainingPlan.for_epochs(
+            max_epochs=self.config.max_epochs,
+            steps_per_epoch=len(self.train_loader),
+            checkpoint_every=self.config.checkpoint_freq,
+        )
+        state = TrainingState()
+        state.record_loss(1.23)
+        self.trainer.last_grad_l2_norm = 7.0
+
+        eval_state = TrainingState()
+        eval_state.record_eval_loss(0.5)
+        eval_state.record_eval_metric("accuracy", numerator=3, denominator=4)
+        self.trainer.report(
+            state,
+            plan,
+            eval_state,
+        )
+
+        row = self.trainer.metric_rows[0]
+        self.assertEqual(row["train_loss"], 1.23)
+        self.assertEqual(row["val_loss"], 0.5)
+        self.assertEqual(row["val_accuracy"], 0.75)
+
+    def test_report_logs_pretty_printed_metrics_dict(self):
+        self.trainer.global_step = len(self.train_loader)
+        plan = TrainingPlan.for_epochs(
+            max_epochs=self.config.max_epochs,
+            steps_per_epoch=len(self.train_loader),
+            checkpoint_every=self.config.checkpoint_freq,
+        )
+        state = TrainingState()
+        state.record_loss(1.23)
+        self.trainer.last_grad_l2_norm = 7.0
+
+        eval_state = TrainingState()
+        eval_state.record_eval_loss(0.5)
+        eval_state.record_eval_metric("accuracy", numerator=3, denominator=4)
+
+        with self.assertLogs("autograd.tools.trainer", level="INFO") as captured:
+            self.trainer.report(state, plan, eval_state)
+
+        joined_logs = "\n".join(captured.output)
+        self.assertIn("[Epoch 1]", joined_logs)
+        self.assertIn("'epoch': 1", joined_logs)
+        self.assertIn("'step': 2", joined_logs)
+        self.assertIn("'train_loss': '1.2300'", joined_logs)
+        self.assertIn("'val_loss': '0.5000'", joined_logs)
+        self.assertIn("'val_accuracy': '0.7500'", joined_logs)
+        self.assertIn("'grad_l2_norm': '7.0000'", joined_logs)
+        self.assertIn("'lr': '0.010000'", joined_logs)
+
+    def test_fit_plan_derives_step_mode_fields_from_config(self):
+        config = GenericTrainingConfig(
+            max_steps=3,
+            checkpoint_freq=2,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+        )
+
+        plan = TrainingPlan.for_steps(
+            max_steps=config.max_steps,
+            checkpoint_every=config.checkpoint_freq,
+        )
+
+        self.assertFalse(plan.by_epoch)
+        self.assertEqual(plan.target_step, 3)
+        self.assertEqual(plan.report_every_steps, 2)
+        self.assertEqual(plan.checkpoint_every, 2)
+        self.assertIsNone(plan.steps_per_epoch)
+        self.assertEqual(plan.metrics_interval, 1)
+
+    def test_fit_plan_derives_epoch_mode_fields_from_config(self):
+        plan = TrainingPlan.for_epochs(
+            max_epochs=self.config.max_epochs,
+            steps_per_epoch=len(self.train_loader),
+            checkpoint_every=self.config.checkpoint_freq,
+        )
+
+        self.assertTrue(plan.by_epoch)
+        self.assertEqual(
+            plan.target_step,
+            self.config.max_epochs * len(self.train_loader),
+        )
+        self.assertEqual(plan.report_every_steps, len(self.train_loader))
+        self.assertEqual(plan.checkpoint_every, self.config.checkpoint_freq)
+        self.assertEqual(plan.steps_per_epoch, len(self.train_loader))
+        self.assertEqual(plan.metrics_interval, 1)
+
+    def test_evaluate_does_not_mutate_trainer_metrics(self):
+        eval_result = self.trainer.evaluate(self.val_loader)
+
+        self.assertAlmostEqual(eval_result.val_loss, 1.23, places=5)
+        self.assertEqual(eval_result.eval_metrics["accuracy"], 1.0)
+        self.assertEqual(self.trainer.metric_rows, [])
+
+    def test_evaluate_returns_raw_eval_aggregates(self):
+        eval_state = self.trainer.evaluate(self.val_loader)
+
+        self.assertAlmostEqual(eval_state.eval_loss_sum, 1.23, places=5)
+        self.assertEqual(eval_state.eval_loss_batches, 1)
+        self.assertEqual(eval_state.eval_metric_totals["accuracy"]["numerator"], 2.0)
+        self.assertEqual(
+            eval_state.eval_metric_totals["accuracy"]["denominator"],
+            2.0,
+        )
 
 
 class TestLLMTrainer(BaseTrainerTest):
@@ -564,8 +1319,8 @@ class TestLLMTrainer(BaseTrainerTest):
         ]
 
         # Replace MagicMock with a real in-memory loader
-        self.train_loader = MockDataLoader(self.train_data, seq_len=seq_len)
-        self.val_loader = MockDataLoader(self.val_data, seq_len=seq_len)
+        self.train_loader = make_data_loader(self.train_data)
+        self.val_loader = make_data_loader(self.val_data)
 
         # We'll mock forward_fn to skip real model logic
         self.forward_fn = MagicMock()
@@ -600,23 +1355,11 @@ class TestLLMTrainer(BaseTrainerTest):
         # 2 epochs * 2 train batches = 4 steps
         self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
-    def test_train_step_returns_loss(self):
-        """Check that a single train step returns the constant scalar loss."""
+    def test_compute_loss_returns_tensor(self):
+        """Check that compute_loss returns the constant scalar Tensor."""
         batch = next(iter(self.train_data))
-        loss_val = self.trainer.train_step(batch)
-        self.assertAlmostEqual(loss_val, 1.23, places=5)
-
-    def test_evaluate_does_not_require_loader_metadata(self):
-        class MinimalLoader:
-            def __init__(self, data):
-                self.data = data
-
-            def __iter__(self):
-                return iter(self.data)
-
-        avg_val_loss = self.trainer.evaluate(MinimalLoader(self.val_data))
-
-        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        loss = self.trainer._compute_loss(batch)
+        self.assertAlmostEqual(float(loss.item()), 1.23, places=5)
 
     def test_evaluate_runs_eval_callbacks_and_returns_val_loss(self):
         callback = MagicMock()
@@ -631,10 +1374,18 @@ class TestLLMTrainer(BaseTrainerTest):
 
         avg_val_loss = trainer.evaluate(self.val_loader)
 
-        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        self.assertAlmostEqual(avg_val_loss.val_loss, 1.23, places=5)
+        self.assertEqual(avg_val_loss.eval_metrics, {})
         callback.assert_called_once_with(
             trainer.model, trainer.forward_fn, self.val_loader, trainer.config
         )
+
+    def test_llm_evaluate_rejects_empty_val_loader(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded no batches.",
+        ):
+            self.trainer.evaluate(make_data_loader([]))
 
     @patch("autograd.tools.callback.text_utils.inference")
     def test_manual_qualitative_inference_helpers_do_not_depend_on_loader(
@@ -665,14 +1416,14 @@ class TestLLMTrainer(BaseTrainerTest):
 
     def test_llm_evaluate_respects_max_eval_steps_from_config(self):
         self.config.max_eval_steps = 1
-        val_loader = MockDataLoader(self.val_data * 2, seq_len=10)
+        val_loader = make_data_loader(self.val_data * 2)
 
         avg_val_loss = self.trainer.evaluate(val_loader)
 
-        self.assertAlmostEqual(avg_val_loss, 1.23, places=5)
+        self.assertAlmostEqual(avg_val_loss.val_loss, 1.23, places=5)
         self.assertEqual(self.loss_fn.call_count, 1)
 
-    def test_train_step_supports_sft_batches_from_generic_data_loader(self):
+    def test_compute_loss_supports_sft_batches_from_generic_data_loader(self):
         bpe = MockBPE()
         pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
         tokenized_example = tokenize_prompt_completion(
@@ -722,14 +1473,16 @@ class TestLLMTrainer(BaseTrainerTest):
             label_smoothing=0.0,
         )
 
-        train_loss = trainer.train_step(batch)
+        train_loss = trainer._compute_loss(batch)
         val_loss = trainer.evaluate(loader)
 
-        self.assertAlmostEqual(train_loss, float(expected_loss.item()), places=6)
-        self.assertAlmostEqual(val_loss, float(expected_loss.item()), places=6)
+        self.assertAlmostEqual(
+            float(train_loss.item()), float(expected_loss.item()), places=6
+        )
+        self.assertAlmostEqual(val_loss.val_loss, float(expected_loss.item()), places=6)
 
     def test_fit_supports_unsized_streaming_data_loaders(self):
-        self.config.max_epochs = 10
+        self.config.max_epochs = None
         self.config.max_steps = 1
         self.config.max_eval_steps = 1
 


### PR DESCRIPTION
## Description
- Support activation checkpointing by throwing out the forward pass results for the GPT-2 model's decoder layers (current bottleneck), and recomputing the forward pass in backward().
- Large refactor for the trainer to support max_steps and max_epochs properly
- Fix checkpointing to properly serialize classes in order to allow for checkpoint resumption
- Add some key metrics in trainer

## Tests

**GPT-2 Pre-training Run (~19 hours)**
```
(ml-by-hand) ➜  ml-by-hand git:(act-ckpt) ✗ python -m examples.gpt_2
2026-04-21 01:33:01,391 - INFO - 178255102 characters in the entire dataset. Sample:

April

April (Apr.) is the fourth month of the year in the Julian and Gregorian calendars, and come
2026-04-21 01:33:01,391 - INFO - Loading the vocabulary from disk.
2026-04-21 01:33:01,395 - INFO - Found existing encoded data at 'training_data/bpe_12000_wiki_simple_encoded_data.npz', loading it instead of re-encoding.
2026-04-21 01:33:01,396 - INFO - Vocabulary size: 12260
2026-04-21 01:33:01,396 - INFO - Encoded data length: 47193131
Data length: len(train_data)=42473817 len(test_data)=4719314
2026-04-21 01:33:01,396 - INFO - Attempting to load from checkpoint: checkpoints/wiki_GPT2_30000.json, checkpoints/wiki_GPT2_30000.npz
2026-04-21 01:33:01,473 - INFO - Loaded GPT2 from epoch 0 with step_count=30000
2026-04-21 01:33:01,474 - INFO - Training GPT2 with 360.39M parameters.
2026-04-21 01:33:01,474 - INFO - Fit plan:
{'mode': 'steps',
 'target_step': 200000,
 'report_every_steps': 200,
 'global_batch_size': 32,
 'micro_batch_size': 1,
 'gradient_accumulation_steps': 32}
Training:  15%|██████                                  | 30200/200000 [00:30<2:25:16, 19.48it/s2026-04-21 01:40:23,329 - INFO - [Step 30200]
...

Training:  26%|█████████▋                           | 52400/200000 [18:30:25<2:05:25, 19.61it/s2026-04-21 20:24:13,463 - INFO - [Step 52400]
{'step': 52400,
 'train_loss': '5.1969',
 'val_loss': '5.6531',
 'grad_l2_norm': '3.1488',
 'lr': '0.000057'}
Training:  26%|█████████▋                           | 52600/200000 [18:51:32<2:08:03, 19.18it/s]
```

<img width="4136" height="3344" alt="image" src="https://github.com/user-attachments/assets/1178af96-8f15-42dc-ad3e-318b22a3f43a" />
