### PR TITLE
Reduce training overhead from GPU to CPU sync

### DIFF
--- a/autograd/backend.py
+++ b/autograd/backend.py
@@ -78,6 +78,25 @@ def eval(*xs: Any) -> None:
         xp.eval(*xs)
 
 
+def eval_backend(*values: Any) -> None:
+    """
+    Force MLX's lazy parameter/state updates at optimizer-step boundaries.
+
+    Without this explicit boundary, update graphs can be evaluated later at
+    less predictable synchronization points such as scalar reads or checkpoints.
+    """
+    if not IS_MLX:
+        return
+
+    from mlx.utils import tree_map
+
+    def unwrap_tensor(value: Any) -> Any:
+        data = getattr(value, "data", None)
+        return data if hasattr(data, "shape") else value
+
+    eval(tree_map(unwrap_tensor, values))
+
+
 def _scatter_add(dst: Any, idx: Any, updates: Any):
     if IS_MLX:
         return dst.at[idx].add(updates)

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -243,7 +243,7 @@ class Optimizer:
         elif hasattr(params, "grad"):
             update_fn(params)
 
-    def _clip_grad_norm(self, max_norm: float, norm_type: float = 2.0) -> None:
+    def _clip_grad_norm(self, max_norm: float, norm_type: float = 2.0) -> float:
         r"""
         Scale the gradients of all parameters in-place so that their norm is at most max_norm.
 
@@ -260,7 +260,7 @@ class Optimizer:
             norm_type (float, optional): The type of norm to use (default is 2, Euclidean norm a.k.a. L2 norm).
         """
         # Compute the global norm of all gradients
-        total_norm = 0.0
+        total_norm = xp.asarray(0.0, dtype=xp.float32)
         for param in self.model_parameters.values():
             if param.grad is not None:
                 grad_data = param.grad.data
@@ -277,6 +277,8 @@ class Optimizer:
         for param in self.model_parameters.values():
             if param.grad is not None:
                 param.grad.data *= scale_factor
+
+        return float(xp.to_scalar(total_norm))
 
     def zero_grad(self) -> None:
         """
@@ -299,7 +301,7 @@ class Optimizer:
 
     def grad_l2_norm(self) -> float:
         """Return the L2 norm of all current parameter gradients."""
-        grad_norm = 0.0
+        grad_norm = xp.asarray(0.0, dtype=xp.float32)
         for param in self.model_parameters.values():
             if param.grad is not None:
                 grad_norm += (param.grad.data**2).sum()
@@ -362,7 +364,7 @@ class Optimizer:
                             f"Skipping state for param {param_name} not found in current model"
                         )
 
-    def step(self) -> None:
+    def step(self) -> Optional[float]:
         """
         Perform a single optimization step.
 
@@ -370,6 +372,7 @@ class Optimizer:
         """
         self.timestep += 1
         self.update_lr()
+        return None
 
 
 class SGD(Optimizer):
@@ -388,7 +391,7 @@ class SGD(Optimizer):
         """
         super(SGD, self).__init__(model_parameters, lr=lr, **kwargs)
 
-    def step(self) -> None:
+    def step(self) -> Optional[float]:
         """
         Perform a single optimization step using SGD.
 
@@ -403,10 +406,14 @@ class SGD(Optimizer):
                 return
             param.data -= self.lr * param.grad.data
 
+        grad_l2_norm = None
         if "max_grad_norm" in self._hyperparams:
-            self._clip_grad_norm(self._hyperparams["max_grad_norm"], norm_type=2.0)
+            grad_l2_norm = self._clip_grad_norm(
+                self._hyperparams["max_grad_norm"], norm_type=2.0
+            )
 
         self._recursive_param_op(self.model_parameters, update_fn)
+        return grad_l2_norm
 
 
 class Adam(Optimizer):
@@ -455,7 +462,7 @@ class Adam(Optimizer):
         self._states["m"] = defaultdict(float)  # first momentum estimate
         self._states["v"] = defaultdict(float)  # second momentum estimate
 
-    def step(self) -> None:
+    def step(self) -> Optional[float]:
         """
         Perform a single optimization step using the Adam algorithm.
 
