### PR TITLE
Non-perf training improvements

### DIFF
--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -59,6 +59,14 @@ class CosineScheduler(LRScheduler):
             lr_decay_iters (int, optional): Step at which learning rate decay ends. Defaults to 200.
             min_lr (float, optional): Minimum learning rate. Defaults to 1e-4.
         """
+        if warmup_steps < 0:
+            raise ValueError(f"warmup_steps must be >= 0, got {warmup_steps}")
+        if lr_decay_iters <= warmup_steps:
+            raise ValueError(
+                "CosineScheduler requires lr_decay_iters > warmup_steps, "
+                f"got warmup_steps={warmup_steps}, lr_decay_iters={lr_decay_iters}"
+            )
+
         self.warmup_steps = warmup_steps
         self.lr_decay_iters = lr_decay_iters
         self.min_lr = min_lr

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -42,6 +42,10 @@ class GenericTrainingConfig:
     report_every_steps: Optional[int] = None
     # Whether to load from a checkpoint
     resume_epoch: Optional[int] = None
+    # Optional checkpoint basename (without .json/.npz) used to initialize
+    # model weights before training. The configured architecture must match
+    # the checkpoint; mismatches should fail during load_state_dict.
+    pretrained_checkpoint_path: Optional[str] = None
     training_run_name: str = "default"
     dataset_name: Optional[str] = ""
     # Effective batch size after gradient accumulation.

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -89,10 +89,32 @@ class GenericTrainingConfig:
                 "global_batch_size must be divisible by micro_batch_size, "
                 f"got {self.global_batch_size} and {self.micro_batch_size}"
             )
+        self._validate_checkpoint_accumulation_alignment()
 
     @property
     def gradient_accumulation_steps(self) -> int:
         return self.global_batch_size // self.micro_batch_size
+
+    def _validate_checkpoint_accumulation_alignment(self) -> None:
+        if self.max_steps is None:
+            return
+
+        accumulation_steps = self.gradient_accumulation_steps
+        if accumulation_steps == 1 or self.checkpoint_freq > self.max_steps:
+            return
+
+        if self.checkpoint_freq % accumulation_steps != 0:
+            raise ValueError(
+                "checkpoint_freq must be divisible by gradient_accumulation_steps "
+                "when step-mode checkpointing uses gradient accumulation, "
+                f"got checkpoint_freq={self.checkpoint_freq}, "
+                f"gradient_accumulation_steps={accumulation_steps}. "
+                "Otherwise a checkpoint can be written before optimizer.step() "
+                "has materialized optimizer state for the accumulated gradients. "
+                "Use a checkpoint_freq that is a multiple of "
+                "gradient_accumulation_steps; if you need a final checkpoint, "
+                "max_steps should land on the same boundary."
+            )
 
 
 @dataclass

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -245,6 +245,7 @@ class AbstractTrainer(ABC):
             model_kwargs=config.model_kwargs,
             optimizer_kwargs=config.optimizer_kwargs,
             resume_epoch=config.resume_epoch,
+            pretrained_checkpoint_path=config.pretrained_checkpoint_path,
             checkpoint_path=kwargs.get("checkpoint_path"),
         )
         # `global_step` counts consumed training batches / microbatches,
@@ -533,7 +534,7 @@ class AbstractTrainer(ABC):
         if steps_per_epoch <= 0:
             raise ValueError("train_data_loader must yield at least one batch.")
 
-        if self.checkpoint:
+        if self.global_step > 0:
             loaded_steps_per_epoch = self.checkpoint.get("steps_per_epoch")
             if loaded_steps_per_epoch != steps_per_epoch:
                 raise ValueError(
@@ -563,6 +564,7 @@ class AbstractTrainer(ABC):
         model_kwargs: Dict[str, Any],
         optimizer_kwargs: Dict[str, Any],
         resume_epoch: Optional[int] = None,
+        pretrained_checkpoint_path: Optional[str] = None,
         checkpoint_path: Optional[str] = None,
     ) -> Tuple[Any, Any, dict]:
         """Loads model & optimizer states from checkpoint if a checkpoint is requested.
@@ -586,6 +588,9 @@ class AbstractTrainer(ABC):
             optimizer_kwargs (Dict[str, Any]): Keyword arguments for optimizer initialization.
             resume_epoch (Optional[int]): Optional checkpoint filename hint used when
                 `checkpoint_path` is not provided.
+            pretrained_checkpoint_path (Optional[str]): Optional checkpoint basename
+                (without .json/.npz) used to initialize model weights into a freshly
+                initialized model/optimizer from the current config.
             checkpoint_path (Optional[str]): If provided, path of the checkpoint file.
 
         Returns:
