### PR TITLE
Flatten matmul leading batch size dimensions to save memory

### DIFF
--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -1502,19 +1502,32 @@ class Matmul(Function):
             # shape of grad_x should match x.data.shape
 
         if y.requires_grad:
-            # Transpose x on the last two dims (x^T)
-            x_t = xp.swapaxes(x.data, -1, -2)
-            raw_grad_y = xp.matmul(x_t, grad.data)
-            # Now if y was 2D => shape (m, p), but raw_grad_y might be (B,m,p). We sum over batch dims.
-            # Let's figure out how many leading dims y has (besides the last 2).
-            if y.data.ndim == 2 and raw_grad_y.ndim > 2:
-                # sum over all batch/time dims => axis=0..(raw_grad_y.ndim-2)
-                # e.g. raw_grad_y is (B, m, p), we want (m, p)
-                axes_to_sum = tuple(range(raw_grad_y.ndim - 2))
-                grad_y = xp.sum(raw_grad_y, axis=axes_to_sum)
+            if y.data.ndim == 2 and x.data.ndim > 2:
+                # When x is batched but y is a shared 2D weight matrix:
+                #   x: (..., m), grad: (..., p), y: (m, p)
+                # flatten the leading dims so we compute the final weight
+                # gradient directly as:
+                #   x_flat.T @ grad_flat -> (m, p)
+                # instead of first materializing a batched (..., m, p)
+                # temporary and summing it afterward.
+                x_flat = x.data.reshape(-1, x.data.shape[-1])
+                grad_flat = grad.data.reshape(-1, grad.data.shape[-1])
+                grad_y = xp.matmul(xp.swapaxes(x_flat, -1, -2), grad_flat)
             else:
-                # If y had a batch dimension as well, raw_grad_y already has the right shape
-                grad_y = raw_grad_y
+                # Otherwise preserve the general batched matmul path, including
+                # cases where y itself has batch dimensions.
+                x_t = xp.swapaxes(x.data, -1, -2)
+                raw_grad_y = xp.matmul(x_t, grad.data)
+                # Now if y was 2D => shape (m, p), but raw_grad_y might be (B,m,p). We sum over batch dims.
+                # Let's figure out how many leading dims y has (besides the last 2).
+                if y.data.ndim == 2 and raw_grad_y.ndim > 2:
+                    # sum over all batch/time dims => axis=0..(raw_grad_y.ndim-2)
+                    # e.g. raw_grad_y is (B, m, p), we want (m, p)
+                    axes_to_sum = tuple(range(raw_grad_y.ndim - 2))
+                    grad_y = xp.sum(raw_grad_y, axis=axes_to_sum)
+                else:
+                    # If y had a batch dimension as well, raw_grad_y already has the right shape
+                    grad_y = raw_grad_y
 
         return grad_x, grad_y
 

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 from unittest import TestCase
+from unittest.mock import patch
 
 import torch  # for comparison
 
@@ -377,6 +378,44 @@ class TestTensorOps(TestTensor):
         # Verify our manual computation matches PyTorch
         assert array_equal(manual_x_grad, x_torch.grad.numpy())
         assert array_equal(manual_w_grad, w_torch.grad.numpy())
+
+    def test_backward_batched_input_2d_weight_avoids_batched_weight_grad_matmul(self):
+        batch_size, seq_len, hidden_size, vocab_size = 2, 3, 4, 5
+        x = Tensor(
+            xp.random.normal(shape=(batch_size, seq_len, hidden_size)).astype(
+                xp.float32
+            ),
+            requires_grad=True,
+        )
+        w = Tensor(
+            xp.random.normal(shape=(hidden_size, vocab_size)).astype(xp.float32),
+            requires_grad=True,
+        )
+
+        z = x @ w
+
+        matmul_calls = []
+        original_matmul = xp.matmul
+
+        def recording_matmul(lhs, rhs):
+            matmul_calls.append((lhs.shape, rhs.shape))
+            return original_matmul(lhs, rhs)
+
+        with patch("autograd.tensor.xp.matmul", side_effect=recording_matmul):
+            z.backward(xp.ones_like(z.data))
+
+        assert not any(
+            len(lhs_shape) > 2 and len(rhs_shape) > 2
+            for lhs_shape, rhs_shape in matmul_calls
+        )
+
+        x_torch = torch.tensor(x.data, requires_grad=True)
+        w_torch = torch.tensor(w.data, requires_grad=True)
+        z_torch = x_torch @ w_torch
+        z_torch.backward(torch.ones_like(z_torch))
+
+        assert allclose(x.grad.data, x_torch.grad.numpy(), rtol=1e-4, atol=1e-5)
+        assert allclose(w.grad.data, w_torch.grad.numpy(), rtol=1e-4, atol=1e-5)
 
     def test_batch_multiplication(self):
         """Test element-wise multiplication with batched tensors"""


### PR DESCRIPTION
## Description

Before for the MatMul  if we have more than 2 dimensions (e.g. batch size, sequence length, hidden dimension), then we compute MatMul then sum across the first dimension (e.g. batch size). This means we need to materialize the intermediate MatMul matrix. But we don't really care about that intermediate matrix.

More specifically:

Before:
```
x = (batch_size: 4, seq_len: 512, hidden_size: 768)
x.T = (batch_size: 4, hidden_size: 768, seq_len: 512)
grad = (batch_size: 4, seq_len: 512, vocab: 12000)
matmul_result = x.T @ grad = (batch_size: 4, hidden_size: 768, vocab: 12000)
matmul_result.sum(axis=0) = (hidden_size: 768, vocab: 12000)
```

After:
```
x_flat = (batch_size * seq_len: 4*512, hidden_size: 768)
x_flat.T = (hidden_size: 768, batch_size * seq_len: 4*512)
grad_flat = (batch_size * seq_len: 4*512, vocab: 12000)
matmul_result = x_flat.T @ grad_flat = (hidden_size: 768, vocab: 12000)
```

## Tests

| Case | Time Delta | Peak Memory Delta |
|---|---|---|
| Attention Q/K/V-style projection, both inputs requires grad (4,512,768) @ (768,768) | 27.75% faster | -20.69% |
| Internal MLP expand projection, both inputs requires grad (4,512,768) @ (768,3072) | 1.27% faster | -26.09% |
| Internal MLP contract projection, both inputs requires grad (4,512,3072) @ (3072,768) | 3.06% faster | -30.00% |
| Final vocab output projection, both inputs requires grad (4,512,768) @ (768,12000) | 5.26% faster | -27.89% |
| Final vocab projection, weight-grad only (4,512,768) @ (768,12000) | 6.37% faster | -28.23% |