@@ -465,8 +472,11 @@ class Adam(Optimizer):
         """
         super().step()
 
+        grad_l2_norm = None
         if "max_grad_norm" in self._hyperparams:
-            self._clip_grad_norm(self._hyperparams["max_grad_norm"], norm_type=2.0)
+            grad_l2_norm = self._clip_grad_norm(
+                self._hyperparams["max_grad_norm"], norm_type=2.0
+            )
 
         beta1 = self._hyperparams["beta1"]
         beta2 = self._hyperparams["beta2"]
@@ -499,3 +509,4 @@ class Adam(Optimizer):
             if weight_decay > 0.0:
                 param.data = param.data - self.lr * weight_decay * param.data
             param.data -= self.lr * m_hat / (xp.sqrt(v_hat) + epsilon)
+        return grad_l2_norm

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from typing import Any, Callable, Dict, Optional
 
-from autograd.backend import xp
+from autograd.backend import eval_backend, xp
 from autograd.tensor import Tensor
 
 logger = logging.getLogger(__name__)
@@ -243,7 +243,11 @@ class Optimizer:
         elif hasattr(params, "grad"):
             update_fn(params)
 
-    def _clip_grad_norm(self, max_norm: float, norm_type: float = 2.0) -> float:
+    def clip_grad_norm(
+        self,
+        max_norm: float,
+        norm_type: float = 2.0,
+    ) -> Any:
         r"""
         Scale the gradients of all parameters in-place so that their norm is at most max_norm.
 
@@ -278,7 +282,9 @@ class Optimizer:
             if param.grad is not None:
                 param.grad.data *= scale_factor
 
-        return float(xp.to_scalar(total_norm))
+        # Return the backend scalar lazily. Callers that need to log this value
+        # own the device-to-host scalarization.
+        return total_norm
 
     def zero_grad(self) -> None:
         """
@@ -364,15 +370,14 @@ class Optimizer:
                             f"Skipping state for param {param_name} not found in current model"
                         )
 
-    def step(self) -> Optional[float]:
+    def step(self) -> None:
         """
         Perform a single optimization step.
-
-        This method increments the timestep and updates the learning rate.
         """
-        self.timestep += 1
-        self.update_lr()
-        return None
+        raise NotImplementedError
+
+    def _eval_backend(self) -> None:
+        eval_backend(self.model_parameters, self._states)
 
 
 class SGD(Optimizer):
@@ -391,29 +396,24 @@ class SGD(Optimizer):
         """
         super(SGD, self).__init__(model_parameters, lr=lr, **kwargs)
 
-    def step(self) -> Optional[float]:
+    def step(self) -> None:
         """
         Perform a single optimization step using SGD.
 
         This method updates each parameter by subtracting the product of the learning rate
-        and the parameter's gradient. If 'max_grad_norm' is specified in hyperparameters,
-        gradient clipping is applied before the update.
+        and the parameter's gradient.
         """
-        super().step()
+        self.timestep += 1
+        self.update_lr()
 
         def update_fn(param: Any) -> None:
             if param.grad is None:
                 return
             param.data -= self.lr * param.grad.data
 
-        grad_l2_norm = None
-        if "max_grad_norm" in self._hyperparams:
-            grad_l2_norm = self._clip_grad_norm(
-                self._hyperparams["max_grad_norm"], norm_type=2.0
-            )
-
         self._recursive_param_op(self.model_parameters, update_fn)
-        return grad_l2_norm
+        self._eval_backend()
+        return None
 
 
 class Adam(Optimizer):
@@ -462,21 +462,16 @@ class Adam(Optimizer):
         self._states["m"] = defaultdict(float)  # first momentum estimate
         self._states["v"] = defaultdict(float)  # second momentum estimate
 
-    def step(self) -> Optional[float]:
+    def step(self) -> None:
         """
         Perform a single optimization step using the Adam algorithm.
 
-        This method updates the biased first and second moment estimates,
+        This method updates the biased first and second order momentum estimates,
         applies bias correction, performs a decoupled weight decay step if specified,
         and updates the parameters accordingly.
         """
-        super().step()
-
-        grad_l2_norm = None
-        if "max_grad_norm" in self._hyperparams:
-            grad_l2_norm = self._clip_grad_norm(
-                self._hyperparams["max_grad_norm"], norm_type=2.0
-            )
+        self.timestep += 1
+        self.update_lr()
 
         beta1 = self._hyperparams["beta1"]
         beta2 = self._hyperparams["beta2"]
@@ -509,4 +504,5 @@ class Adam(Optimizer):
             if weight_decay > 0.0:
                 param.data = param.data - self.lr * weight_decay * param.data
             param.data -= self.lr * m_hat / (xp.sqrt(v_hat) + epsilon)
