### PR TITLE
Optimize tokenizer encoding

### DIFF
--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pickle
 from collections import Counter
+from functools import partial
 from multiprocessing import Pool, cpu_count
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -205,15 +206,27 @@ class BytePairEncoder:
                     for i in range(0, len(raw_text), chunk_size)
                 ]
                 with Pool(self.n_workers) as pool:
-                    partial_encoded = pool.map(self.encode, text_chunks)
+                    partial_encoded = list(
+                        tqdm(
+                            pool.imap(
+                                partial(self.encode, show_progress=False),
+                                text_chunks,
+                            ),
+                            total=len(text_chunks),
+                            desc="Encoding text chunks",
+                            unit="chunk",
+                        )
+                    )
             else:
-                partial_encoded = [self.encode(raw_text)]
+                partial_encoded = [self.encode(raw_text, show_progress=True)]
 
-            encoded_data = xp.array([], dtype=xp.int32)
-            for part in partial_encoded:
-                encoded_data = xp.concatenate(
-                    [encoded_data, xp.array(part, dtype=xp.int32)]
-                )
+            encoded_parts = [xp.array(part, dtype=xp.int32) for part in partial_encoded]
+            if not encoded_parts:
+                encoded_data = xp.array([], dtype=xp.int32)
+            elif len(encoded_parts) == 1:
+                encoded_data = encoded_parts[0]
+            else:
+                encoded_data = xp.concatenate(encoded_parts)
 
             # 4) Save to disk
             xp.savez_compressed(self.encoded_data_path, arr_0=encoded_data)
@@ -321,7 +334,9 @@ class BytePairEncoder:
 
         return self._unicode_to_int_vocab, self._int_to_unicode_vocab
 
-    def encode(self, input_text: str, **kwargs) -> List[int]:
+    def encode(
+        self, input_text: str, *, show_progress: bool = False, **kwargs
+    ) -> List[int]:
         """Encodes a raw input string into a list of BPE token IDs.
 
         The process is:
@@ -360,15 +375,22 @@ class BytePairEncoder:
                         self._unicode_to_int_vocab[bytes([b_int])]
                     )
 
-        # Apply learned merges in a naive pass
+        # Learned merges are replayed in training order. `pairs` only skips the
+        # full token scan when a learned pair is absent from the current input.
+        token_ids: Sequence[int] = byte_encoded_chars
+        pairs = set(zip(token_ids, token_ids[1:]))
         for pair, new_id in tqdm(
-            self.learned_merges, desc="Applying merges to encode", leave=False
+            self.learned_merges,
+            desc="Applying merges to encode",
+            leave=False,
+            disable=not show_progress,
         ):
-            byte_encoded_chars = list(
-                self._merge_pairs(pair, new_id, byte_encoded_chars)
-            )
+            if pair not in pairs:
+                continue
+            token_ids = self._merge_pairs(pair, new_id, token_ids)
+            pairs = set(zip(token_ids, token_ids[1:]))
 
-        return byte_encoded_chars
+        return list(token_ids)
 
     def decode(self, encoded_tokens: List[int]) -> str:
         """Decodes a sequence of BPE token IDs back into a string.
