### PR TITLE
Add mixed precision training support

### DIFF
--- a/autograd/backend.py
+++ b/autograd/backend.py
@@ -66,6 +66,14 @@ if IS_CUPY and xp.cuda.runtime.getDeviceCount() <= 0:
     )
 
 ARRAY_TYPE = type(xp.array(0, dtype=xp.float32)) if IS_MLX else xp.ndarray
+LOW_PRECISION_FLOAT_DTYPES = tuple(
+    dtype
+    for dtype in (
+        getattr(xp, "float16", None),
+        getattr(xp, "bfloat16", None),
+    )
+    if dtype is not None
+)
 
 
 # ---------------------------------------------------------------------------

--- a/autograd/functional.py
+++ b/autograd/functional.py
@@ -1063,6 +1063,8 @@ class CrossEntropy(Function):
         """
 
         y_true = xp.array(y_true, dtype=xp.int64)
+        if y_pred.dtype in (xp.float16, xp.bfloat16):
+            y_pred = y_pred.astype(xp.float32)
 
         # 1. If 3D logits, flatten them for simpler processing while preserving
         # the original shape for the backward pass.

--- a/autograd/functional.py
+++ b/autograd/functional.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 from typing import Any, Optional, Tuple, Union
 
 from autograd.backend import (
+    LOW_PRECISION_FLOAT_DTYPES,
     Array,
     ArrayLike,
     xp,
@@ -1063,7 +1064,7 @@ class CrossEntropy(Function):
         """
 
         y_true = xp.array(y_true, dtype=xp.int64)
-        if y_pred.dtype in (xp.float16, xp.bfloat16):
+        if y_pred.dtype in LOW_PRECISION_FLOAT_DTYPES:
             y_pred = y_pred.astype(xp.float32)
 
         # 1. If 3D logits, flatten them for simpler processing while preserving

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -1251,14 +1251,20 @@ class LayerNorm(Module):
             >>> x = Tensor(xp.random.randn(2, 10))
             >>> y = ln(x)  # Expected: (2, 10)
         """
+
+        # For mixed precision, keep LayerNorm statistics in fp32 for stability.
+        input_dtype = x.data.dtype
+        low_precision_input = input_dtype in (xp.float16, xp.bfloat16)
+        stats_x = x.astype(xp.float32) if low_precision_input else x
+
         # Equation 4 in section 3.1 in the paper
-        mean = x.mean(
+        mean = stats_x.mean(
             axis=-1, keepdims=True
         )  # (batch_size, seq_len, 1), across "input_size" dimension
-        var = ((x - mean) ** 2).mean(
+        var = ((stats_x - mean) ** 2).mean(
             axis=-1, keepdims=True
         )  # (batch_size, seq_len, 1), across "input_size" dimension
-        x_norm = (x - mean) / (
+        x_norm = (stats_x - mean) / (
             var + self.epsilon
         ).sqrt()  # (batch_size, seq_len, input_size)
 
@@ -1266,6 +1272,10 @@ class LayerNorm(Module):
         output = x_norm * self._parameters["gain"].expand(
             x_norm.shape
         ) + self._parameters["bias"].expand(x_norm.shape)
+
+        # For mixed precision, return to the activation dtype so the following dense ops stay low precision.
+        if low_precision_input:
+            output = output.astype(input_dtype)
         return output
 
 

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -12,7 +12,7 @@ from typing import (
     cast,
 )
 
-from autograd.backend import ARRAY_TYPE, NAME, ArrayLike, xp
+from autograd.backend import ARRAY_TYPE, LOW_PRECISION_FLOAT_DTYPES, NAME, ArrayLike, xp
 
 from .functional import (
     relu,
@@ -1254,7 +1254,7 @@ class LayerNorm(Module):
 
         # For mixed precision, keep LayerNorm statistics in fp32 for stability.
         input_dtype = x.data.dtype
-        low_precision_input = input_dtype in (xp.float16, xp.bfloat16)
+        low_precision_input = input_dtype in LOW_PRECISION_FLOAT_DTYPES
         stats_x = x.astype(xp.float32) if low_precision_input else x
 
         # Equation 4 in section 3.1 in the paper

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from typing import Any, Callable, Dict, Optional
 
-from autograd.backend import eval_backend, xp
+from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, eval_backend, xp
 from autograd.tensor import Tensor
 
 logger = logging.getLogger(__name__)
@@ -490,7 +490,7 @@ class Adam(Optimizer):
 
             # For mixed precision, keep Adam statistics in fp32 for stability.
             param_dtype = param.data.dtype
-            if grad.dtype in (xp.float16, xp.bfloat16):
+            if grad.dtype in LOW_PRECISION_FLOAT_DTYPES:
                 grad = grad.astype(xp.float32)
             new_m = beta1 * m_old + (1 - beta1) * grad  # update first order momentum
             new_v = beta2 * v_old + (1 - beta2) * (
@@ -511,7 +511,7 @@ class Adam(Optimizer):
             param.data -= self.lr * m_hat / (xp.sqrt(v_hat) + epsilon)
 
             # For mixed precision, return to the param_dtype so the following dense ops stay low precision.
-            if param_dtype in (xp.float16, xp.bfloat16):
+            if param_dtype in LOW_PRECISION_FLOAT_DTYPES:
                 param.data = param.data.astype(param_dtype)
         self._eval_backend()
         return None

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -487,6 +487,11 @@ class Adam(Optimizer):
             v_old = self._states["v"][name]
 
             grad = param.grad.data  # or param.grad if it's np array
+
+            # For mixed precision, keep Adam statistics in fp32 for stability.
+            param_dtype = param.data.dtype
+            if grad.dtype in (xp.float16, xp.bfloat16):
+                grad = grad.astype(xp.float32)
             new_m = beta1 * m_old + (1 - beta1) * grad  # update first order momentum
             new_v = beta2 * v_old + (1 - beta2) * (
                 grad**2
@@ -504,5 +509,9 @@ class Adam(Optimizer):
             if weight_decay > 0.0:
                 param.data = param.data - self.lr * weight_decay * param.data
             param.data -= self.lr * m_hat / (xp.sqrt(v_hat) + epsilon)
+
+            # For mixed precision, return to the param_dtype so the following dense ops stay low precision.
+            if param_dtype in (xp.float16, xp.bfloat16):
+                param.data = param.data.astype(param_dtype)
         self._eval_backend()
         return None

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -506,6 +506,9 @@ class Tensor:
 
         return SetItem.apply(self, value, idx=idx)
 
+    def astype(self, dtype: Any) -> "Tensor":
+        return Cast.apply(self, dtype=dtype)
+
     def sum(
         self, axis: Optional[Union[int, Tuple[int, ...]]] = None, keepdims: bool = False
     ) -> "Tensor":
@@ -1667,6 +1670,15 @@ class SetItem(Function):
             >>> # During backprop, only index 1 will contribute to the gradient.
         """
         return grad.data[self.idx]