-        return grad_l2_norm
+        self._eval_backend()
+        return None

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -52,6 +52,8 @@ class GenericTrainingConfig:
     global_batch_size: int = 1
     # Per-forward/backward batch size that must fit in memory.
     micro_batch_size: int = 1
+    # Optional trainer-level gradient clipping threshold.
+    max_grad_norm: Optional[float] = None
 
     def __post_init__(self) -> None:
         if self.max_epochs is None and self.max_steps is None:
@@ -93,6 +95,8 @@ class GenericTrainingConfig:
                 "global_batch_size must be divisible by micro_batch_size, "
                 f"got {self.global_batch_size} and {self.micro_batch_size}"
             )
+        if self.max_grad_norm is not None and self.max_grad_norm <= 0:
+            raise ValueError(f"max_grad_norm must be > 0, got {self.max_grad_norm}")
         self._validate_checkpoint_accumulation_alignment()
 
     @property

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -329,17 +329,12 @@ class AbstractTrainer(ABC):
 
                     self.global_step += 1
                     progress_bar.update(1)
+                    should_report = plan.should_report(self.global_step)
 
-                    # whether we should flush
-                    if state.has_enough_batches(
-                        accumulation_steps
-                    ) or plan.should_report(self.global_step):
-                        self.optimizer_step(
-                            state,
-                            record_grad_norm=plan.should_report(self.global_step),
-                        )
+                    if state.has_enough_batches(accumulation_steps):
+                        self.optimizer_step(state)
 
-                    if plan.should_report(self.global_step):
+                    if should_report:
                         eval_state = (
                             self.evaluate(val_data_loader)
                             if val_data_loader is not None
@@ -361,22 +356,14 @@ class AbstractTrainer(ABC):
                     )
 
                 # This is after all the batches in the data loader
-                self.optimizer_step(
-                    state,
-                    record_grad_norm=False,
-                )
+                self.optimizer_step(state)
 
-    def optimizer_step(
-        self, state: TrainingState, *, record_grad_norm: bool = True
-    ) -> None:
+    def optimizer_step(self, state: TrainingState) -> None:
         if state.accumulated_batches == 0:
             return
 
         self.optimizer.scale_gradients(1.0 / state.accumulated_batches)
-
-        if record_grad_norm:
-            self.last_grad_l2_norm = self.optimizer.grad_l2_norm()
-        self.optimizer.step()
+        self.last_grad_l2_norm = self.optimizer.step()
         self.optimizer.zero_grad()
         state.accumulated_batches = 0
 
@@ -407,8 +394,9 @@ class AbstractTrainer(ABC):
             "epoch": completed_epochs,
             "step": float(self.global_step),
             **state.to_metrics_row(eval_state=eval_state),
-            "grad_l2_norm": self.last_grad_l2_norm,
         }
+        if self.last_grad_l2_norm is not None:
+            row["grad_l2_norm"] = self.last_grad_l2_norm
 
         if plan.should_checkpoint(self.global_step):
             self._maybe_save_checkpoint(plan=plan, eval_state=eval_state)

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -3,7 +3,16 @@ import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pprint import pformat
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    cast,
+)
 
 from tqdm import tqdm
 
@@ -332,7 +341,12 @@ class AbstractTrainer(ABC):
                     should_report = plan.should_report(self.global_step)
 
                     if state.has_enough_batches(accumulation_steps):
-                        self.optimizer_step(state)
+                        self.optimizer_step(
+                            state,
+                            # Always clip when configured, but only read back
+                            # the grad norm on steps that will report it.
+                            record_grad_norm=should_report,
+                        )
 
                     if should_report:
                         eval_state = (
@@ -356,14 +370,26 @@ class AbstractTrainer(ABC):
                     )
 
                 # This is after all the batches in the data loader
-                self.optimizer_step(state)
+                self.optimizer_step(state, record_grad_norm=False)
 
-    def optimizer_step(self, state: TrainingState) -> None:
+    def optimizer_step(
+        self,
+        state: TrainingState,
+        *,
+        record_grad_norm: bool = True,
+    ) -> None:
         if state.accumulated_batches == 0:
             return
 
         self.optimizer.scale_gradients(1.0 / state.accumulated_batches)
-        self.last_grad_l2_norm = self.optimizer.step()
+        grad_l2_norm = None
+        if self.config.max_grad_norm is not None:
+            grad_l2_norm = self.optimizer.clip_grad_norm(self.config.max_grad_norm)
+        self.optimizer.step()
+        if record_grad_norm and grad_l2_norm is not None:
+            self.last_grad_l2_norm = float(xp.to_scalar(grad_l2_norm))
+        else:
+            self.last_grad_l2_norm = None
         self.optimizer.zero_grad()
         state.accumulated_batches = 0
 