@@ -559,10 +581,12 @@ class BytePairEncoder:
             >>> merged = BytePairEncoder._merge_pairs((65, 66), 300, corpus) # Expected: (300, 67, 300) or similar depending on merge implementation
         """
         merged_tokens: List[int] = []
+        first, second = pair
         i = 0
-        while i < len(corpus):
+        last = len(corpus) - 1
+        while i <= last:
             # If we see the pair, merge them
-            if i < len(corpus) - 1 and (corpus[i], corpus[i + 1]) == pair:
+            if i < last and corpus[i] == first and corpus[i + 1] == second:
                 merged_tokens.append(new_idx)
                 i += 2
             else:

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import tempfile
 from unittest import TestCase
 
 from sklearn.datasets import load_breast_cancer, load_diabetes
@@ -47,6 +48,15 @@ class RegressionModel(nn.Module):
 
 
 class TestTrain(TestCase):
+    def setUp(self) -> None:
+        self._tmp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+        self._trainer_dirs = (
+            SimpleTrainer.CHECKPOINT_DIR,
+            SimpleTrainer.METRICS_DIR,
+        )
+        SimpleTrainer.CHECKPOINT_DIR = os.path.join(self._tmp_dir.name, "checkpoints")
+        SimpleTrainer.METRICS_DIR = os.path.join(self._tmp_dir.name, "training_runs")
+
     def tearDown(self) -> None:
         reg_metrics_path = (
             f"{SimpleTrainer.METRICS_DIR}/{RegressionModel.__name__}_default.npz"
@@ -58,6 +68,11 @@ class TestTrain(TestCase):
             os.remove(reg_metrics_path)
         if os.path.exists(classifier_metrics_path):
             os.remove(classifier_metrics_path)
+        (
+            SimpleTrainer.CHECKPOINT_DIR,
+            SimpleTrainer.METRICS_DIR,
+        ) = self._trainer_dirs
+        self._tmp_dir.cleanup()
 
     def test_binary_classification(self):
         X, y = load_breast_cancer(return_X_y=True)

--- a/test/autograd/text/test_tokenizer.py
+++ b/test/autograd/text/test_tokenizer.py
@@ -3,8 +3,12 @@ from collections import Counter
 from unittest import TestCase
 from unittest.mock import patch
 
+import numpy as np
+
 from autograd.text.tokenizer import BytePairEncoder
 from test.helpers import array_equal
+
+ORIGINAL_NP_CONCATENATE = np.concatenate
 
 
 class TestTokenizer(TestCase):
@@ -122,6 +126,34 @@ class TestTokenizer(TestCase):
         decoded = self.bpe.decode(encoded)
         self.assertEqual(input_text, decoded)
 
+    def test_encode_matches_learned_merge_replay(self):
+        self.bpe.train_vocabulary(self.original_text, overwrite_saved_file=True)
+
+        def replay_learned_merges(text):
+            tokens = []
+            for chunk in self.bpe._pretokenize(text):
+                if chunk in self.bpe.SPECIAL_TOKENS:
+                    tokens.append(self.bpe._unicode_to_int_vocab[chunk.encode("utf-8")])
+                else:
+                    tokens.extend(
+                        self.bpe._unicode_to_int_vocab[bytes([b])]
+                        for b in chunk.encode("utf-8")
+                    )
+
+            pairs = set(zip(tokens, tokens[1:]))
+            for pair, new_id in self.bpe.learned_merges:
+                if pair in pairs:
+                    tokens = list(BytePairEncoder._merge_pairs(pair, new_id, tokens))
+                    pairs = set(zip(tokens, tokens[1:]))
+            return tokens
+
+        for text in [
+            self.original_text,
+            self.original_text + "<|endoftext|>" + self.original_text,
+            "low lower newest widest",
+        ]:
+            self.assertEqual(self.bpe.encode(text), replay_learned_merges(text))
+
     def test_special_tokens_encoded_as_single_id(self):
         # This checks special tokens remain single ID
         st_id = self.bpe._unicode_to_int_vocab[
@@ -200,3 +232,154 @@ class TestTokenizer(TestCase):
         )
 
         self.assertGreater(len(encoded), 0)
+
+    @patch("autograd.text.tokenizer.Pool")
+    def test_prepare_data_disables_per_chunk_encode_progress_in_parallel(
+        self, mock_pool
+    ):
+        class RecordingBPE(BytePairEncoder):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.show_progress_calls = []
+
+            def encode(self, input_text: str, *, show_progress: bool = True, **kwargs):
+                self.show_progress_calls.append(show_progress)
+                return super().encode(input_text, show_progress=show_progress, **kwargs)
+
+        class FakePool:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def imap(self, func, iterable):
+                for item in iterable:
+                    yield func(item)
+
+        bpe = RecordingBPE(
+            num_merges=0,
+            vocab_file_path="parallel_vocab.pkl",
+            encoded_data_path="parallel_encoded_data.npz",
+            n_workers=2,
+        )
+        self.addCleanup(
+            lambda: (
+                os.path.exists(bpe.vocab_file_path) and os.remove(bpe.vocab_file_path)
+            )
+        )
+        self.addCleanup(
+            lambda: (
+                os.path.exists(bpe.encoded_data_path)
+                and os.remove(bpe.encoded_data_path)
+            )
+        )
+        mock_pool.return_value = FakePool()
+
+        encoded = bpe.prepare_data(
+            "x" * 20000,
+            overwrite_vocabulary_file=True,
+            overwrite_encoded_data=True,
+        )
+
+        self.assertGreater(len(encoded), 0)
+        self.assertEqual(bpe.show_progress_calls, [False, False])
+
+    def test_encode_disables_progress_by_default(self):
+        with patch("autograd.text.tokenizer.tqdm") as mock_tqdm:
+            self.bpe.encode("hello")
+
+        self.assertTrue(mock_tqdm.called)
+        self.assertTrue(mock_tqdm.call_args.kwargs["disable"])
+
+    @patch("autograd.text.tokenizer.Pool")
+    @patch("autograd.text.tokenizer.xp.concatenate")
+    @patch("autograd.text.tokenizer.xp.savez_compressed")
+    def test_prepare_data_concatenates_parallel_chunks_once(
+        self, _mock_savez, mock_concatenate, mock_pool
+    ):
+        class RecordingBPE(BytePairEncoder):
+            def train_vocabulary(
+                self, input_text: str, overwrite_saved_file: bool = False
+            ):
+                return self._unicode_to_int_vocab, self._int_to_unicode_vocab
+
+            def encode(self, input_text: str, *, show_progress: bool = True, **kwargs):
+                return [len(input_text)]
+
+        class FakePool:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def imap(self, func, iterable):
+                for item in iterable:
+                    yield func(item)
+
+        def counted_concatenate(arrays, axis=0):
+            return ORIGINAL_NP_CONCATENATE(arrays, axis=axis)
+
+        bpe = RecordingBPE(
+            num_merges=0,
+            vocab_file_path="concat_vocab.pkl",
+            encoded_data_path="concat_encoded_data.npz",
+            n_workers=2,
+        )
+        self.addCleanup(
+            lambda: (
+                os.path.exists(bpe.encoded_data_path)
+                and os.remove(bpe.encoded_data_path)
+            )
+        )
+        mock_pool.return_value = FakePool()
+        mock_concatenate.side_effect = counted_concatenate
+
+        encoded = bpe.prepare_data(
+            "x" * 20000,
+            overwrite_vocabulary_file=False,
+            overwrite_encoded_data=True,
+        )
+
+        self.assertEqual(mock_concatenate.call_count, 1)
+        self.assertEqual(encoded.tolist(), [10000, 10000])
+
+    @patch(
+        "autograd.text.tokenizer.Pool", side_effect=AssertionError("pool not expected")
+    )
+    def test_prepare_data_enables_progress_for_single_text_encode(self, _mock_pool):
+        class RecordingBPE(BytePairEncoder):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.show_progress_calls = []
+
+            def encode(self, input_text: str, *, show_progress: bool = False, **kwargs):
+                self.show_progress_calls.append(show_progress)
+                return super().encode(input_text, show_progress=show_progress, **kwargs)
+
+        bpe = RecordingBPE(
+            num_merges=2,
+            vocab_file_path="single_progress_vocab.pkl",
+            encoded_data_path="single_progress_encoded_data.npz",
+            n_workers=4,
+        )
+        self.addCleanup(
+            lambda: (
+                os.path.exists(bpe.vocab_file_path) and os.remove(bpe.vocab_file_path)
+            )
+        )
+        self.addCleanup(
+            lambda: (
+                os.path.exists(bpe.encoded_data_path)
+                and os.remove(bpe.encoded_data_path)
+            )
+        )
+
+        bpe.prepare_data(
+            "hello hello",
+            overwrite_vocabulary_file=True,
+            overwrite_encoded_data=True,
+        )
+
+        self.assertEqual(bpe.show_progress_calls, [True])

--- a/test/autograd/tools/test_model.py
+++ b/test/autograd/tools/test_model.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 from copy import deepcopy
 from unittest import TestCase
 
@@ -29,7 +30,8 @@ class TestModel(TestCase):
     def setUp(self):
         # Create a test model with some initial arguments
         self.model = MockModule(999, kwarg0="testing_kwarg0")
-        self.checkpoint_dir = "."
+        self._tmp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+        self.checkpoint_dir = self._tmp_dir.name
         self.checkpoint_name = "test_model"
         self.json_path = os.path.join(
             self.checkpoint_dir, f"{self.checkpoint_name}.json"
@@ -41,6 +43,7 @@ class TestModel(TestCase):
         for f in [self.json_path, self.npz_path]:
             if os.path.exists(f):
                 os.remove(f)
+        self._tmp_dir.cleanup()
 
     def _meta_types(self, node):
         types = []
@@ -154,7 +157,7 @@ class TestModel(TestCase):
         self.assertNotIn("np.ndarray", meta_types)
 
     def test_save_checkpoint_builds_paths_from_checkpoint_name(self):
-        checkpoint_dir = "test_checkpoints"
+        checkpoint_dir = os.path.join(self._tmp_dir.name, "test_checkpoints")
         checkpoint_name = "mock_run_MockModule_7"
         json_path, npz_path = save_checkpoint(
             self.model.state_dict(),

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -1,5 +1,6 @@
 import math
 import os
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -272,13 +273,23 @@ class BaseTrainerTest(unittest.TestCase):
     def setUp(self):
         # A mock loss function returning a constant scalar
         self.loss_fn = MagicMock(return_value=Tensor(1.23))
+        self._tmp_dir = tempfile.TemporaryDirectory(dir="/tmp")
+        self._trainer_dirs = {}
+        self.checkpoint_dir = os.path.join(self._tmp_dir.name, "checkpoints")
+        self.metrics_dir = os.path.join(self._tmp_dir.name, "training_runs")
+        for trainer_cls in (SimpleTrainer, LLMTrainer):
+            self._trainer_dirs[trainer_cls] = (
+                trainer_cls.CHECKPOINT_DIR,
+                trainer_cls.METRICS_DIR,
+            )
+            trainer_cls.CHECKPOINT_DIR = self.checkpoint_dir
+            trainer_cls.METRICS_DIR = self.metrics_dir
 
     def tearDown(self) -> None:
-        metrics_path = (
-            f"{SimpleTrainer.METRICS_DIR}/{MockModelClass.__name__}_default.npz"
-        )
-        if os.path.exists(metrics_path):
-            os.remove(metrics_path)
+        for trainer_cls, (checkpoint_dir, metrics_dir) in self._trainer_dirs.items():
+            trainer_cls.CHECKPOINT_DIR = checkpoint_dir
+            trainer_cls.METRICS_DIR = metrics_dir
+        self._tmp_dir.cleanup()
 
 
 class TestSimpleTrainer(BaseTrainerTest):


### PR DESCRIPTION
## Description
- Avoid scanning the full token list if the learned byte pair is not present
- when a merge is present, the token sequence is merged in the same order as the BPE tokenizer training process's merge order
- Avoid repeated xp.concatenate in the loop and only concatenate once at the end to convert chunks into array
- Fix TQDM progress bar where nested progress bar will repeatedly finish from 0% to 100% and make the outer progress bar not visible
- Redirect unit test artifacts to /tmp folder instead of in the current working directory (most of the test case updates)

## Tests

| Setup | Metric | Result |
|---|---|---|
| n_workers=1 | direct encode | PR 22.47% faster |
| n_workers=1 | uncached prepare_data | PR 20.27% faster |
| n_workers=8 | direct encode | PR 26.08% faster |
| n_workers=8 | uncached prepare_data | PR 13.41% faster |