@@ -594,6 +599,29 @@ class AbstractTrainer(ABC):
                 - optimizer (optim.Optimizer): The loaded or newly instantiated optimizer.
                 - checkpoint (dict): Dictionary of checkpoint data if loaded, otherwise empty.
         """
+
+        if pretrained_checkpoint_path is not None:
+            if resume_epoch is not None or checkpoint_path is not None:
+                raise ValueError(
+                    "pretrained_checkpoint_path cannot be combined with resume_epoch "
+                    "or checkpoint_path."
+                )
+
+            ckpt_json = f"{pretrained_checkpoint_path}.json"
+            ckpt_npz = f"{pretrained_checkpoint_path}.npz"
+            logger.info(
+                f"Attempting to load pretrained weights from checkpoint: {ckpt_json}, {ckpt_npz}"
+            )
+            loaded_ckpt = load_checkpoint(ckpt_json, ckpt_npz)
+
+            model = model_class(**model_kwargs)
+            optimizer = optimizer_class(model.parameters, **optimizer_kwargs)
+            # The configured model architecture must match the checkpoint.
+            model.load_state_dict(loaded_ckpt["model_state_dict"])
+            logger.info(
+                f"Loaded pretrained {model_class.__name__} weights from {pretrained_checkpoint_path}"
+            )
+            return model, optimizer, {}
 
         if resume_epoch is not None or checkpoint_path is not None:
             # Look for checkpoint files

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -495,6 +495,13 @@ class TestAdam(TestCase):
 
 
 class TestCosineScheduler(TestCase):
+    def test_rejects_decay_not_past_warmup(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "CosineScheduler requires lr_decay_iters > warmup_steps",
+        ):
+            CosineScheduler(warmup_steps=1, lr_decay_iters=1)
+
     def setUp(self):
         self.warmup_steps = 100
         self.lr_decay_iters = 5000

--- a/test/autograd/tools/test_config_schema.py
+++ b/test/autograd/tools/test_config_schema.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+from autograd.tools.config_schema import TransformerTrainingConfig
+
+
+class TestTransformerTrainingConfig(TestCase):
+    def test_rejects_checkpoint_before_gradient_accumulation_boundary(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "checkpoint_freq must be divisible by gradient_accumulation_steps",
+        ):
+            TransformerTrainingConfig(
+                training_run_name="test",
+                dataset_name="dataset",
+                max_steps=5,
+                checkpoint_freq=5,
+                global_batch_size=32,
+                micro_batch_size=4,
+                model_kwargs={},
+                optimizer_kwargs={"lr": 1e-3},
+                label_smoothing=0.0,
+                teacher_forcing=False,
+            )

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -763,6 +763,88 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertEqual(checkpoint["optimizer_init_kwargs"], loaded_optimizer_kwargs)
 
     @patch("autograd.tools.trainer.load_checkpoint")
+    def test_pretrained_checkpoint_path_loads_weights_but_resets_training_state(
+        self, mock_load_checkpoint
+    ):
+        class TrackingModel(MockModelClass):
+            def __init__(self, hidden_size=128, **kwargs):
+                super().__init__(hidden_size=hidden_size, **kwargs)
+                self.loaded_state_dict = None
+
+            def load_state_dict(self, state_dict):
+                self.loaded_state_dict = state_dict
+
+        class TrackingOptimizer(MockOptimizerClass):
+            def __init__(self, parameters, lr=1e-3, **kwargs):
+                super().__init__(parameters, lr=lr, **kwargs)
+                self.loaded_state_dict = None
+
+            def load_state_dict(self, state_dict):
+                self.loaded_state_dict = state_dict
+
+        model_state_dict = {"weights": "from-pretrain"}
+        optimizer_state_dict = {"step": 123}
+        mock_load_checkpoint.return_value = {
+            "epoch": 9,
+            "step_count": len(self.train_loader),
+            "steps_per_epoch": len(self.train_loader),
+            "best_val_loss": 0.25,
+            "model_state_dict": model_state_dict,
+            "optimizer_state_dict": optimizer_state_dict,
+            "model_init_kwargs": {"hidden_size": 512},
+            "optimizer_init_kwargs": {"lr": 0.02},
+        }
+        config = GenericTrainingConfig(
+            max_epochs=1,
+            checkpoint_freq=1,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            resume_epoch=None,
+            pretrained_checkpoint_path="dummy_pretrained",
+        )
+
+        trainer = SimpleTrainer(
+            model_cls=TrackingModel,
+            optimizer_cls=TrackingOptimizer,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+
+        self.assertEqual(trainer.model.hidden_size, 256)
+        self.assertEqual(trainer.model.loaded_state_dict, model_state_dict)
+        self.assertIsNone(trainer.optimizer.loaded_state_dict)
+        self.assertEqual(trainer.optimizer.lr, 0.01)
+        self.assertEqual(trainer.global_step, 0)
+        self.assertIsNone(trainer.best_val_loss)
+        self.assertEqual(trainer.checkpoint, {})
+        mock_load_checkpoint.assert_called_once_with(
+            "dummy_pretrained.json", "dummy_pretrained.npz"
+        )
+
+    def test_pretrained_checkpoint_path_conflicts_with_resume_epoch(self):
+        config = GenericTrainingConfig(
+            max_epochs=1,
+            checkpoint_freq=1,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            resume_epoch=1,
+            pretrained_checkpoint_path="dummy_pretrained",
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "pretrained_checkpoint_path cannot be combined with resume_epoch or checkpoint_path",
+        ):
+            SimpleTrainer(
+                model_cls=MockModelClass,
+                optimizer_cls=MockOptimizerClass,
+                loss_fn=self.loss_fn,
+                config=config,
+                output_type="logits",
+            )
+
+    @patch("autograd.tools.trainer.load_checkpoint")
     def test_checkpoint_path_resume_uses_checkpoint_progress_not_config_hint(
         self, mock_load_checkpoint
     ):
@@ -844,8 +926,8 @@ class TestSimpleTrainer(BaseTrainerTest):
 
     def test_fit_flushes_pending_gradients_before_report_boundary(self):
         config = GenericTrainingConfig(
-            max_steps=1,
-            checkpoint_freq=1,
+            max_steps=2,
+            checkpoint_freq=2,
             model_kwargs={"hidden_size": 256},
             optimizer_kwargs={"lr": 0.01},
             global_batch_size=2,


### PR DESCRIPTION
## Description
- Add support for loading a pretrained checkpoint for further post-training.
- Validate the checkpoint saving frequency against gradient accumulation frequency. We want to prevent extra gradients that haven't been accumulated/used for param update after the checkpoint has been saved.
- Add validation on CosineScheduler warmup steps vs learning rate decay steps so that warm up steps is strictly smaller. Otherwise, we're in a very limbo situation where LR started to decay but hasn't finished warm up.

## Tests
Updated unit tests.