--- a/examples/cifar.py
+++ b/examples/cifar.py
@@ -277,7 +277,8 @@ if __name__ == "__main__":
         max_epochs=30,
         checkpoint_freq=100,
         model_kwargs={"num_classes": 10},
-        optimizer_kwargs={"lr": 3e-3, "max_grad_norm": 1.0},
+        optimizer_kwargs={"lr": 3e-3},
+        max_grad_norm=1.0,
     )
     train_cifar_multiclass_model(
         train_data_loader,
@@ -295,7 +296,8 @@ if __name__ == "__main__":
         max_epochs=100,
         checkpoint_freq=100,
         model_kwargs={"num_classes": 10},
-        optimizer_kwargs={"lr": 1e-3, "max_grad_norm": 1.0},
+        optimizer_kwargs={"lr": 1e-3},
+        max_grad_norm=1.0,
     )
     train_cifar_multiclass_model(
         train_data_loader,
@@ -313,7 +315,8 @@ if __name__ == "__main__":
         max_epochs=100,
         checkpoint_freq=100,
         model_kwargs={"num_classes": 10},
-        optimizer_kwargs={"lr": 1e-3, "max_grad_norm": 1.0},
+        optimizer_kwargs={"lr": 1e-3},
+        max_grad_norm=1.0,
     )
     train_cifar_multiclass_model(
         train_data_loader,
@@ -356,7 +359,8 @@ if __name__ == "__main__":
         max_epochs=100,
         checkpoint_freq=100,
         model_kwargs={"num_classes": 100},
-        optimizer_kwargs={"lr": 1e-3, "max_grad_norm": 1.0},
+        optimizer_kwargs={"lr": 1e-3},
+        max_grad_norm=1.0,
     )
     train_cifar_multiclass_model(
         train_data_loader,
@@ -374,7 +378,8 @@ if __name__ == "__main__":
         max_epochs=100,
         checkpoint_freq=100,
         model_kwargs={"num_classes": 100},
-        optimizer_kwargs={"lr": 1e-3, "max_grad_norm": 1.0},
+        optimizer_kwargs={"lr": 1e-3},
+        max_grad_norm=1.0,
     )
     train_cifar_multiclass_model(
         train_data_loader,
@@ -392,7 +397,8 @@ if __name__ == "__main__":
         max_epochs=100,
         checkpoint_freq=100,
         model_kwargs={"num_classes": 100},
-        optimizer_kwargs={"lr": 1e-3, "max_grad_norm": 1.0},
+        optimizer_kwargs={"lr": 1e-3},
+        max_grad_norm=1.0,
     )
     train_cifar_multiclass_model(
         train_data_loader,

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -148,6 +148,7 @@ if __name__ == "__main__":
         checkpoint_freq=2,
         global_batch_size=train_global_batch_size,
         micro_batch_size=train_micro_batch_size,
+        max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 6,
             "hidden_size": 144,
@@ -158,7 +159,6 @@ if __name__ == "__main__":
         optimizer_kwargs={
             "lr": 1e-3,
             "beta2": 0.99,
-            "max_grad_norm": 1.0,
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": optim.CosineScheduler,

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -204,6 +204,7 @@ if __name__ == "__main__":
         checkpoint_freq=4,
         global_batch_size=train_global_batch_size,
         micro_batch_size=train_global_batch_size,
+        max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 6,  # GPT-2 small uses 12
             "hidden_size": 768,  # GPT-2 small uses 768, must be divisible by num_attention_heads
@@ -214,7 +215,6 @@ if __name__ == "__main__":
         optimizer_kwargs={
             "lr": 1e-3,
             "beta2": 0.99,
-            "max_grad_norm": 1.0,
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": "CosineScheduler",
@@ -251,6 +251,7 @@ if __name__ == "__main__":
         report_every_steps=200,
         global_batch_size=32,
         micro_batch_size=1,
+        max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 12,  # GPT-2 small uses 12
             "hidden_size": 1536,  # GPT-2 small uses 768, must be divisible by num_attention_heads
@@ -262,7 +263,6 @@ if __name__ == "__main__":
         optimizer_kwargs={
             "lr": 1e-3,
             "beta2": 0.99,
-            "max_grad_norm": 1.0,
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": optim.CosineScheduler,

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -246,11 +246,11 @@ if __name__ == "__main__":
         training_run_name="wiki",
         dataset_name="wiki_simple_english",
         max_steps=200000,
-        max_eval_steps=200,
-        checkpoint_freq=10000,
-        report_every_steps=200,
+        max_eval_steps=20,
+        checkpoint_freq=2000,
+        report_every_steps=100,
         global_batch_size=32,
-        micro_batch_size=1,
+        micro_batch_size=4,
         max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 12,  # GPT-2 small uses 12
@@ -270,7 +270,7 @@ if __name__ == "__main__":
                 "lr_decay_iters": 160000,  # 80% of max_steps
             },
         },
-        resume_epoch=30000,  # Set this to None if you don't want to load from checkpoint
+        resume_epoch=55000,  # Set this to None if you don't want to load from checkpoint
         teacher_forcing=False,
         label_smoothing=0.1,
         eval_start_string="April is",

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -476,9 +476,9 @@ if __name__ == "__main__":
             max_epochs=10,
             checkpoint_freq=10,
             model_kwargs={},
+            max_grad_norm=1.0,
             optimizer_kwargs={
                 "lr": 1e-3,
-                "max_grad_norm": 1.0,
             },
         ),
         msg="ResNet-based",

--- a/examples/movie_sentiment.py
+++ b/examples/movie_sentiment.py
@@ -243,6 +243,7 @@ if __name__ == "__main__":
             "hidden_size": 64,
             "output_size": 1,
         },