+
+
+class Cast(Function):
+    def forward(self, x: Array, dtype: Any) -> Array:
+        self.input_dtype = x.dtype
+        return x.astype(dtype)
+
+    def backward(self, grad: "Tensor") -> Array:
+        return grad.data.astype(self.input_dtype)
 
 
 class Sqrt(Function):

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -53,9 +53,12 @@ class GPT2(nn.Module):
         dropout_prob: float = 0.1,
         num_decoder_layers: int = 12,  # GPT-2 small has 12 layers
         activation_checkpointing: bool = False,
+        parameter_dtype=None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        if isinstance(parameter_dtype, str):
+            parameter_dtype = getattr(xp, parameter_dtype)
         self.hidden_size = hidden_size
         self.max_seq_len = max_seq_len
         self.activation_checkpointing = activation_checkpointing
@@ -85,6 +88,9 @@ class GPT2(nn.Module):
         self.apply(
             lambda m: self._scale_weights(m, num_decoder_layers * 2)
         )  # there are 2 residual layers in each decoder sublayer
+        if parameter_dtype is not None:
+            for parameter in self.parameters.values():
+                parameter.data = parameter.data.astype(parameter_dtype)
 
     def forward(self, tokens: Tensor) -> Tensor:
         """
@@ -171,14 +177,24 @@ class DecoderSublayer(nn.Module):
         )
 
     def forward(self, x: Tensor) -> Tensor:
+        input_dtype = x.data.dtype
+        low_precision_input = input_dtype in (xp.float16, xp.bfloat16)
+
         # Pre-norm before attention
         a = self.layer_norm1(x)
 
         x = x + self.multi_head_attention(a, a, a, is_causal=True)
+        if low_precision_input:
+            # Dense attention can promote through its fp32 mask path; cast the residual
+            # stream back so later matmuls keep the intended low-precision activations.
+            x = x.astype(input_dtype)
 
         # Pre-norm before feed-forward
         b = self.layer_norm2(x)
         x = x + self.feedforward(b)
+        if low_precision_input:
+            # Linear bias/addition can also promote; preserve the block's input dtype.
+            x = x.astype(input_dtype)
         return x
 
 
@@ -259,6 +275,7 @@ if __name__ == "__main__":
             "max_seq_len": 1024,  # GPT-2 uses 1024
             "num_decoder_layers": 12,  # GPT-2 uses 12
             "activation_checkpointing": True,
+            "parameter_dtype": "bfloat16",
         },
         optimizer_kwargs={
             "lr": 1e-3,

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -9,7 +9,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from autograd import functional, nn, optim
-from autograd.backend import Array, xp
+from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, xp
 from autograd.data.collator import CausalLMWindowCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import TokenWindowDataset
@@ -178,7 +178,7 @@ class DecoderSublayer(nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         input_dtype = x.data.dtype
-        low_precision_input = input_dtype in (xp.float16, xp.bfloat16)
+        low_precision_input = input_dtype in LOW_PRECISION_FLOAT_DTYPES
 
         # Pre-norm before attention
         a = self.layer_norm1(x)


### PR DESCRIPTION
## Description
This is a very rough attempt in mixed precision training.

Essentially, in the GPT-2 example change in this PR, we are defining these dtypes:
- model params: bfloat16 (this is hard-coded for certain bf16-compatible backends for now)
- optimizer states:  float32 (Adam casts bf16 grads to fp32 before updating momentum estimates)
- gradient accumulation: float32
- LayerNorm stats: float32
- Cross entropy logits: float32  
- activations:  bfloat16 (after going through LayerNorm/attention/feedforward)


## Tests

| Metric | `main` branch fp32 | Mixed bf16 | Delta |
|---|---|---|---|
| steps/s | 3.764 | 3.706 | -1.54% |
| tokens/s | 7708 | 7591 | -1.52% |
| active memory | 596.69 MiB | 497.25 MiB | -16.67% |
| peak memory | 7.07 GiB | 6.99 GiB | -1.13% |