-        optimizer_kwargs={"lr": 0.001, "max_grad_norm": 1.0},
+        optimizer_kwargs={"lr": 0.001},
+        max_grad_norm=1.0,
     )
     main(LSTM, train_data_loader, test_data_loader, config_lstm)

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -585,6 +585,7 @@ if __name__ == "__main__":
         checkpoint_freq=500,
         global_batch_size=train_global_batch_size,
         micro_batch_size=train_micro_batch_size,
+        max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 12,
             "hidden_size": 768,
@@ -595,7 +596,6 @@ if __name__ == "__main__":
         optimizer_kwargs={
             "lr": 1e-3,
             "beta2": 0.99,
-            "max_grad_norm": 1.0,
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": optim.CosineScheduler,

--- a/test/autograd/test_backend.py
+++ b/test/autograd/test_backend.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from autograd.backend import (
+    eval_backend,
     get_random_state,
     set_random_state,
     xp,
@@ -72,6 +73,13 @@ def test_scatter_add_accumulates_repeated_indices():
 
     assert np.array_equal(xp.to_numpy(dst), np.array([0.0, 0.0, 0.0], dtype=np.float32))
     assert np.array_equal(xp.to_numpy(out), np.array([0.0, 5.0, 0.0], dtype=np.float32))
+
+
+def test_eval_backend_accepts_nested_arrays_and_tensors():
+    tensor = Tensor(xp.asarray([1.0], dtype=xp.float32))
+    nested = {"tensor": tensor, "array": xp.asarray([2.0], dtype=xp.float32)}
+
+    eval_backend(nested, [xp.asarray([3.0], dtype=xp.float32)], None)
 
 
 def test_as_strided_view_matches_explicit_windows():

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -201,6 +201,17 @@ class TestOptimizer(TestCase):
         assert allclose(custom_final_g1, torch_final_g1, rtol=1e-6, atol=1e-7)
         assert allclose(custom_final_g2, torch_final_g2, rtol=1e-6, atol=1e-7)
 
+    def test_clip_grad_norm_returns_pre_clip_l2_norm(self):
+        g1 = xp.array([3.0, 4.0], dtype=xp.float32)
+        g2 = xp.array([12.0], dtype=xp.float32)
+
+        self.params["param1"].grad = Tensor(g1)
+        self.params["param2"].grad = Tensor(g2)
+
+        grad_norm = self.optimizer._clip_grad_norm(max_norm=1.0, norm_type=2.0)
+
+        self.assertAlmostEqual(grad_norm, 13.0, places=6)
+
     def test_clip_grad_norm_l2_above_threshold(self):
         g1 = xp.array([3.0, 4.0, 5.0], dtype=xp.float32)
         g2 = xp.array([6.0, 7.0, 8.0], dtype=xp.float32)

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -1,6 +1,7 @@
 import math
 from copy import deepcopy
 from unittest import TestCase
+from unittest.mock import patch
 
 import torch  # for test validation
 
@@ -117,10 +118,9 @@ class TestOptimizer(TestCase):
             assert allclose(old_sd["states"]["v"][pid], new_sd["states"]["v"][pid])
         self.assertEqual(old_sd["states"]["timestep"], new_sd["states"]["timestep"])
 
-    def test_timestep_increment(self):
-        initial_ts = self.optimizer.timestep
-        self.optimizer.step()
-        self.assertEqual(self.optimizer.timestep, initial_ts + 1)
+    def test_base_optimizer_step_is_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self.optimizer.step()
 
     def test_scale_gradients_scales_all_parameter_gradients(self):
         self.params["param1"].grad = Tensor(xp.array([1.0, -2.0], dtype=xp.float32))
@@ -192,7 +192,7 @@ class TestOptimizer(TestCase):
         torch_final_g2 = t2.grad.detach().numpy()
 
         # ------ Custom clip ------
-        self.optimizer._clip_grad_norm(max_norm=1.0, norm_type=2.0)
+        self.optimizer.clip_grad_norm(max_norm=1.0, norm_type=2.0)
 
         # Compare final gradients
         custom_final_g1 = self.params["param1"].grad.data
@@ -208,9 +208,27 @@ class TestOptimizer(TestCase):
         self.params["param1"].grad = Tensor(g1)
         self.params["param2"].grad = Tensor(g2)
 
-        grad_norm = self.optimizer._clip_grad_norm(max_norm=1.0, norm_type=2.0)
+        grad_norm = self.optimizer.clip_grad_norm(max_norm=1.0, norm_type=2.0)
 
-        self.assertAlmostEqual(grad_norm, 13.0, places=6)
+        self.assertAlmostEqual(float(xp.to_scalar(grad_norm)), 13.0, places=6)
+
+    def test_clip_grad_norm_returns_lazy_backend_norm(self):
+        g1 = xp.array([3.0, 4.0], dtype=xp.float32)
+        g2 = xp.array([12.0], dtype=xp.float32)
+
+        self.params["param1"].grad = Tensor(g1)
+        self.params["param2"].grad = Tensor(g2)
+
+        with patch.object(
+            xp,
+            "to_scalar",
+            side_effect=AssertionError("clip should return a lazy backend scalar"),
+        ):
+            grad_norm = self.optimizer.clip_grad_norm(max_norm=1.0, norm_type=2.0)
+
+        clipped_norm = self.optimizer.grad_l2_norm()
+        self.assertAlmostEqual(float(xp.to_scalar(grad_norm)), 13.0, places=6)
+        self.assertAlmostEqual(clipped_norm, 1.0, places=5)
 
     def test_clip_grad_norm_l2_above_threshold(self):
         g1 = xp.array([3.0, 4.0, 5.0], dtype=xp.float32)
@@ -230,7 +248,7 @@ class TestOptimizer(TestCase):
         torch_final_g2 = t2.grad.detach().numpy()
 
         # Custom
-        self.optimizer._clip_grad_norm(max_norm=5.0, norm_type=2.0)
+        self.optimizer.clip_grad_norm(max_norm=5.0, norm_type=2.0)
         custom_final_g1 = self.params["param1"].grad.data
         custom_final_g2 = self.params["param2"].grad.data
 
@@ -255,7 +273,7 @@ class TestOptimizer(TestCase):
         torch_final_g2 = t2.grad.detach().numpy()
 
         # Custom
-        self.optimizer._clip_grad_norm(max_norm=20.0, norm_type=1.0)
+        self.optimizer.clip_grad_norm(max_norm=20.0, norm_type=1.0)
         custom_final_g1 = self.params["param1"].grad.data
         custom_final_g2 = self.params["param2"].grad.data
 
@@ -281,7 +299,7 @@ class TestOptimizer(TestCase):
         torch_final_g2 = t2.grad.detach().numpy()
 
         # Custom
-        self.optimizer._clip_grad_norm(max_norm=5.0, norm_type=2.0)
+        self.optimizer.clip_grad_norm(max_norm=5.0, norm_type=2.0)
         custom_final_g1 = self.params["param1"].grad.data
         custom_final_g2 = self.params["param2"].grad.data
 
@@ -305,6 +323,14 @@ class TestSGD(TestCase):
         self.optimizer.zero_grad()
         self.assertEqual(self.param1.grad, None)
         self.assertEqual(self.param2.grad, None)
+
+    def test_step_increments_timestep(self):
+        initial_ts = self.optimizer.timestep
+        self.param1.grad = 0.1
+
+        self.optimizer.step()
+
+        self.assertEqual(self.optimizer.timestep, initial_ts + 1)
 
     def test_step(self):
         self.param1.grad = 0.1
@@ -335,6 +361,21 @@ class TestSGD(TestCase):
 
         assert allclose(self.param1.data, 1.0)
         assert allclose(self.param2.data, 2.0 - (0.2 * 0.01))
+
+    def test_step_evaluates_after_parameter_update(self):
+        self.param1.grad = 0.1
+
+        observed = []
+
+        def record_eval(params, states):
+            observed.append((self.param1.data, states["timestep"]))
+
+        with patch("autograd.optim.eval_backend", side_effect=record_eval):
+            self.optimizer.step()
+
+        self.assertEqual(len(observed), 1)
+        assert allclose(observed[0][0], 1.0 - 0.1 * 0.01)
+        self.assertEqual(observed[0][1], 1)
 
 
 class TestAdam(TestCase):

--- a/test/autograd/tools/test_config_schema.py
+++ b/test/autograd/tools/test_config_schema.py
@@ -4,6 +4,22 @@ from autograd.tools.config_schema import TransformerTrainingConfig
 
 
 class TestTransformerTrainingConfig(TestCase):
+    def test_rejects_non_positive_max_grad_norm(self):
+        with self.assertRaisesRegex(ValueError, "max_grad_norm must be > 0"):
+            TransformerTrainingConfig(
+                training_run_name="test",
+                dataset_name="dataset",
+                max_steps=5,
+                checkpoint_freq=5,
+                global_batch_size=1,
+                micro_batch_size=1,
+                model_kwargs={},
+                optimizer_kwargs={"lr": 1e-3},
+                max_grad_norm=0.0,
+                label_smoothing=0.0,
+                teacher_forcing=False,
+            )
+
     def test_rejects_checkpoint_before_gradient_accumulation_boundary(self):
         with self.assertRaisesRegex(
             ValueError,

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -1043,6 +1043,30 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         self.assertEqual(trainer.optimizer.step_call_count, 2)
 
+    def test_fit_reporting_does_not_force_partial_optimizer_steps(self):
+        config = GenericTrainingConfig(
+            max_steps=40,
+            checkpoint_freq=40,
+            report_every_steps=10,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=4,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+        train_loader = make_data_loader(self.train_data * 20)
+
+        trainer.fit(train_loader)
+
+        self.assertEqual(trainer.global_step, 40)
+        self.assertEqual(trainer.optimizer.step_call_count, 10)
+
     def test_fit_flushes_leftover_gradients_at_epoch_end(self):
         config = GenericTrainingConfig(
             max_epochs=1,
@@ -1069,13 +1093,13 @@ class TestSimpleTrainer(BaseTrainerTest):
         state = TrainingState()
         self.trainer.last_grad_l2_norm = 7.0
 
-        self.trainer.optimizer_step(state, record_grad_norm=False)
+        self.trainer.optimizer_step(state)
 
         self.assertEqual(self.trainer.optimizer.step_call_count, 0)
         self.assertEqual(self.trainer.last_grad_l2_norm, 7.0)
         self.assertEqual(state.accumulated_batches, 0)
 
-    def test_fit_records_grad_norm_only_on_report_steps(self):
+    def test_fit_does_not_report_grad_norm_without_clipping(self):
         config = GenericTrainingConfig(
             max_steps=4,
             checkpoint_freq=4,
@@ -1094,12 +1118,13 @@ class TestSimpleTrainer(BaseTrainerTest):
         train_loader = make_data_loader(self.train_data * 2)
 
         with patch.object(
-            trainer.optimizer, "grad_l2_norm", return_value=7.0
-        ) as mock_grad_l2_norm:
+            trainer.optimizer,
+            "grad_l2_norm",
+            side_effect=AssertionError("trainer should not call grad_l2_norm"),
+        ):
             trainer.fit(train_loader)
 
-        self.assertEqual(mock_grad_l2_norm.call_count, 1)
-        self.assertEqual(trainer.metric_rows[0]["grad_l2_norm"], 7.0)
+        self.assertNotIn("grad_l2_norm", trainer.metric_rows[0])
 
     def _fit_scalar_weight_model(
         self, train_data, *, global_batch_size, micro_batch_size
@@ -1184,6 +1209,49 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         trainer.fit(train_loader)
 
+        self.assertAlmostEqual(trainer.metric_rows[0]["grad_l2_norm"], 20.0, places=5)
+
+    def test_clip_enabled_uses_clip_grad_norm_for_reporting(self):
+        config = GenericTrainingConfig(
+            max_epochs=1,
+            checkpoint_freq=1,
+            model_kwargs={"initial_weight": 0.0},
+            optimizer_kwargs={"lr": 0.0, "max_grad_norm": 1.0},
+            global_batch_size=1,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=ScalarWeightModel,
+            optimizer_cls=SGD,
+            loss_fn=lambda pred, target: (
+                (pred - Tensor(target, requires_grad=False)) ** 2
+            ).mean(),
+            config=config,
+        )
+        train_loader = make_data_loader(
+            [
+                (
+                    xp.array([[1.0]], dtype=xp.float32),
+                    xp.array([[10.0]], dtype=xp.float32),
+                )
+            ]
+        )
+
+        with (
+            patch.object(
+                trainer.optimizer,
+                "grad_l2_norm",
+                side_effect=AssertionError("trainer should not call grad_l2_norm"),
+            ),
+            patch.object(
+                trainer.optimizer,
+                "_clip_grad_norm",
+                wraps=trainer.optimizer._clip_grad_norm,
+            ) as mock_clip_grad_norm,
+        ):
+            trainer.fit(train_loader)
+
+        self.assertEqual(mock_clip_grad_norm.call_count, 1)
         self.assertAlmostEqual(trainer.metric_rows[0]["grad_l2_norm"], 20.0, places=5)
 
     def test_leftover_accumulation_matches_single_batch_update(self):

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -1186,7 +1186,8 @@ class TestSimpleTrainer(BaseTrainerTest):
             max_epochs=1,
             checkpoint_freq=1,
             model_kwargs={"initial_weight": 0.0},
-            optimizer_kwargs={"lr": 0.0, "max_grad_norm": 1.0},
+            optimizer_kwargs={"lr": 0.0},
+            max_grad_norm=1.0,
             global_batch_size=1,
             micro_batch_size=1,
         )
@@ -1216,7 +1217,8 @@ class TestSimpleTrainer(BaseTrainerTest):
             max_epochs=1,
             checkpoint_freq=1,
             model_kwargs={"initial_weight": 0.0},
-            optimizer_kwargs={"lr": 0.0, "max_grad_norm": 1.0},
+            optimizer_kwargs={"lr": 0.0},
+            max_grad_norm=1.0,
             global_batch_size=1,
             micro_batch_size=1,
         )
@@ -1245,8 +1247,8 @@ class TestSimpleTrainer(BaseTrainerTest):
             ),
             patch.object(
                 trainer.optimizer,
-                "_clip_grad_norm",
-                wraps=trainer.optimizer._clip_grad_norm,
+                "clip_grad_norm",
+                wraps=trainer.optimizer.clip_grad_norm,
             ) as mock_clip_grad_norm,
         ):
             trainer.fit(train_loader)


### PR DESCRIPTION
## Description
- Add explicit `eval()` for the option to force MLX's lazy parameter/state updates at optimizer-step boundaries. Previously, we were accumulating lazy ops across multiple steps, and this could potentially result in bursty / unexpected sync between GPU and CPU.
- Defer `clip_grad_norm` to work on GPU until absolutely necessary reporting/logging steps then move the grad norm back to CPU
- Decouple reporting from optimizer stepping. They can run separately. Previously, they were dependent.
- Move `max_grad_norm` from optimizer config to just general training config. This behavior is similar to PyTorch.

## Tests

| Change | Observed gain |
|---|---|
| Decouple reporting from optimizer stepping. | Better maintainability and determinism |
| Keep clipping behavior with max_grad_norm=1.0. The branch still clips gradients, but avoids scalar logging/sync cost when the value is not reported. | Correctness-preserving perf change |


For explicit `eval()` for materializing at predictable `Optimizer.step()`:

| Case | Explicit eval | Steps/s | Delta vs disabled | Note |
|---|---|---|---|---|
| report_every_steps=1 | enabled | 21.63 | -2.34% | Slightly slower when every step already reports/syncs. |
| report_every_steps=1 | disabled | 22.15 | baseline | No delayed sync buildup. |
| report_every_steps=100 | enabled | 21.31 | +12.1% | Clear win; lazy work is forced at optimizer-step boundaries. |
| report_every_steps=100 | disabled | 18.73 | baseline | Optimizer step looks cheap, but deferred work hits later. |