### PR TITLE
Data loader refactor

### DIFF
--- a/autograd/data/collator.py
+++ b/autograd/data/collator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Optional, Sequence, Tuple
+from typing import Any, Callable, Sequence, Tuple
 
 from autograd.backend import Array, xp
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch, TokenWindowExample
@@ -8,6 +8,11 @@ from autograd.text import utils as text_utils
 
 
 def pack_tokens(tokens: Array, max_tokens: int, pad_idx: int) -> Array:
+    # This is fixed-window truncation/padding, not true multi-example packing.
+    # Left truncation assumes the tail of each SFT record is most valuable, which
+    # usually keeps the final assistant answer but can drop earlier conversation
+    # turns, the latest user prompt, or the start of an overlong assistant answer.
+    # Use a conversation-aware packer when those boundaries matter.
     if len(tokens) > max_tokens:
         tokens = tokens[-max_tokens:]
     if len(tokens) < max_tokens:
@@ -17,6 +22,157 @@ def pack_tokens(tokens: Array, max_tokens: int, pad_idx: int) -> Array:
             axis=0,
         )
     return tokens
+
+
+def truncate_aligned_left(
+    values: Sequence[Array],
+    max_tokens: int,
+) -> Tuple[Array, ...]:
+    """
+    Keep the last `max_tokens` from each aligned 1D value.
+
+    Shapes:
+    - input: each value is `(T,)`
+    - output: each value is `(min(T, max_tokens),)`
+
+    Example:
+        values=([10, 11, 12, 13], [0, 0, 1, 1]), max_tokens=3
+        -> [11, 12, 13], [0, 1, 1]
+
+    Tradeoff: this is simple and usually preserves the answer tail, but it can
+    cut through conversation boundaries and remove the latest user prompt.
+    This operation preserves alignment only; it does not know what any field
+    means.
+
+    Caller contract: `values` is a non-empty sequence of same-length 1D arrays.
+    """
+    if max_tokens < 1:
+        raise ValueError("max_tokens must be >= 1")
+    first_len = len(values[0])
+    if first_len <= max_tokens:
+        return tuple(values)
+    return tuple(value[-max_tokens:] for value in values)
+
+
+def pad_aligned_right(
+    values: Sequence[Array],
+    max_tokens: int,
+    pad_values: Sequence[int],
+) -> Tuple[Array, ...]:
+    """
+    Right-pad aligned 1D values to a fixed length.
+
+    Example:
+        values=([10, 11], [0, 1]), pad_values=(257, 0), max_tokens=4
+        -> [10, 11, 257, 257], [0, 1, 0, 0]
+
+    Tradeoff: fixed shapes are backend-friendly and easy to reason about, but
+    dynamic batch padding can avoid wasted compute when packed lengths vary.
+    Pad semantics live at the call site through `pad_values`.
+
+    Caller contract: `values` and `pad_values` have the same length, `values`
+    are same-length 1D arrays, and each value is no longer than `max_tokens`.
+    """
+    first_len = len(values[0])
+    if first_len == max_tokens:
+        return tuple(values)
+
+    pad_width = max_tokens - first_len
+    padded_values = []
+    for value, pad_value in zip(values, pad_values):
+        value_array = xp.array(value)
+        padded_values.append(
+            xp.concatenate(
+                [
+                    value_array,
+                    xp.full((pad_width,), pad_value, dtype=value_array.dtype),
+                ],
+                axis=0,
+            )
+        )
+    return tuple(padded_values)
+
+
+def greedy_pack_aligned_examples(
+    examples: Sequence[dict[str, Array]],
+    fields: Sequence[str],
+    max_tokens: int,
+) -> list[dict[str, Array]]:
+    """
+    Greedily pack examples while preserving alignment across selected fields.
+
+    Example lengths with max_tokens=8:
+        [3, 4, 5] -> packs [3+4], [5]
+
+    This operation preserves token/mask alignment and should run before
+    collation because packing changes the dataset examples themselves.
+
+    Tradeoff: for causal LM rows, tokens can attend across earlier packed
+    examples after an EOS delimiter. This is efficient and simple, but not
+    block-diagonal conversation isolation.
+
+    Caller contract: `fields` is non-empty, selected fields are aligned, and
+    overlong examples have already been truncated.
+    """
+    if max_tokens < 1:
+        raise ValueError("max_tokens must be >= 1")
+
+    packed_examples: list[dict[str, Array]] = []
+    current_values = {field: [] for field in fields}
+    current_len = 0
+
+    def flush_current() -> None:
+        nonlocal current_values, current_len
+        if not current_values[fields[0]]:
+            return
+        packed_examples.append(
+            {field: xp.concatenate(current_values[field], axis=0) for field in fields}
+        )
+        current_values = {field: [] for field in fields}
+        current_len = 0
+
+    for example in examples:
+        values = {field: xp.array(example[field], dtype=xp.int32) for field in fields}
+        example_len = len(values[fields[0]])
+        if example_len > max_tokens:
+            raise ValueError(
+                "example is longer than max_tokens; truncate before packing"
+            )
+
+        if current_len and current_len + example_len > max_tokens:
+            flush_current()
+
+        for field in fields:
+            current_values[field].append(values[field])
+        current_len += example_len
+
+    flush_current()
+    return packed_examples
+
+
+def build_causal_lm_inputs_and_labels(
+    tokens: Array,
+    loss_mask: Array,
+) -> Tuple[Array, Array]:
+    """
+    Shift one token/mask row into causal-LM inputs and labels.
+
+    Example:
+        tokens    = [10, 20, 30]
+        loss_mask = [ 0,  1,  1]
+        input_ids = [10, 20]
+        labels    = [20, 30]
+
+    Any shifted label whose source token has `loss_mask == 0` becomes
+    `IGNORE_INDEX`, so prompt, role-marker, and pad tokens do not train loss.
+
+    Caller contract: `tokens` and `loss_mask` are aligned and contain at least
+    two tokens after padding.
+    """
+    input_ids = tokens[:-1]
+    labels = xp.array(tokens[1:], dtype=xp.int32)
+    labels[xp.array(loss_mask[1:], dtype=xp.float32) == 0] = IGNORE_INDEX
+    return input_ids, labels
 
 
 class Collator(ABC):
@@ -116,38 +272,37 @@ class CausalLMCollator(Collator):
         self,
         max_tokens: int,
         pad_idx: int,
-        packer: Optional[Callable[[Array, int, int], Array]] = None,
+        *,
+        truncator: Callable[[Sequence[Array], int], Tuple[Array, ...]],
+        padder: Callable[[Sequence[Array], int, Sequence[int]], Tuple[Array, ...]],
+        label_builder: Callable[[Array, Array], Tuple[Array, Array]],
     ) -> None:
         if max_tokens < 2:
             raise ValueError("max_tokens must be >= 2 for causal LM")
         self.max_tokens = max_tokens
         self.pad_idx = pad_idx
-        self.packer = packer or pack_tokens
+        self.truncator = truncator
+        self.padder = padder
+        self.label_builder = label_builder
 
     def __call__(self, examples: Sequence[dict[str, Array]]) -> CausalLMBatch:
-        if not examples:
-            raise ValueError("examples must not be empty")
         batch_inputs = []
         batch_labels = []
 
         for example in examples:
             tokens = xp.array(example["tokens"], dtype=xp.int32)
-            loss_mask = xp.array(
-                example.get(
-                    "loss_mask",
-                    xp.ones(tokens.shape, dtype=xp.int32),
-                ),
-                dtype=xp.int32,
+            loss_mask = xp.array(example["loss_mask"], dtype=xp.int32)
+
+            truncated_tokens, truncated_loss_mask = self.truncator(
+                (tokens, loss_mask),
+                self.max_tokens,
             )
-            if len(tokens) != len(loss_mask):
-                raise ValueError("tokens and loss_mask must have the same length")
-
-            packed_tokens = self.packer(tokens, self.max_tokens, self.pad_idx)
-            packed_loss_mask = self.packer(loss_mask, self.max_tokens, 0)
-
-            input_tokens = packed_tokens[:-1]
-            labels = xp.array(packed_tokens[1:], dtype=xp.int32)
-            labels[xp.array(packed_loss_mask[1:], dtype=xp.float32) == 0] = IGNORE_INDEX
+            padded_tokens, padded_loss_mask = self.padder(
+                (truncated_tokens, truncated_loss_mask),
+                self.max_tokens,
+                (self.pad_idx, 0),
+            )
+            input_tokens, labels = self.label_builder(padded_tokens, padded_loss_mask)
 
             batch_inputs.append(input_tokens)
             batch_labels.append(labels)
@@ -168,12 +323,13 @@ class Seq2SeqCollator(Collator):
         max_tokens: int,
         pad_idx: int,
         sos_idx: int,
-        packer: Optional[Callable[[Array, int, int], Array]] = None,
+        *,
+        packer: Callable[[Array, int, int], Array],
     ) -> None:
         self.max_tokens = max_tokens
         self.pad_idx = pad_idx
         self.sos_idx = sos_idx
-        self.packer = packer or pack_tokens
+        self.packer = packer
 
     def __call__(self, examples: Sequence[dict[str, Array]]) -> Seq2SeqBatch:
         batch_inputs = []

--- a/autograd/data/collator.py
+++ b/autograd/data/collator.py
@@ -1,18 +1,37 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Sequence, Tuple
+from typing import Any, Sequence, Tuple
 
 from autograd.backend import Array, xp
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch, TokenWindowExample
 from autograd.functional import IGNORE_INDEX
-from autograd.text import utils as text_utils
 
 
-def pack_tokens(tokens: Array, max_tokens: int, pad_idx: int) -> Array:
-    # This is fixed-window truncation/padding, not true multi-example packing.
-    # Left truncation assumes the tail of each SFT record is most valuable, which
-    # usually keeps the final assistant answer but can drop earlier conversation
-    # turns, the latest user prompt, or the start of an overlong assistant answer.
-    # Use a conversation-aware packer when those boundaries matter.
+def create_padding_mask(
+    token_indices: Array,
+    pad_idx: int = 0,
+    dims: tuple[int, ...] | None = None,
+) -> Array:
+    """
+    Create a float padding mask where pad-token positions are `1.0`.
+
+    With `dims=None`, a `(batch_size, seq_len)` token matrix becomes the
+    standard attention-mask shape `(batch_size, 1, 1, seq_len)`. Pass `dims`
+    when a collator is formatting one sequence at a time and needs an explicit
+    broadcast shape.
+    """
+    token_indices = xp.array(token_indices)
+    pad_positions = (token_indices == pad_idx).astype(xp.float32)
+
+    if dims is None:
+        # Default shape for attention over batched token IDs.
+        return xp.expand_dims(xp.expand_dims(pad_positions, axis=1), axis=1)
+    return pad_positions.reshape(dims)
+
+
+def truncate_and_pad_tokens(tokens: Array, max_tokens: int, pad_idx: int) -> Array:
+    # Fixed-window truncation/padding for one token sequence.
+    # Left truncation assumes the tail is most valuable. Use a boundary-aware
+    # formatter when conversation or source/target boundaries matter.
     if len(tokens) > max_tokens:
         tokens = tokens[-max_tokens:]
     if len(tokens) < max_tokens:
@@ -22,157 +41,6 @@ def pack_tokens(tokens: Array, max_tokens: int, pad_idx: int) -> Array:
             axis=0,
         )
     return tokens
-
-
-def truncate_aligned_left(
-    values: Sequence[Array],
-    max_tokens: int,
-) -> Tuple[Array, ...]:
-    """
-    Keep the last `max_tokens` from each aligned 1D value.
-
-    Shapes:
-    - input: each value is `(T,)`
-    - output: each value is `(min(T, max_tokens),)`
-
-    Example:
-        values=([10, 11, 12, 13], [0, 0, 1, 1]), max_tokens=3
-        -> [11, 12, 13], [0, 1, 1]
-
-    Tradeoff: this is simple and usually preserves the answer tail, but it can
-    cut through conversation boundaries and remove the latest user prompt.
-    This operation preserves alignment only; it does not know what any field
-    means.
-
-    Caller contract: `values` is a non-empty sequence of same-length 1D arrays.
-    """
-    if max_tokens < 1:
-        raise ValueError("max_tokens must be >= 1")
-    first_len = len(values[0])
-    if first_len <= max_tokens:
-        return tuple(values)
-    return tuple(value[-max_tokens:] for value in values)
-
-
-def pad_aligned_right(
-    values: Sequence[Array],
-    max_tokens: int,
-    pad_values: Sequence[int],
-) -> Tuple[Array, ...]:
-    """
-    Right-pad aligned 1D values to a fixed length.
-
-    Example:
-        values=([10, 11], [0, 1]), pad_values=(257, 0), max_tokens=4
-        -> [10, 11, 257, 257], [0, 1, 0, 0]
-
-    Tradeoff: fixed shapes are backend-friendly and easy to reason about, but
-    dynamic batch padding can avoid wasted compute when packed lengths vary.
-    Pad semantics live at the call site through `pad_values`.
-
-    Caller contract: `values` and `pad_values` have the same length, `values`
-    are same-length 1D arrays, and each value is no longer than `max_tokens`.
-    """
-    first_len = len(values[0])
-    if first_len == max_tokens:
-        return tuple(values)
-
-    pad_width = max_tokens - first_len
-    padded_values = []
-    for value, pad_value in zip(values, pad_values):
-        value_array = xp.array(value)
-        padded_values.append(
-            xp.concatenate(
-                [
-                    value_array,
-                    xp.full((pad_width,), pad_value, dtype=value_array.dtype),
-                ],
-                axis=0,
-            )
-        )
-    return tuple(padded_values)
-
-
-def greedy_pack_aligned_examples(
-    examples: Sequence[dict[str, Array]],
-    fields: Sequence[str],
-    max_tokens: int,
-) -> list[dict[str, Array]]:
-    """
-    Greedily pack examples while preserving alignment across selected fields.
-
-    Example lengths with max_tokens=8:
-        [3, 4, 5] -> packs [3+4], [5]
-
-    This operation preserves token/mask alignment and should run before
-    collation because packing changes the dataset examples themselves.
-
-    Tradeoff: for causal LM rows, tokens can attend across earlier packed
-    examples after an EOS delimiter. This is efficient and simple, but not
-    block-diagonal conversation isolation.
-
-    Caller contract: `fields` is non-empty, selected fields are aligned, and
-    overlong examples have already been truncated.
-    """
-    if max_tokens < 1:
-        raise ValueError("max_tokens must be >= 1")
-
-    packed_examples: list[dict[str, Array]] = []
-    current_values = {field: [] for field in fields}
-    current_len = 0
-
-    def flush_current() -> None:
-        nonlocal current_values, current_len
-        if not current_values[fields[0]]:
-            return
-        packed_examples.append(
-            {field: xp.concatenate(current_values[field], axis=0) for field in fields}
-        )
-        current_values = {field: [] for field in fields}
-        current_len = 0
-
-    for example in examples:
-        values = {field: xp.array(example[field], dtype=xp.int32) for field in fields}
-        example_len = len(values[fields[0]])
-        if example_len > max_tokens:
-            raise ValueError(
-                "example is longer than max_tokens; truncate before packing"
-            )
-
-        if current_len and current_len + example_len > max_tokens:
-            flush_current()
-
-        for field in fields:
-            current_values[field].append(values[field])
-        current_len += example_len
-
-    flush_current()
-    return packed_examples
-
-
-def build_causal_lm_inputs_and_labels(
-    tokens: Array,
-    loss_mask: Array,
-) -> Tuple[Array, Array]:
-    """
-    Shift one token/mask row into causal-LM inputs and labels.
-
-    Example:
-        tokens    = [10, 20, 30]
-        loss_mask = [ 0,  1,  1]
-        input_ids = [10, 20]
-        labels    = [20, 30]
-
-    Any shifted label whose source token has `loss_mask == 0` becomes
-    `IGNORE_INDEX`, so prompt, role-marker, and pad tokens do not train loss.
-
-    Caller contract: `tokens` and `loss_mask` are aligned and contain at least
-    two tokens after padding.
-    """
-    input_ids = tokens[:-1]
-    labels = xp.array(tokens[1:], dtype=xp.int32)
-    labels[xp.array(loss_mask[1:], dtype=xp.float32) == 0] = IGNORE_INDEX
-    return input_ids, labels
 
 
 class Collator(ABC):
@@ -187,7 +55,7 @@ class Collator(ABC):
 
 class PairedCollator(Collator):
     """
-    Batches paired examples from `PairedIterableDataset`.
+    Batches paired examples from `PairedMapDataset`.
 
     Examples:
         >>> collator = PairedCollator()
@@ -267,42 +135,95 @@ class CausalLMWindowCollator(Collator):
         )
 
 
-class CausalLMCollator(Collator):
+class _CausalLMBaseCollator(Collator):
+    """
+    Shared mechanics for causal LM collators.
+
+    Each example contains aligned `tokens` and `loss_mask` arrays. The shared
+    flow is: left-truncate both arrays together, right-pad them together, shift
+    tokens into `(input_ids, labels)`, and stack the final batch.
+    """
+
     def __init__(
         self,
         max_tokens: int,
-        pad_idx: int,
         *,
-        truncator: Callable[[Sequence[Array], int], Tuple[Array, ...]],
-        padder: Callable[[Sequence[Array], int, Sequence[int]], Tuple[Array, ...]],
-        label_builder: Callable[[Array, Array], Tuple[Array, Array]],
+        pad_idx: int,
     ) -> None:
         if max_tokens < 2:
             raise ValueError("max_tokens must be >= 2 for causal LM")
         self.max_tokens = max_tokens
         self.pad_idx = pad_idx
-        self.truncator = truncator
-        self.padder = padder
-        self.label_builder = label_builder
 
-    def __call__(self, examples: Sequence[dict[str, Array]]) -> CausalLMBatch:
-        batch_inputs = []
-        batch_labels = []
+    def _truncate_examples(
+        self,
+        examples: Sequence[dict[str, Array]],
+    ) -> list[Tuple[Array, Array]]:
+        truncated_examples = []
 
         for example in examples:
             tokens = xp.array(example["tokens"], dtype=xp.int32)
             loss_mask = xp.array(example["loss_mask"], dtype=xp.int32)
+            if len(tokens) != len(loss_mask):
+                raise ValueError("tokens and loss_mask must have the same length")
 
-            truncated_tokens, truncated_loss_mask = self.truncator(
-                (tokens, loss_mask),
-                self.max_tokens,
+            if len(tokens) > self.max_tokens:
+                tokens = tokens[-self.max_tokens :]
+                loss_mask = loss_mask[-self.max_tokens :]
+
+            truncated_tokens, truncated_loss_mask = tokens, loss_mask
+            truncated_examples.append((truncated_tokens, truncated_loss_mask))
+
+        return truncated_examples
+
+    def _pad_right(
+        self,
+        tokens: Array,
+        loss_mask: Array,
+        target_length: int,
+    ) -> Tuple[Array, Array]:
+        if len(tokens) == target_length:
+            return tokens, loss_mask
+
+        pad_width = target_length - len(tokens)
+        padded_tokens = xp.concatenate(
+            [
+                tokens,
+                xp.full((pad_width,), self.pad_idx, dtype=tokens.dtype),
+            ],
+            axis=0,
+        )
+        padded_loss_mask = xp.concatenate(
+            [
+                loss_mask,
+                xp.zeros((pad_width,), dtype=loss_mask.dtype),
+            ],
+            axis=0,
+        )
+        return padded_tokens, padded_loss_mask
+
+    def _build_inputs_and_labels(
+        self,
+        tokens: Array,
+        loss_mask: Array,
+    ) -> Tuple[Array, Array]:
+        input_ids = tokens[:-1]
+        labels = xp.array(tokens[1:], dtype=xp.int32)
+        labels[xp.array(loss_mask[1:], dtype=xp.float32) == 0] = IGNORE_INDEX
+        return input_ids, labels
+
+    def _stack_padded_examples(
+        self,
+        padded_examples: Sequence[Tuple[Array, Array]],
+    ) -> CausalLMBatch:
+        batch_inputs = []
+        batch_labels = []
+
+        for padded_tokens, padded_loss_mask in padded_examples:
+            input_tokens, labels = self._build_inputs_and_labels(
+                padded_tokens,
+                padded_loss_mask,
             )
-            padded_tokens, padded_loss_mask = self.padder(
-                (truncated_tokens, truncated_loss_mask),
-                self.max_tokens,
-                (self.pad_idx, 0),
-            )
-            input_tokens, labels = self.label_builder(padded_tokens, padded_loss_mask)
 
             batch_inputs.append(input_tokens)
             batch_labels.append(labels)
@@ -313,9 +234,59 @@ class CausalLMCollator(Collator):
         )
 
 
+class FixedLengthCausalLMCollator(_CausalLMBaseCollator):
+    """
+    Builds causal-LM batches padded to `max_tokens`.
+
+    The batch-time flow is: left-truncate each `(tokens, loss_mask)` row, then
+    right-pad every row to `max_tokens`, then shift tokens into inputs/labels.
+    """
+
+    def __call__(self, examples: Sequence[dict[str, Array]]) -> CausalLMBatch:
+        truncated_examples = self._truncate_examples(examples)
+        padded_examples = tuple(
+            self._pad_right(
+                tokens,
+                loss_mask,
+                target_length=self.max_tokens,
+            )
+            for tokens, loss_mask in truncated_examples
+        )
+        return self._stack_padded_examples(padded_examples)
+
+
+class BatchMaxLengthCausalLMCollator(_CausalLMBaseCollator):
+    """
+    Builds causal-LM batches padded to the longest row in this batch.
+
+    The batch-time flow is: left-truncate each `(tokens, loss_mask)` row, then
+    right-pad every row to the longest truncated row in this batch, then shift
+    tokens into inputs/labels.
+    """
+
+    def __call__(self, examples: Sequence[dict[str, Array]]) -> CausalLMBatch:
+        truncated_examples = self._truncate_examples(examples)
+        longest_row_length = max(
+            2, max(len(tokens) for tokens, _ in truncated_examples)
+        )
+        padded_examples = tuple(
+            self._pad_right(
+                tokens,
+                loss_mask,
+                target_length=longest_row_length,
+            )
+            for tokens, loss_mask in truncated_examples
+        )
+        return self._stack_padded_examples(padded_examples)
+
+
 class Seq2SeqCollator(Collator):
     """
     Builds encoder-decoder LM batches with decoder inputs and padding masks.
+
+    Each example has source `input_ids` and target `labels`. The collator pads
+    both to `max_tokens`, masks padded labels with `IGNORE_INDEX`, and builds
+    decoder inputs by shifting target tokens right with an SOS token.
     """
 
     def __init__(
@@ -323,45 +294,68 @@ class Seq2SeqCollator(Collator):
         max_tokens: int,
         pad_idx: int,
         sos_idx: int,
-        *,
-        packer: Callable[[Array, int, int], Array],
     ) -> None:
+        if max_tokens < 1:
+            raise ValueError("max_tokens must be >= 1 for seq2seq")
         self.max_tokens = max_tokens
         self.pad_idx = pad_idx
         self.sos_idx = sos_idx
-        self.packer = packer
 
     def __call__(self, examples: Sequence[dict[str, Array]]) -> Seq2SeqBatch:
         batch_inputs = []
-        batch_decoder_targets = []
+        batch_decoder_inputs = []
         batch_labels = []
+        batch_src_masks = []
+        batch_tgt_masks = []
 
         for example in examples:
             input_ids = xp.array(example["input_ids"], dtype=xp.int32)
             labels = xp.array(example["labels"], dtype=xp.int32)
 
-            packed_input_ids = self.packer(input_ids, self.max_tokens, self.pad_idx)
-            packed_target_tokens = self.packer(labels, self.max_tokens, self.pad_idx)
+            formatted_input_ids = truncate_and_pad_tokens(
+                input_ids,
+                self.max_tokens,
+                self.pad_idx,
+            )
 
-            masked_labels = xp.array(packed_target_tokens, dtype=xp.int32)
+            decoder_targets = truncate_and_pad_tokens(
+                labels,
+                self.max_tokens,
+                self.pad_idx,
+            )
+            masked_labels = xp.array(decoder_targets, dtype=xp.int32)
             masked_labels[masked_labels == self.pad_idx] = IGNORE_INDEX
 
-            batch_inputs.append(packed_input_ids)
-            batch_decoder_targets.append(packed_target_tokens)
+            sos_token = xp.array([self.sos_idx], dtype=decoder_targets.dtype)
+            decoder_input_ids = xp.concatenate(
+                [sos_token, decoder_targets[:-1]],
+                axis=0,
+            )
+
+            src_mask = create_padding_mask(
+                formatted_input_ids,
+                self.pad_idx,
+                dims=(1, 1, len(formatted_input_ids)),
+            )
+            tgt_mask = create_padding_mask(
+                decoder_input_ids,
+                self.pad_idx,
+                dims=(1, 1, len(decoder_input_ids)),
+            )
+
+            batch_inputs.append(formatted_input_ids)
+            batch_decoder_inputs.append(decoder_input_ids)
             batch_labels.append(masked_labels)
+            batch_src_masks.append(src_mask)
+            batch_tgt_masks.append(tgt_mask)
 
         input_ids = xp.stack(batch_inputs, axis=0)
-        decoder_targets = xp.stack(batch_decoder_targets, axis=0)
+        decoder_input_ids = xp.stack(batch_decoder_inputs, axis=0)
         labels = xp.stack(batch_labels, axis=0)
-        batch_size = input_ids.shape[0]
-        sos_column = xp.full((batch_size, 1), self.sos_idx, dtype=decoder_targets.dtype)
-        decoder_input_ids = xp.concatenate(
-            [sos_column, decoder_targets[:, :-1]], axis=1
-        )
         return Seq2SeqBatch(
             input_ids=input_ids,
             decoder_input_ids=decoder_input_ids,
             labels=labels,
-            src_mask=text_utils.create_padding_mask(input_ids, self.pad_idx),
-            tgt_mask=text_utils.create_padding_mask(decoder_input_ids, self.pad_idx),
+            src_mask=xp.stack(batch_src_masks, axis=0),
+            tgt_mask=xp.stack(batch_tgt_masks, axis=0),
         )

--- a/autograd/data/data_loader.py
+++ b/autograd/data/data_loader.py
@@ -5,15 +5,17 @@ Data pipeline boundary:
 - dataset / transforms
 
 2. Batch assembly and batch-time shaping
-- collate_fn
+- collator
 
 3. Training-specific logic
 - trainer / training loop / model forward
 """
 
+from numbers import Integral
 from typing import Any, Callable, Sequence
 
-from autograd.data.dataset import IterableDataset
+from autograd.data.dataset import MapDataset
+from autograd.data.sampler import Sampler
 
 CollateFn = Callable[[Sequence[Any]], Any]
 
@@ -22,17 +24,18 @@ class DataLoader:
     """
     Generic example-batching loader.
 
-    Dataset yields examples.
+    Map-style datasets iterate in stored order unless a sampler is supplied.
     DataLoader groups examples.
     Collator creates batches.
     """
 
     def __init__(
         self,
-        dataset: IterableDataset,
+        dataset: MapDataset,
         batch_size: int,
-        collate_fn: CollateFn | None = None,
+        collator: CollateFn | None = None,
         *,
+        sampler: Sampler | None = None,
         drop_last: bool = False,
     ) -> None:
         if batch_size < 1:
@@ -40,27 +43,38 @@ class DataLoader:
 
         self.dataset = dataset
         self.batch_size = batch_size
-        self.collate_fn = collate_fn
+        self.collator = collator
+        self.sampler = sampler
         self.drop_last = drop_last
 
     def on_epoch_start(self) -> None:
         self.dataset.on_epoch_start()
+        if self.sampler is not None:
+            self.sampler.on_epoch_start()
 
     def __iter__(self):
         examples = []
         yielded_batches = 0
 
-        for example in self.dataset:
+        if self.sampler is not None:
+            dataset_len = len(self.dataset)
+            iterable = (
+                self.dataset[self._validate_sampler_index(index, dataset_len)]
+                for index in self.sampler
+            )
+        else:
+            iterable = iter(self.dataset)
+        for example in iterable:
             examples.append(example)
 
             if len(examples) == self.batch_size:
                 yielded_batches += 1
-                yield self.collate_fn(examples) if self.collate_fn else examples
+                yield self.collator(examples) if self.collator else examples
                 examples = []
 
         if examples and not self.drop_last:
             yielded_batches += 1
-            yield self.collate_fn(examples) if self.collate_fn else examples
+            yield self.collator(examples) if self.collator else examples
 
         if yielded_batches == 0:
             raise ValueError(
@@ -69,17 +83,10 @@ class DataLoader:
                 "have dropped the only partial batch."
             )
 
-        try:
-            expected_batches = len(self)
-        except TypeError:
-            return
-        if yielded_batches != expected_batches:
-            raise ValueError(
-                "DataLoader yielded a different number of batches than len(DataLoader)."
-            )
-
     def __len__(self) -> int:
-        n = len(self.dataset)
+        # A sampler can yield a subset, repeat examples, or shard data, so the
+        # number of rows seen by this loader is not always len(dataset).
+        n = len(self.sampler) if self.sampler is not None else len(self.dataset)
 
         if self.drop_last:
             batch_count = n // self.batch_size
@@ -94,3 +101,17 @@ class DataLoader:
             )
 
         return batch_count
+
+    def _validate_sampler_index(self, index: Any, dataset_len: int) -> int:
+        if not isinstance(index, Integral):
+            raise TypeError(
+                f"sampler yielded non-integer index {index!r} "
+                f"of type {type(index).__name__}"
+            )
+        index_int = int(index)
+        if index_int < 0 or index_int >= dataset_len:
+            raise IndexError(
+                f"sampler yielded index {index_int} outside dataset length "
+                f"{dataset_len}"
+            )
+        return index_int

--- a/autograd/data/data_loader.py
+++ b/autograd/data/data_loader.py
@@ -48,31 +48,49 @@ class DataLoader:
 
     def __iter__(self):
         examples = []
-        yielded_batch = False
+        yielded_batches = 0
 
         for example in self.dataset:
             examples.append(example)
 
             if len(examples) == self.batch_size:
-                yielded_batch = True
+                yielded_batches += 1
                 yield self.collate_fn(examples) if self.collate_fn else examples
                 examples = []
 
         if examples and not self.drop_last:
-            yielded_batch = True
+            yielded_batches += 1
             yield self.collate_fn(examples) if self.collate_fn else examples
 
-        if not yielded_batch:
+        if yielded_batches == 0:
             raise ValueError(
                 "DataLoader yielded no batches. The dataset may be empty, may "
                 "have yielded no examples for this pass, or drop_last=True may "
                 "have dropped the only partial batch."
             )
 
+        try:
+            expected_batches = len(self)
+        except TypeError:
+            return
+        if yielded_batches != expected_batches:
+            raise ValueError(
+                "DataLoader yielded a different number of batches than len(DataLoader)."
+            )
+
     def __len__(self) -> int:
         n = len(self.dataset)
 
         if self.drop_last:
-            return n // self.batch_size
+            batch_count = n // self.batch_size
+        else:
+            batch_count = (n + self.batch_size - 1) // self.batch_size
 
-        return (n + self.batch_size - 1) // self.batch_size
+        if batch_count < 1:
+            raise ValueError(
+                "DataLoader yielded no batches. The dataset may be empty, may "
+                "have yielded no examples for this pass, or drop_last=True may "
+                "have dropped the only partial batch."
+            )
+
+        return batch_count

--- a/autograd/data/dataset.py
+++ b/autograd/data/dataset.py
@@ -1,245 +1,108 @@
-from abc import ABC, abstractmethod
-from typing import Any, Callable, Iterator, Literal, Optional, Sequence
-
-import numpy as np
+from typing import Any, Iterator, Sequence
 
 from autograd.backend import Array, xp
 from autograd.data.types import TokenWindowExample
 
 
-class IterableDataset(ABC):
+class MapDataset:
     """
-    Abstract interface for iterable datasets that yield training records.
+    Map-style dataset for already-shaped examples.
 
-    By default, each iteration yields one example dictionary.
+    Samplers operate on this interface: they yield indices, and DataLoader uses
+    those indices to fetch examples with `dataset[index]`.
 
-    Examples:
-        >>> class DummyIterableDataset(IterableDataset):
-        ...     def __iter__(self):
-        ...         yield {"tokens": xp.array([1, 2, 3], dtype=xp.int32)}
-        ...     def __len__(self):
-        ...         return 1
-        >>> dataset = DummyIterableDataset()
-        >>> next(iter(dataset))["tokens"].shape
-        (3,)
+    Use `PairedMapDataset` when examples are built from two aligned fields.
     """
+
+    def __init__(self, examples: Sequence[Any]) -> None:
+        self.examples = list(examples)
 
     def on_epoch_start(self) -> None:
         pass
 
-    @abstractmethod
+    def __getitem__(self, index: int) -> Any:
+        return self.examples[index]
+
     def __iter__(self) -> Iterator[Any]:
-        pass
+        for index in range(len(self)):
+            yield self[index]
 
     def __len__(self) -> int:
-        raise TypeError(f"object of type '{self.__class__.__name__}' has no len()")
+        return len(self.examples)
 
 
-class PairedIterableDataset(IterableDataset):
+class PairedMapDataset(MapDataset):
     """
     Iterates over in-memory paired `(X, y)` data one example at a time.
 
     Examples:
         >>> X = xp.arange(6).reshape(3, 2)
         >>> y = xp.array([0, 1, 2])
-        >>> dataset = PairedIterableDataset(X, y, shuffle=False)
+        >>> dataset = PairedMapDataset(X, y)
         >>> example = next(iter(dataset))
         >>> example["inputs"].shape, int(example["targets"])
         ((2,), 0)
-    """
-
-    def __init__(
-        self, X: Sequence[Any], y: Sequence[Any], shuffle: bool = True
-    ) -> None:
-        if len(X) != len(y):
-            raise ValueError("X and y must contain the same number of examples")
-        self.X = X
-        self.y = y
-        self.shuffle = shuffle
-        self.num_samples = len(X)
-        self.indices = xp.arange(self.num_samples)
-
-    def on_epoch_start(self) -> None:
-        if self.shuffle:
-            self.indices = xp.random.permutation(self.num_samples)
-
-    def __iter__(self) -> Iterator[dict[str, Array]]:
-        for sample_idx in self.indices:
-            idx = int(sample_idx)
-            yield {"inputs": self.X[idx], "targets": self.y[idx]}
-
-    def __len__(self) -> int:
-        return self.num_samples
-
-
-class TransformDataset(IterableDataset):
-    """
-    Wraps another dataset and applies per-example transforms during iteration.
-
-    Examples:
-        >>> dataset = PairedIterableDataset(
-        ...     xp.arange(6).reshape(3, 2),
-        ...     xp.array([0, 1, 2]),
-        ...     shuffle=False,
+        >>> seq2seq = PairedMapDataset(
+        ...     [xp.array([1, 2])],
+        ...     [xp.array([3, 4])],
+        ...     input_key="input_ids",
+        ...     target_key="labels",
+        ...     dtype=xp.int32,
         ... )
-        >>> wrapped = TransformDataset(
-        ...     dataset,
-        ...     transform=lambda example: {
-        ...         "inputs": example["inputs"],
-        ...         "targets": xp.array(int(example["targets"] == 1), dtype=xp.int32),
-        ...     },
-        ... )
-        >>> int(next(iter(wrapped))["targets"])
-        0
-    """
-
-    def __init__(
-        self,
-        dataset: IterableDataset,
-        transform: Optional[Callable[[Any], Any]] = None,
-    ) -> None:
-        self.dataset = dataset
-        self.transform = transform
-
-    def on_epoch_start(self) -> None:
-        self.dataset.on_epoch_start()
-
-    def __iter__(self) -> Iterator[Any]:
-        for example in self.dataset:
-            if self.transform is None:
-                yield example
-            else:
-                yield self.transform(example)
-
-    def __len__(self) -> int:
-        return len(self.dataset)
-
-
-class Seq2SeqDataset(IterableDataset):
-    """
-    Iterates over in-memory encoder-decoder token pairs one example at a time.
-
-    Examples:
-        >>> dataset = Seq2SeqDataset(
-        ...     input_sequences=[xp.array([1, 2], dtype=xp.int32)],
-        ...     label_sequences=[xp.array([3, 4], dtype=xp.int32)],
-        ...     shuffle=False,
-        ... )
-        >>> example = next(iter(dataset))
+        >>> example = next(iter(seq2seq))
         >>> example["input_ids"].tolist(), example["labels"].tolist()
         ([1, 2], [3, 4])
-    """
-
-    def __init__(
-        self,
-        input_sequences: Sequence[Array],
-        label_sequences: Sequence[Array],
-        shuffle: bool = True,
-    ) -> None:
-        if len(input_sequences) != len(label_sequences):
-            raise ValueError(
-                "input_sequences and label_sequences must contain the same number of examples"
-            )
-
-        self.examples = []
-        for input_ids, labels in zip(input_sequences, label_sequences):
-            input_array = xp.array(input_ids, dtype=xp.int32)
-            label_array = xp.array(labels, dtype=xp.int32)
-            self.examples.append(
-                {
-                    "input_ids": input_array,
-                    "labels": label_array,
-                }
-            )
-
-        self.shuffle = shuffle
-        self.num_examples = len(self.examples)
-        self.indices = xp.arange(self.num_examples)
-
-    def on_epoch_start(self) -> None:
-        if self.shuffle:
-            self.indices = xp.random.permutation(self.num_examples)
-
-    def __iter__(self) -> Iterator[dict[str, Array]]:
-        for sample_idx in self.indices:
-            example = self.examples[int(sample_idx)]
-            yield {
-                "input_ids": example["input_ids"],
-                "labels": example["labels"],
-            }
-
-    def __len__(self) -> int:
-        return self.num_examples
-
-
-class TokenSequenceDataset(IterableDataset):
-    """
-    Iterates over LM token sequences with per-token loss masks.
-
-    Examples:
-        >>> dataset = TokenSequenceDataset(
-        ...     token_sequences=[xp.array([10, 11, 20], dtype=xp.int32)],
-        ...     loss_masks=[xp.array([0, 0, 1], dtype=xp.int32)],
-        ...     shuffle=False,
+        >>> causal_lm = PairedMapDataset(
+        ...     [xp.array([10, 11, 12])],
+        ...     [xp.array([0, 1, 1])],
+        ...     input_key="tokens",
+        ...     target_key="loss_mask",
+        ...     dtype=xp.int32,
         ... )
-        >>> example = next(iter(dataset))
+        >>> example = next(iter(causal_lm))
         >>> example["tokens"].tolist(), example["loss_mask"].tolist()
-        ([10, 11, 20], [0, 0, 1])
+        ([10, 11, 12], [0, 1, 1])
     """
 
     def __init__(
         self,
-        token_sequences: Optional[Sequence[Array]] = None,
-        loss_masks: Optional[Sequence[Array]] = None,
-        shuffle: bool = True,
+        inputs: Sequence[Any],
+        targets: Sequence[Any],
+        *,
+        input_key: str = "inputs",
+        target_key: str = "targets",
+        dtype: Any | None = None,
     ) -> None:
-        self.shuffle = shuffle
-
-        if token_sequences is None:
-            raise ValueError("token_sequences are required")
-        if loss_masks is None:
-            loss_masks = [
-                xp.ones((len(tokens),), dtype=xp.int32) for tokens in token_sequences
-            ]
-        if len(token_sequences) != len(loss_masks):
+        if len(inputs) != len(targets):
             raise ValueError(
-                "token_sequences and loss_masks must contain the same number of examples"
+                "inputs and targets must contain the same number of examples"
             )
-        self.examples = []
-        for tokens, loss_mask in zip(token_sequences, loss_masks):
-            tokens_array = xp.array(tokens, dtype=xp.int32)
-            loss_mask_array = xp.array(loss_mask, dtype=xp.int32)
-            if len(tokens_array) != len(loss_mask_array):
-                raise ValueError(
-                    "token sequence and loss mask must have the same length"
-                )
-            self.examples.append({"tokens": tokens_array, "loss_mask": loss_mask_array})
-        self.num_examples = len(self.examples)
-        self.indices = xp.arange(self.num_examples)
 
-    def on_epoch_start(self) -> None:
-        if self.shuffle:
-            self.indices = xp.random.permutation(self.num_examples)
-
-    def __iter__(self) -> Iterator[dict[str, Array]]:
-        for sample_idx in self.indices:
-            example = self.examples[int(sample_idx)]
-            yield {
-                "tokens": example["tokens"],
-                "loss_mask": example["loss_mask"],
-            }
-
-    def __len__(self) -> int:
-        return self.num_examples
+        examples = []
+        for index in range(len(inputs)):
+            input_value = inputs[index]
+            target_value = targets[index]
+            if dtype is not None:
+                input_value = xp.array(input_value, dtype=dtype)
+                target_value = xp.array(target_value, dtype=dtype)
+            examples.append({input_key: input_value, target_key: target_value})
+        super().__init__(examples)
 
 
-class TokenWindowDataset(IterableDataset):
+class TokenWindowMapDataset(MapDataset):
     """
-    Yields one lazy token-window example at a time.
+    Maps token-window offsets to lazy examples.
 
     One item is not a batch.
     One item represents one stream window:
         stream[offset : offset + window_len]
+    The dataset owns the token stream and offset -> window mapping only.
+    Samplers own traversal order.
+
+    Use `SequentialSampler` for ordered windows, `RandomSampler` for one shuffled
+    pass, and `RandomSampler(replacement=True, num_samples=...)` for fixed-size
+    random-with-replacement epochs. Calling `DataLoader.on_epoch_start()` calls
+    the sampler hook, so a `RandomSampler` gives a fresh random order each epoch.
     """
 
     def __init__(
@@ -247,78 +110,24 @@ class TokenWindowDataset(IterableDataset):
         data: Array,
         *,
         window_len: int,
-        sampling: Literal["random", "sequential"] = "random",
-        examples_per_epoch: int | None = None,
-        offset_buffer_size: int = 4096,
     ) -> None:
         self.stream = xp.array(data, dtype=xp.int32)
         self.window_len = window_len
-        self.sampling = sampling
-        self.examples_per_epoch = examples_per_epoch
-        self.offset_buffer_size = offset_buffer_size
 
         # The edge case where len(stream) == window length, valid_window_count == 1, offset 0 is valid
         self.valid_window_count = len(self.stream) - self.window_len + 1
-
-        if self.sampling not in {"random", "sequential"}:
-            raise ValueError(
-                f"sampling must be 'random' or 'sequential', got {self.sampling!r}"
-            )
-        if self.offset_buffer_size < 1:
-            raise ValueError("offset_buffer_size must be >= 1")
-        if self.examples_per_epoch is not None and self.examples_per_epoch < 1:
-            raise ValueError("examples_per_epoch must be >= 1 when provided")
-        if self.sampling == "sequential" and self.examples_per_epoch is not None:
-            raise ValueError("examples_per_epoch is only valid for sampling='random'")
 
         if self.valid_window_count < 1:
             raise ValueError(
                 f"Need at least {self.window_len} tokens, got {len(self.stream)}"
             )
 
-    def on_epoch_start(self) -> None:
-        pass
-
-    def __iter__(self):
-        if self.sampling == "random":
-            yielded = 0
-
-            while self.examples_per_epoch is None or yielded < self.examples_per_epoch:
-                remaining = (
-                    self.offset_buffer_size
-                    if self.examples_per_epoch is None
-                    else min(self.offset_buffer_size, self.examples_per_epoch - yielded)
-                )
-                # Keeping offsets on CPU so we're using numpy explicitly
-
-                offsets = np.random.randint(
-                    0,
-                    self.valid_window_count,  # exclusive high
-                    size=remaining,
-                    dtype=np.int32,
-                )
-
-                for offset in offsets:
-                    yielded += 1
-                    yield TokenWindowExample(
-                        stream=self.stream,
-                        offset=int(offset),
-                        window_len=self.window_len,
-                    )
-
-            return
-
-        for offset in range(self.valid_window_count):
-            yield TokenWindowExample(
-                stream=self.stream,
-                offset=offset,
-                window_len=self.window_len,
-            )
+    def __getitem__(self, offset: int) -> TokenWindowExample:
+        return TokenWindowExample(
+            stream=self.stream,
+            offset=offset,
+            window_len=self.window_len,
+        )
 
     def __len__(self) -> int:
-        if self.sampling == "random":
-            if self.examples_per_epoch is None:
-                raise TypeError("TokenWindowDataset with sampling='random' is infinite")
-            return self.examples_per_epoch
-
         return self.valid_window_count

--- a/autograd/data/sampler.py
+++ b/autograd/data/sampler.py
@@ -1,0 +1,157 @@
+from abc import ABC, abstractmethod
+from typing import Iterator
+
+import numpy as np
+
+from autograd.data.dataset import MapDataset
+
+
+class Sampler(ABC):
+    """
+    Produces dataset indices for one epoch.
+
+    MapDataset owns examples. Sampler owns index order. DataLoader owns
+    grouping ordered examples into batches.
+
+    `len(sampler)` is the number of indices the sampler will yield for one
+    epoch. It may differ from `len(dataset)` for samplers that draw subsets,
+    repeat examples, or shard data.
+    """
+
+    def on_epoch_start(self) -> None:
+        pass
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[int]:
+        pass
+
+    @abstractmethod
+    def __len__(self) -> int:
+        pass
+
+
+class SequentialSampler(Sampler):
+    """Yields dataset indices in stored order."""
+
+    def __init__(self, dataset: MapDataset) -> None:
+        if not isinstance(dataset, MapDataset):
+            raise TypeError("SequentialSampler requires MapDataset")
+        self.dataset = dataset
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(range(len(self.dataset)))
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+
+class RandomSampler(Sampler):
+    """
+    Yields random dataset indices each epoch.
+
+    Without replacement, each epoch is a shuffled finite pass unless
+    `num_samples` asks for a shorter or repeated multi-pass sample. With
+    replacement, each epoch draws `num_samples` independent indices. Call
+    `on_epoch_start()` to resample, which `DataLoader.on_epoch_start()` does for
+    attached samplers.
+    """
+
+    def __init__(
+        self,
+        dataset: MapDataset,
+        *,
+        replacement: bool = False,
+        num_samples: int | None = None,
+    ) -> None:
+        if not isinstance(dataset, MapDataset):
+            raise TypeError("RandomSampler requires MapDataset")
+        if len(dataset) < 1:
+            raise ValueError("RandomSampler requires a non-empty dataset")
+        if num_samples is None:
+            num_samples = len(dataset)
+        if num_samples < 1:
+            raise ValueError("num_samples must be >= 1")
+        self.dataset = dataset
+        self.replacement = replacement
+        self.num_samples = num_samples
+        self.indices = self._sample_indices()
+
+    def _sample_indices(self) -> list[int]:
+        if self.replacement:
+            return np.random.randint(
+                0,
+                len(self.dataset),
+                size=self.num_samples,
+                dtype=np.int32,
+            ).tolist()
+
+        indices = []
+        while len(indices) < self.num_samples:
+            permutation = list(range(len(self.dataset)))
+            np.random.shuffle(permutation)
+            indices.extend(permutation[: self.num_samples - len(indices)])
+        return indices
+
+    def on_epoch_start(self) -> None:
+        self.indices = self._sample_indices()
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self.indices)
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+
+class TokenLengthGroupedRandomSampler(Sampler):
+    """
+    Yields indices so nearby examples have similar lengths.
+
+    Use this with a dynamic-padding collator. The sampler does not pack examples:
+    each sampled index still maps to one independent batch row.
+
+    Args:
+        dataset: MapDataset with a `"tokens"` field in each example.
+        sort_buffer_size: Number of shuffled indices to sort by length at a
+            time. Larger buffers reduce padding more but make ordering less
+            random. The DataLoader batch size is still the number of examples
+            passed to the collator at once.
+    """
+
+    def __init__(
+        self,
+        dataset: MapDataset,
+        *,
+        sort_buffer_size: int,
+    ) -> None:
+        if not isinstance(dataset, MapDataset):
+            raise TypeError("TokenLengthGroupedRandomSampler requires MapDataset")
+        if sort_buffer_size < 1:
+            raise ValueError("sort_buffer_size must be >= 1")
+        if len(dataset) > 0 and "tokens" not in dataset[0]:
+            raise ValueError(
+                "TokenLengthGroupedRandomSampler requires examples with a 'tokens' field"
+            )
+        self.dataset = dataset
+        self.sort_buffer_size = sort_buffer_size
+        self.indices = self._ordered_indices()
+
+    def _ordered_indices(self) -> list[int]:
+        shuffled = list(range(len(self.dataset)))
+        np.random.shuffle(shuffled)
+        ordered = []
+        for start in range(0, len(shuffled), self.sort_buffer_size):
+            buffer = shuffled[start : start + self.sort_buffer_size]
+            ordered.extend(sorted(buffer, key=self._sequence_length))
+        return ordered
+
+    def _sequence_length(self, index: int) -> int:
+        return len(self.dataset[index]["tokens"])
+
+    def on_epoch_start(self) -> None:
+        self.indices = self._ordered_indices()
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self.indices)
+
+    def __len__(self) -> int:
+        return len(self.dataset)

--- a/autograd/data/utils.py
+++ b/autograd/data/utils.py
@@ -6,7 +6,7 @@ from urllib.request import urlopen
 from pyarrow import parquet as pq  # pyright: ignore[reportMissingImports]
 
 from autograd.backend import Array, xp
-from autograd.data.dataset import Seq2SeqDataset
+from autograd.data.dataset import PairedMapDataset
 
 
 def train_test_split(
@@ -133,9 +133,8 @@ def build_seq2seq_dataset_from_text_pairs(
     text_pairs: Sequence[tuple[str, str]],
     bpe,
     *,
-    shuffle: bool,
     target_suffix: str = "",
-) -> Seq2SeqDataset:
+) -> PairedMapDataset:
     input_sequences = []
     label_sequences = []
 
@@ -160,8 +159,10 @@ def build_seq2seq_dataset_from_text_pairs(
     if not input_sequences:
         raise ValueError("text_pairs must contain at least one example")
 
-    return Seq2SeqDataset(
-        input_sequences=input_sequences,
-        label_sequences=label_sequences,
-        shuffle=shuffle,
+    return PairedMapDataset(
+        input_sequences,
+        label_sequences,
+        input_key="input_ids",
+        target_key="labels",
+        dtype=xp.int32,
     )

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -249,41 +249,6 @@ def prepare_mlx_attention_mask(
     return "explicit_additive", xp.array(raw_mask, dtype=xp.float32) * -1e9
 
 
-def create_padding_mask(
-    token_indices: Array,
-    pad_idx: int = 0,
-    dims: Optional[Tuple[int, ...]] = None,
-) -> Array:
-    """
-    Creates a padding mask with configurable output dimensions.
-
-    Args:
-        token_indices (Array): shape (batch_size, seq_len) containing token indices
-        pad_idx (int): Integer indicating the padding token index
-        dims (tuple or None): Desired shape. If None, (batch_size, 1, 1, seq_len).
-
-    Returns:
-        Array: A mask array where positions of 'pad_idx' are 1.0
-
-    Examples:
-        >>> token_indices = np.array([[1, 0, 2], [0, 3, 4]])
-        >>> mask = create_padding_mask(token_indices, pad_idx=0)
-        >>> print(mask.shape)
-        (2, 1, 1, 3)
-    """
-    token_indices = xp.array(token_indices)
-    pad_positions = (token_indices == pad_idx).astype(xp.float32)
-
-    if dims is None:
-        # Default shape for standard attention: (batch_size, 1, 1, seq_len)
-        return xp.expand_dims(xp.expand_dims(pad_positions, axis=1), axis=1)
-    else:
-        # We will simply reshape pad_positions to the desired dims
-        # assuming the number of elements matches.
-        mask = pad_positions.reshape(dims)
-        return mask
-
-
 def clean_and_tokenize(
     text: str, pattern: str = r"\w+|[^\w\s]|[\n\s]", lowercase: bool = True
 ) -> List[str]:

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -97,32 +97,10 @@ class GenericTrainingConfig:
             )
         if self.max_grad_norm is not None and self.max_grad_norm <= 0:
             raise ValueError(f"max_grad_norm must be > 0, got {self.max_grad_norm}")
-        self._validate_checkpoint_accumulation_alignment()
 
     @property
     def gradient_accumulation_steps(self) -> int:
         return self.global_batch_size // self.micro_batch_size
-
-    def _validate_checkpoint_accumulation_alignment(self) -> None:
-        if self.max_steps is None:
-            return
-
-        accumulation_steps = self.gradient_accumulation_steps
-        if accumulation_steps == 1 or self.checkpoint_freq > self.max_steps:
-            return
-
-        if self.checkpoint_freq % accumulation_steps != 0:
-            raise ValueError(
-                "checkpoint_freq must be divisible by gradient_accumulation_steps "
-                "when step-mode checkpointing uses gradient accumulation, "
-                f"got checkpoint_freq={self.checkpoint_freq}, "
-                f"gradient_accumulation_steps={accumulation_steps}. "
-                "Otherwise a checkpoint can be written before optimizer.step() "
-                "has materialized optimizer state for the accumulated gradients. "
-                "Use a checkpoint_freq that is a multiple of "
-                "gradient_accumulation_steps; if you need a final checkpoint, "
-                "max_steps should land on the same boundary."
-            )
 
 
 @dataclass

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -171,12 +171,11 @@ class TrainingPlan:
     def for_epochs(
         cls,
         max_epochs: int,
-        steps_per_epoch: int,
+        batch_count: int,
+        accumulation_steps: int,
         checkpoint_every: int,
     ) -> "TrainingPlan":
-        if steps_per_epoch <= 0:
-            raise ValueError("steps_per_epoch must be > 0 in epoch mode.")
-
+        steps_per_epoch = (batch_count + accumulation_steps - 1) // accumulation_steps
         return cls(
             by_epoch=True,
             target_step=max_epochs * steps_per_epoch,
@@ -257,9 +256,8 @@ class AbstractTrainer(ABC):
             pretrained_checkpoint_path=config.pretrained_checkpoint_path,
             checkpoint_path=kwargs.get("checkpoint_path"),
         )
-        # `global_step` counts consumed training batches / microbatches,
-        # not optimizer updates. Under gradient accumulation, multiple
-        # microbatches can contribute to one optimizer step.
+        # `global_step` counts optimizer updates. Epoch-mode configs are converted
+        # to optimizer-step targets before entering the training loop.
         self.global_step = int(self.checkpoint.get("step_count", 0))
         self.metric_rows: list[dict[str, Optional[float]]] = []
         self.best_val_loss: Optional[float] = self.checkpoint.get("best_val_loss")
@@ -278,8 +276,8 @@ class AbstractTrainer(ABC):
                 validation batches.
 
         Notes:
-            `global_step` counts consumed training batches / microbatches.
-            It does not count optimizer updates when gradient accumulation is enabled.
+            `global_step` counts optimizer updates. Epoch-mode configs are converted
+            to optimizer-step targets before entering the training loop.
         """
 
         self._validate_fit_inputs(train_data_loader)
@@ -306,7 +304,8 @@ class AbstractTrainer(ABC):
         else:
             plan = TrainingPlan.for_epochs(
                 max_epochs=cast(int, self.config.max_epochs),
-                steps_per_epoch=len(train_data_loader),
+                batch_count=len(train_data_loader),
+                accumulation_steps=accumulation_steps,
                 checkpoint_every=self.config.checkpoint_freq,
             )
 
@@ -336,17 +335,39 @@ class AbstractTrainer(ABC):
                     loss.backward()
                     state.record_loss(loss)
 
-                    self.global_step += 1
-                    should_report = plan.should_report(self.global_step)
-
                     if state.has_enough_batches(accumulation_steps):
-                        self.optimizer_step(
+                        next_step = self.global_step + 1
+                        should_report = plan.should_report(next_step)
+                        if self.optimizer_step(
                             state,
-                            # Always clip when configured, but only read back
-                            # the grad norm on steps that will report it.
+                            # Always clip when configured, but only read back the
+                            # grad norm on steps that will report it.
                             record_grad_norm=should_report,
-                        )
+                        ):
+                            self.global_step = next_step
+                            progress_bar.update(1)
 
+                            if should_report:
+                                eval_state = (
+                                    self.evaluate(val_data_loader)
+                                    if val_data_loader is not None
+                                    else None
+                                )
+                                self.report(state, plan, eval_state)
+
+                    if plan.is_done(self.global_step):
+                        break
+
+                # This is after all the batches in the data loader
+                next_step = self.global_step + 1
+                should_report = plan.should_report(next_step)
+                if self.optimizer_step(
+                    state,
+                    # Always clip when configured, but only read back the grad norm
+                    # on steps that will report it.
+                    record_grad_norm=should_report,
+                ):
+                    self.global_step = next_step
                     progress_bar.update(1)
 
                     if should_report:
@@ -357,30 +378,14 @@ class AbstractTrainer(ABC):
                         )
                         self.report(state, plan, eval_state)
 
-                    if plan.is_done(self.global_step):
-                        break
-
-                if (
-                    plan.by_epoch
-                    and plan.steps_per_epoch is not None
-                    and batches_this_pass != plan.steps_per_epoch
-                ):
-                    raise ValueError(
-                        "In epoch mode, len(train_data_loader) must match the actual "
-                        "number of batches yielded per loader pass."
-                    )
-
-                # This is after all the batches in the data loader
-                self.optimizer_step(state, record_grad_norm=False)
-
     def optimizer_step(
         self,
         state: TrainingState,
         *,
         record_grad_norm: bool = True,
-    ) -> None:
+    ) -> bool:
         if state.accumulated_batches == 0:
-            return
+            return False
 
         self.optimizer.scale_gradients(1.0 / state.accumulated_batches)
         grad_l2_norm = None
@@ -393,6 +398,7 @@ class AbstractTrainer(ABC):
             self.last_grad_l2_norm = None
         self.optimizer.zero_grad()
         state.accumulated_batches = 0
+        return True
 
     def evaluate(self, val_data_loader: DataLoader) -> TrainingState:
         val_data_loader.on_epoch_start()
@@ -539,19 +545,22 @@ class AbstractTrainer(ABC):
             return
 
         try:
-            steps_per_epoch = len(train_data_loader)
+            batch_count = len(train_data_loader)
         except TypeError as exc:
             raise ValueError(
                 "Infinite training loaders require max_steps. "
                 "Set max_steps or give the dataset examples_per_epoch."
             ) from exc
 
-        if steps_per_epoch <= 0:
-            raise ValueError("train_data_loader must yield at least one batch.")
-
         if self.global_step > 0:
+            plan = TrainingPlan.for_epochs(
+                max_epochs=cast(int, self.config.max_epochs),
+                batch_count=batch_count,
+                accumulation_steps=int(self.config.gradient_accumulation_steps),
+                checkpoint_every=self.config.checkpoint_freq,
+            )
             loaded_steps_per_epoch = self.checkpoint.get("steps_per_epoch")
-            if loaded_steps_per_epoch != steps_per_epoch:
+            if loaded_steps_per_epoch != plan.steps_per_epoch:
                 raise ValueError(
                     "Cannot resume epoch-mode checkpoint with changed steps_per_epoch."
                 )
@@ -1001,7 +1010,7 @@ class LLMTrainer(AbstractTrainer):
             EvalResult: The average validation loss and derived metrics.
         """
         state = TrainingState()
-        for batch_data in tqdm(val_data_loader, desc="Evaluation", leave=False):
+        for batch_data in tqdm(iter(val_data_loader), desc="Evaluation", leave=False):
             if (
                 self.config.max_eval_steps is not None
                 and state.eval_loss_batches >= self.config.max_eval_steps

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -544,14 +544,7 @@ class AbstractTrainer(ABC):
         if self.config.max_steps is not None:
             return
 
-        try:
-            batch_count = len(train_data_loader)
-        except TypeError as exc:
-            raise ValueError(
-                "Infinite training loaders require max_steps. "
-                "Set max_steps or give the dataset examples_per_epoch."
-            ) from exc
-
+        batch_count = len(train_data_loader)
         if self.global_step > 0:
             plan = TrainingPlan.for_epochs(
                 max_epochs=cast(int, self.config.max_epochs),

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -337,7 +337,6 @@ class AbstractTrainer(ABC):
                     state.record_loss(loss)
 
                     self.global_step += 1
-                    progress_bar.update(1)
                     should_report = plan.should_report(self.global_step)
 
                     if state.has_enough_batches(accumulation_steps):
@@ -347,6 +346,8 @@ class AbstractTrainer(ABC):
                             # the grad norm on steps that will report it.
                             record_grad_norm=should_report,
                         )
+
+                    progress_bar.update(1)
 
                     if should_report:
                         eval_state = (

--- a/examples/cifar.py
+++ b/examples/cifar.py
@@ -5,7 +5,8 @@ from openml.datasets import get_dataset  # pyright: ignore[reportMissingImports]
 from autograd import functional, nn, optim
 from autograd.data.collator import PairedCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import PairedIterableDataset
+from autograd.data.dataset import PairedMapDataset
+from autograd.data.sampler import RandomSampler
 from autograd.data.utils import train_test_split
 from autograd.tools.config_schema import GenericTrainingConfig
 from autograd.tools.trainer import SimpleTrainer
@@ -260,15 +261,17 @@ if __name__ == "__main__":
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
 
+    train_dataset = PairedMapDataset(X_train, y_train)
     train_data_loader = DataLoader(
-        PairedIterableDataset(X_train, y_train, shuffle=True),
+        train_dataset,
         batch_size=256,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
+        sampler=RandomSampler(train_dataset),
     )
     test_data_loader = DataLoader(
-        PairedIterableDataset(X_test, y_test, shuffle=False),
+        PairedMapDataset(X_test, y_test),
         batch_size=256,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
     )
 
     # Train ResNet CIFAR-10 model
@@ -342,15 +345,17 @@ if __name__ == "__main__":
     logger.info(f"{X.shape=}, {y.shape=}")
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
+    train_dataset = PairedMapDataset(X_train, y_train)
     train_data_loader = DataLoader(
-        PairedIterableDataset(X_train, y_train, shuffle=True),
+        train_dataset,
         batch_size=256,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
+        sampler=RandomSampler(train_dataset),
     )
     test_data_loader = DataLoader(
-        PairedIterableDataset(X_test, y_test, shuffle=False),
+        PairedMapDataset(X_test, y_test),
         batch_size=256,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
     )
 
     # Train ResNet CIFAR-100 model

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -13,7 +13,8 @@ from autograd import functional, nn, optim
 from autograd.backend import xp
 from autograd.data.collator import CausalLMWindowCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import TokenWindowDataset
+from autograd.data.dataset import TokenWindowMapDataset
+from autograd.data.sampler import RandomSampler, SequentialSampler
 from autograd.data.types import CausalLMBatch
 from autograd.tensor import Tensor
 from autograd.text import utils as text_utils
@@ -217,27 +218,33 @@ if __name__ == "__main__":
         forward_fn=GPT1ForwardFn(),
     )
 
+    train_dataset = TokenWindowMapDataset(
+        data=xp.array(train_data, dtype=xp.int32),
+        # CausalLMWindowCollator shifts one token to build input_ids/labels,
+        # so a length-T model context needs a raw window of length T + 1.
+        window_len=trainer.model.max_seq_len + 1,
+    )
+    test_dataset = TokenWindowMapDataset(
+        data=xp.array(test_data, dtype=xp.int32),
+        # CausalLMWindowCollator shifts one token to build input_ids/labels,
+        # so a length-T model context needs a raw window of length T + 1.
+        window_len=trainer.model.max_seq_len + 1,
+    )
     train_data_loader = DataLoader(
-        dataset=TokenWindowDataset(
-            data=xp.array(train_data, dtype=xp.int32),
-            # CausalLMWindowCollator shifts one token to build input_ids/labels,
-            # so a length-T model context needs a raw window of length T + 1.
-            window_len=trainer.model.max_seq_len + 1,
-            sampling="random",
-        ),
+        dataset=train_dataset,
         batch_size=train_micro_batch_size,
-        collate_fn=CausalLMWindowCollator(),
+        collator=CausalLMWindowCollator(),
+        sampler=RandomSampler(
+            train_dataset,
+            replacement=True,
+            num_samples=len(train_dataset),
+        ),
     )
     test_data_loader = DataLoader(
-        dataset=TokenWindowDataset(
-            data=xp.array(test_data, dtype=xp.int32),
-            # CausalLMWindowCollator shifts one token to build input_ids/labels,
-            # so a length-T model context needs a raw window of length T + 1.
-            window_len=trainer.model.max_seq_len + 1,
-            sampling="sequential",
-        ),
+        dataset=test_dataset,
         batch_size=max(1, train_micro_batch_size // 2),
-        collate_fn=CausalLMWindowCollator(),
+        collator=CausalLMWindowCollator(),
+        sampler=SequentialSampler(test_dataset),
     )
 
     trainer.fit(train_data_loader, test_data_loader)

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -12,7 +12,8 @@ from autograd import functional, nn, optim
 from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, xp
 from autograd.data.collator import CausalLMWindowCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import TokenWindowDataset
+from autograd.data.dataset import TokenWindowMapDataset
+from autograd.data.sampler import RandomSampler, SequentialSampler
 from autograd.data.types import CausalLMBatch
 from autograd.tensor import Tensor, checkpoint
 from autograd.text import utils as text_utils
@@ -287,7 +288,7 @@ if __name__ == "__main__":
                 "lr_decay_iters": 160000,  # 80% of max_steps
             },
         },
-        resume_epoch=55000,  # Set this to None if you don't want to load from checkpoint
+        resume_epoch=62000,  # Set this to None if you don't want to load from checkpoint
         teacher_forcing=False,
         label_smoothing=0.1,
         eval_start_string="April is",
@@ -341,27 +342,33 @@ if __name__ == "__main__":
         forward_fn=GPT2ForwardFn(),
     )
 
+    train_dataset = TokenWindowMapDataset(
+        data=xp.array(train_data, dtype=xp.int32),
+        # CausalLMWindowCollator shifts one token to build input_ids/labels,
+        # so a length-T model context needs a raw window of length T + 1.
+        window_len=trainer.model.max_seq_len + 1,
+    )
+    test_dataset = TokenWindowMapDataset(
+        data=xp.array(test_data, dtype=xp.int32),
+        # CausalLMWindowCollator shifts one token to build input_ids/labels,
+        # so a length-T model context needs a raw window of length T + 1.
+        window_len=trainer.model.max_seq_len + 1,
+    )
     train_data_loader = DataLoader(
-        dataset=TokenWindowDataset(
-            data=xp.array(train_data, dtype=xp.int32),
-            # CausalLMWindowCollator shifts one token to build input_ids/labels,
-            # so a length-T model context needs a raw window of length T + 1.
-            window_len=trainer.model.max_seq_len + 1,
-            sampling="random",
-        ),
+        dataset=train_dataset,
         batch_size=CONFIG.micro_batch_size,
-        collate_fn=CausalLMWindowCollator(),
+        collator=CausalLMWindowCollator(),
+        sampler=RandomSampler(
+            train_dataset,
+            replacement=True,
+            num_samples=len(train_dataset),
+        ),
     )
     test_data_loader = DataLoader(
-        dataset=TokenWindowDataset(
-            data=xp.array(test_data, dtype=xp.int32),
-            # CausalLMWindowCollator shifts one token to build input_ids/labels,
-            # so a length-T model context needs a raw window of length T + 1.
-            window_len=trainer.model.max_seq_len + 1,
-            sampling="sequential",
-        ),
+        dataset=test_dataset,
         batch_size=max(1, CONFIG.micro_batch_size // 2),
-        collate_fn=CausalLMWindowCollator(),
+        collator=CausalLMWindowCollator(),
+        sampler=SequentialSampler(test_dataset),
     )
 
     trainer.fit(train_data_loader, test_data_loader)

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -6,7 +6,8 @@ from autograd import functional, nn, optim
 from autograd.backend import xp
 from autograd.data.collator import PairedCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import PairedIterableDataset, TransformDataset
+from autograd.data.dataset import PairedMapDataset
+from autograd.data.sampler import RandomSampler
 from autograd.data.utils import train_test_split
 from autograd.tools.config_schema import GenericTrainingConfig
 from autograd.tools.metrics import accuracy, precision
@@ -258,16 +259,15 @@ def train_mnist_with_hinge_loss(
 
     for digit in range(10):
         logger.info(f"Training digit={digit}")
+        train_dataset = PairedMapDataset(
+            X_train,
+            target_transform_for_digit(digit)(y_train),
+        )
         train_loader = DataLoader(
-            TransformDataset(
-                PairedIterableDataset(X_train, y_train, shuffle=True),
-                transform=lambda example, digit=digit: {
-                    "inputs": example["inputs"],
-                    "targets": target_transform_for_digit(digit)(example["targets"]),
-                },
-            ),
+            train_dataset,
             batch_size=batch_size,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
+            sampler=RandomSampler(train_dataset),
         )
         # Build a training configuration for the trainer.
         config = GenericTrainingConfig(
@@ -335,16 +335,15 @@ def train_mnist_one_vs_rest_model(
 
     for digit in range(10):
         logger.info(f"Training digit={digit}")
+        train_dataset = PairedMapDataset(
+            X_train,
+            target_transform_for_digit(digit)(y_train),
+        )
         train_loader = DataLoader(
-            TransformDataset(
-                PairedIterableDataset(X_train, y_train, shuffle=True),
-                transform=lambda example, digit=digit: {
-                    "inputs": example["inputs"],
-                    "targets": target_transform_for_digit(digit)(example["targets"]),
-                },
-            ),
+            train_dataset,
             batch_size=batch_size,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
+            sampler=RandomSampler(train_dataset),
         )
         # Build the training configuration.
         config = GenericTrainingConfig(
@@ -454,15 +453,17 @@ if __name__ == "__main__":
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
 
     # Create data loaders with a consistent batch size.
+    train_dataset = PairedMapDataset(X_train, y_train)
     train_data_loader = DataLoader(
-        PairedIterableDataset(X_train, y_train, shuffle=True),
+        train_dataset,
         batch_size=512,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
+        sampler=RandomSampler(train_dataset),
     )
     val_data_loader = DataLoader(
-        PairedIterableDataset(X_test, y_test, shuffle=False),
+        PairedMapDataset(X_test, y_test),
         batch_size=512,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
     )
 
     # Train several multi-class models.

--- a/examples/movie_sentiment.py
+++ b/examples/movie_sentiment.py
@@ -5,7 +5,8 @@ from autograd import functional, nn, optim
 from autograd.backend import xp
 from autograd.data.collator import OneHotCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import PairedIterableDataset
+from autograd.data.dataset import PairedMapDataset
+from autograd.data.sampler import RandomSampler
 from autograd.data.utils import load_data, train_test_split
 from autograd.text.utils import create_vocabulary
 from autograd.tools.config_schema import GenericTrainingConfig
@@ -208,15 +209,17 @@ if __name__ == "__main__":
     data = load_data("training_data/IMDB Dataset.csv", "training_data/IMDB Dataset.csv")
     assert not isinstance(data, str)
     X_train, X_test, y_train, y_test, vocab = process_data(data)
+    train_dataset = PairedMapDataset(X_train, y_train)
     train_data_loader = DataLoader(
-        PairedIterableDataset(X_train, y_train, shuffle=True),
+        train_dataset,
         batch_size=32,
-        collate_fn=OneHotCollator(num_classes=len(vocab)),
+        collator=OneHotCollator(num_classes=len(vocab)),
+        sampler=RandomSampler(train_dataset),
     )
     test_data_loader = DataLoader(
-        PairedIterableDataset(X_test, y_test, shuffle=False),
+        PairedMapDataset(X_test, y_test),
         batch_size=32,
-        collate_fn=OneHotCollator(num_classes=len(vocab)),
+        collator=OneHotCollator(num_classes=len(vocab)),
     )
 
     # Train the RNN model.

--- a/examples/neural_turing_machine.py
+++ b/examples/neural_turing_machine.py
@@ -2,7 +2,8 @@ from autograd import functional, nn, optim
 from autograd.backend import xp
 from autograd.data.collator import PairedCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import PairedIterableDataset
+from autograd.data.dataset import PairedMapDataset
+from autograd.data.sampler import RandomSampler
 from autograd.tensor import Tensor
 from autograd.tools import trainer
 from autograd.tools.config_schema import GenericTrainingConfig
@@ -576,15 +577,19 @@ if __name__ == "__main__":
     X_val = to_one_hot(X_val, input_size)
 
     print("------------- Neural Turing Machine ---------------")
+    train_dataset = PairedMapDataset(X, y)
     train_data_loader = DataLoader(
-        PairedIterableDataset(X, y, shuffle=True),
+        train_dataset,
         batch_size=batch_size,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
+        sampler=RandomSampler(train_dataset),
     )
+    val_dataset = PairedMapDataset(X_val, y_val)
     val_data_loader = DataLoader(
-        PairedIterableDataset(X_val, y_val, shuffle=True),
+        val_dataset,
         batch_size=batch_size,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
+        sampler=RandomSampler(val_dataset),
     )
 
     # Create training configuration for the Neural Turing Machine.

--- a/examples/seq2seq.py
+++ b/examples/seq2seq.py
@@ -1,7 +1,8 @@
 from autograd import functional, nn, optim, tensor
 from autograd.data.collator import PairedCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import PairedIterableDataset
+from autograd.data.dataset import PairedMapDataset
+from autograd.data.sampler import RandomSampler
 from autograd.data.utils import load_data
 from autograd.text.utils import create_vocabulary, text_to_one_hot_and_sparse
 from autograd.tools.config_schema import GenericTrainingConfig
@@ -174,15 +175,17 @@ def main():
         train_y, vocab, max_sequence_length=60
     )
 
+    train_dataset = PairedMapDataset(features, labels_vocab_idx)
     train_data_loader = DataLoader(
-        PairedIterableDataset(features, labels_vocab_idx, shuffle=True),
+        train_dataset,
         batch_size=32,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
+        sampler=RandomSampler(train_dataset),
     )
     test_data_loader = DataLoader(
-        PairedIterableDataset(test_features, test_labels_vocab_idx, shuffle=False),
+        PairedMapDataset(test_features, test_labels_vocab_idx),
         batch_size=32,
-        collate_fn=PairedCollator(),
+        collator=PairedCollator(),
     )
 
     # Build a training configuration for the Seq2Seq model.

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -3,8 +3,9 @@ from typing import Any, Optional
 
 from autograd import functional, nn, optim
 from autograd.backend import xp
-from autograd.data.collator import Seq2SeqCollator, pack_tokens
+from autograd.data.collator import Seq2SeqCollator
 from autograd.data.data_loader import DataLoader
+from autograd.data.sampler import RandomSampler
 from autograd.data.utils import (
     build_seq2seq_dataset_from_text_pairs,
     load_parquet_rows,
@@ -665,34 +666,31 @@ if __name__ == "__main__":
     train_dataset = build_seq2seq_dataset_from_text_pairs(
         train_pairs,
         bpe,
-        shuffle=True,
         target_suffix=CONFIG.custom_bpe.split_token,
     )
     test_dataset = build_seq2seq_dataset_from_text_pairs(
         test_pairs,
         bpe,
-        shuffle=False,
         target_suffix=CONFIG.custom_bpe.split_token,
     )
 
     train_data_loader = DataLoader(
         dataset=train_dataset,
         batch_size=train_micro_batch_size,
-        collate_fn=Seq2SeqCollator(
+        collator=Seq2SeqCollator(
             max_tokens=trainer.model.max_seq_len,
             pad_idx=pad_idx,
             sos_idx=sos_idx,
-            packer=pack_tokens,
         ),
+        sampler=RandomSampler(train_dataset),
     )
     test_data_loader = DataLoader(
         dataset=test_dataset,
         batch_size=max(1, train_micro_batch_size // 2),
-        collate_fn=Seq2SeqCollator(
+        collator=Seq2SeqCollator(
             max_tokens=trainer.model.max_seq_len,
             pad_idx=pad_idx,
             sos_idx=sos_idx,
-            packer=pack_tokens,
         ),
     )
 

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from autograd import functional, nn, optim
 from autograd.backend import xp
-from autograd.data.collator import Seq2SeqCollator
+from autograd.data.collator import Seq2SeqCollator, pack_tokens
 from autograd.data.data_loader import DataLoader
 from autograd.data.utils import (
     build_seq2seq_dataset_from_text_pairs,
@@ -682,6 +682,7 @@ if __name__ == "__main__":
             max_tokens=trainer.model.max_seq_len,
             pad_idx=pad_idx,
             sos_idx=sos_idx,
+            packer=pack_tokens,
         ),
     )
     test_data_loader = DataLoader(
@@ -691,6 +692,7 @@ if __name__ == "__main__":
             max_tokens=trainer.model.max_seq_len,
             pad_idx=pad_idx,
             sos_idx=sos_idx,
+            packer=pack_tokens,
         ),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,15 @@ reportIncompatibleMethodOverride = "none"
 exclude = [
     ".venv",
     "build",
+    "checkpoints",
+    "dist",
+    "drafts",
+    "htmlcov",
+    "training_data",
     "training_runs",
+    "**/.pytest_cache",
+    "**/.ruff_cache",
+    "**/__pycache__",
     "**/test/**",    # Ignore all files in the "test" directory
 ]
 

--- a/test/autograd/data/test_collator.py
+++ b/test/autograd/data/test_collator.py
@@ -11,19 +11,29 @@ from autograd.data.collator import (
     OneHotCollator,
     PairedCollator,
     Seq2SeqCollator,
+    build_causal_lm_inputs_and_labels,
+    greedy_pack_aligned_examples,
     pack_tokens,
+    pad_aligned_right,
+    truncate_aligned_left,
 )
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch, TokenWindowExample
-from autograd.data.utils import (
-    openai_chat_to_prompt_completion,
-    tokenize_prompt_completion,
-)
 from autograd.functional import IGNORE_INDEX
 
 
 def mock_padding_mask(X_chunk, pad_idx):
     batch_size, seq_len = X_chunk.shape
     return xp.zeros((batch_size, 1, 1, seq_len))
+
+
+def make_causal_lm_collator(max_tokens: int, pad_idx: int) -> CausalLMCollator:
+    return CausalLMCollator(
+        max_tokens=max_tokens,
+        pad_idx=pad_idx,
+        truncator=truncate_aligned_left,
+        padder=pad_aligned_right,
+        label_builder=build_causal_lm_inputs_and_labels,
+    )
 
 
 class MockBPE:
@@ -33,7 +43,23 @@ class MockBPE:
                 return [0]
             if token == "<SOS>":
                 return [1]
-        return [ord(char) for char in token]
+            if token == "<|endoftext|>":
+                return [2]
+        special_token = "<|endoftext|>"
+        if token == special_token:
+            return [2]
+
+        encoded = []
+        start = 0
+        while True:
+            special_index = token.find(special_token, start)
+            if special_index == -1:
+                encoded.extend(ord(char) for char in token[start:])
+                break
+            encoded.extend(ord(char) for char in token[start:special_index])
+            encoded.append(2)
+            start = special_index + len(special_token)
+        return encoded
 
 
 class TestCollator(unittest.TestCase):
@@ -49,6 +75,92 @@ class TestCollator(unittest.TestCase):
 
         self.assertTrue(
             xp.array_equal(packed, xp.array([12, 13, 20, 21, 22], dtype=xp.int32))
+        )
+
+    def test_truncate_aligned_left_trims_values_together(self):
+        tokens, loss_mask = truncate_aligned_left(
+            (
+                xp.array([10, 11, 12, 13], dtype=xp.int32),
+                xp.array([0, 0, 1, 1], dtype=xp.int32),
+            ),
+            max_tokens=3,
+        )
+
+        self.assertTrue(xp.array_equal(tokens, xp.array([11, 12, 13], dtype=xp.int32)))
+        self.assertTrue(xp.array_equal(loss_mask, xp.array([0, 1, 1], dtype=xp.int32)))
+
+    def test_pad_aligned_right_uses_field_specific_pad_values(self):
+        tokens, loss_mask = pad_aligned_right(
+            (
+                xp.array([10, 11], dtype=xp.int32),
+                xp.array([0, 1], dtype=xp.int32),
+            ),
+            max_tokens=4,
+            pad_values=(257, 0),
+        )
+
+        self.assertTrue(
+            xp.array_equal(tokens, xp.array([10, 11, 257, 257], dtype=xp.int32))
+        )
+        self.assertTrue(
+            xp.array_equal(loss_mask, xp.array([0, 1, 0, 0], dtype=xp.int32))
+        )
+
+    def test_greedy_pack_aligned_examples_preserves_selected_fields(self):
+        packed = greedy_pack_aligned_examples(
+            [
+                {
+                    "tokens": xp.array([10, 11, 12], dtype=xp.int32),
+                    "loss_mask": xp.array([0, 1, 1], dtype=xp.int32),
+                    "ignored": xp.array([100], dtype=xp.int32),
+                },
+                {
+                    "tokens": xp.array([20, 21, 22, 23], dtype=xp.int32),
+                    "loss_mask": xp.array([0, 0, 1, 1], dtype=xp.int32),
+                    "ignored": xp.array([200], dtype=xp.int32),
+                },
+                {
+                    "tokens": xp.array([30, 31], dtype=xp.int32),
+                    "loss_mask": xp.array([0, 1], dtype=xp.int32),
+                    "ignored": xp.array([300], dtype=xp.int32),
+                },
+            ],
+            fields=("tokens", "loss_mask"),
+            max_tokens=7,
+        )
+
+        self.assertEqual(len(packed), 2)
+        self.assertTrue(
+            xp.array_equal(
+                packed[0]["tokens"],
+                xp.array([10, 11, 12, 20, 21, 22, 23], dtype=xp.int32),
+            )
+        )
+        self.assertTrue(
+            xp.array_equal(
+                packed[0]["loss_mask"],
+                xp.array([0, 1, 1, 0, 0, 1, 1], dtype=xp.int32),
+            )
+        )
+        self.assertTrue(
+            xp.array_equal(packed[1]["tokens"], xp.array([30, 31], dtype=xp.int32))
+        )
+        self.assertNotIn("ignored", packed[0])
+
+    def test_build_causal_lm_inputs_and_labels_masks_shifted_targets(self):
+        input_ids, labels = build_causal_lm_inputs_and_labels(
+            xp.array([10, 20, 30, 40], dtype=xp.int32),
+            xp.array([0, 0, 1, 1], dtype=xp.int32),
+        )
+
+        self.assertTrue(
+            xp.array_equal(input_ids, xp.array([10, 20, 30], dtype=xp.int32))
+        )
+        self.assertTrue(
+            xp.array_equal(
+                labels,
+                xp.array([IGNORE_INDEX, 30, 40], dtype=xp.int32),
+            )
         )
 
     def test_paired_collator_batches_examples(self):
@@ -124,7 +236,12 @@ class TestCollator(unittest.TestCase):
         side_effect=mock_padding_mask,
     )
     def test_encoder_decoder_collator_uses_seq2seq_examples(self, mock_padding):
-        collator = Seq2SeqCollator(max_tokens=4, pad_idx=0, sos_idx=1)
+        collator = Seq2SeqCollator(
+            max_tokens=4,
+            pad_idx=0,
+            sos_idx=1,
+            packer=pack_tokens,
+        )
 
         batch = collator(
             [
@@ -192,27 +309,12 @@ def test_window_collator_requires_shiftable_window():
         CausalLMWindowCollator()([example])
 
 
-def test_causal_lm_collator_builds_masked_sft_batch():
-    class DummyBPE:
-        def encode(self, text, allowed_special=None):
-            return [ord(char) for char in text]
-
-    tokenized_example = tokenize_prompt_completion(
-        openai_chat_to_prompt_completion(
-            {
-                "messages": [
-                    {"role": "user", "content": "ABC"},
-                    {"role": "assistant", "content": "DE"},
-                ]
-            }
-        ),
-        DummyBPE(),
-    )
-    batch = CausalLMCollator(max_tokens=6, pad_idx=0)(
+def test_causal_lm_collator_builds_prompt_masked_batch():
+    batch = make_causal_lm_collator(max_tokens=6, pad_idx=0)(
         [
             {
-                "tokens": tokenized_example["tokens"],
-                "loss_mask": tokenized_example["loss_mask"],
+                "tokens": xp.array([65, 66, 67, 2, 68, 69, 2], dtype=xp.int32),
+                "loss_mask": xp.array([0, 0, 0, 0, 1, 1, 1], dtype=xp.int32),
             }
         ]
     )
@@ -220,25 +322,18 @@ def test_causal_lm_collator_builds_masked_sft_batch():
     assert isinstance(batch, CausalLMBatch)
     np.testing.assert_array_equal(
         xp.to_numpy(batch.input_ids[0]),
-        np.array([65, 66, 67, 68, 69], dtype=np.int32),
+        np.array([66, 67, 2, 68, 69], dtype=np.int32),
     )
     np.testing.assert_array_equal(
         xp.to_numpy(batch.labels[0]),
-        np.array([IGNORE_INDEX, IGNORE_INDEX, 68, 69, IGNORE_INDEX], dtype=np.int32),
+        np.array([IGNORE_INDEX, IGNORE_INDEX, 68, 69, 2], dtype=np.int32),
     )
     assert not hasattr(batch, "loss_mask")
 
 
 def test_causal_lm_collator_requires_max_tokens_at_least_two():
     with pytest.raises(ValueError, match="max_tokens must be >= 2 for causal LM"):
-        CausalLMCollator(max_tokens=1, pad_idx=0)
-
-
-def test_causal_lm_collator_rejects_empty_batch():
-    collator = CausalLMCollator(max_tokens=4, pad_idx=0)
-
-    with pytest.raises(ValueError, match="examples must not be empty"):
-        collator([])
+        make_causal_lm_collator(max_tokens=1, pad_idx=0)
 
 
 def test_causal_lm_batch_rejects_loss_mask():

--- a/test/autograd/data/test_collator.py
+++ b/test/autograd/data/test_collator.py
@@ -6,33 +6,34 @@ import pytest
 
 from autograd.backend import xp
 from autograd.data.collator import (
-    CausalLMCollator,
+    BatchMaxLengthCausalLMCollator,
     CausalLMWindowCollator,
+    FixedLengthCausalLMCollator,
     OneHotCollator,
     PairedCollator,
     Seq2SeqCollator,
-    build_causal_lm_inputs_and_labels,
-    greedy_pack_aligned_examples,
-    pack_tokens,
-    pad_aligned_right,
-    truncate_aligned_left,
+    create_padding_mask,
+    truncate_and_pad_tokens,
 )
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch, TokenWindowExample
 from autograd.functional import IGNORE_INDEX
 
 
-def mock_padding_mask(X_chunk, pad_idx):
+def mock_padding_mask(X_chunk, pad_idx, dims=None):
+    if dims is not None:
+        return xp.zeros(dims)
+    if len(X_chunk.shape) == 1:
+        return xp.zeros((1, 1, X_chunk.shape[0]))
     batch_size, seq_len = X_chunk.shape
     return xp.zeros((batch_size, 1, 1, seq_len))
 
 
-def make_causal_lm_collator(max_tokens: int, pad_idx: int) -> CausalLMCollator:
-    return CausalLMCollator(
+def make_causal_lm_collator(
+    max_tokens: int, pad_idx: int
+) -> FixedLengthCausalLMCollator:
+    return FixedLengthCausalLMCollator(
         max_tokens=max_tokens,
         pad_idx=pad_idx,
-        truncator=truncate_aligned_left,
-        padder=pad_aligned_right,
-        label_builder=build_causal_lm_inputs_and_labels,
     )
 
 
@@ -66,102 +67,55 @@ class TestCollator(unittest.TestCase):
     def setUp(self):
         self.bpe = MockBPE()
 
-    def test_pack_tokens_left_truncates_then_pads(self):
-        packed = pack_tokens(
+    def test_create_padding_mask_default_dims(self):
+        token_indices = xp.array(
+            [
+                [1, 2, 0, 0],
+                [3, 4, 5, 0],
+            ],
+            dtype=xp.int32,
+        )
+
+        mask = create_padding_mask(token_indices, pad_idx=0, dims=None)
+
+        self.assertEqual(mask.shape, (2, 1, 1, 4))
+        assert xp.array_equal(mask[0, 0, 0], xp.array([0, 0, 1, 1]))
+        assert xp.array_equal(mask[1, 0, 0], xp.array([0, 0, 0, 1]))
+
+    def test_create_padding_mask_custom_dims(self):
+        token_indices = xp.array([[1, 0, 0], [2, 2, 0]], dtype=xp.int32)
+
+        mask = create_padding_mask(token_indices, pad_idx=0, dims=(2, 1, 3))
+
+        self.assertEqual(mask.shape, (2, 1, 3))
+        assert xp.array_equal(mask[0, 0], xp.array([0, 1, 1]))
+        assert xp.array_equal(mask[1, 0], xp.array([0, 0, 1]))
+
+    def test_truncate_and_pad_tokens_left_truncates_then_right_pads(self):
+        tokens = truncate_and_pad_tokens(
             tokens=xp.array([10, 11, 12, 13, 20, 21, 22], dtype=xp.int32),
             max_tokens=5,
             pad_idx=0,
         )
 
         self.assertTrue(
-            xp.array_equal(packed, xp.array([12, 13, 20, 21, 22], dtype=xp.int32))
+            xp.array_equal(tokens, xp.array([12, 13, 20, 21, 22], dtype=xp.int32))
         )
 
-    def test_truncate_aligned_left_trims_values_together(self):
-        tokens, loss_mask = truncate_aligned_left(
-            (
-                xp.array([10, 11, 12, 13], dtype=xp.int32),
-                xp.array([0, 0, 1, 1], dtype=xp.int32),
-            ),
-            max_tokens=3,
-        )
+    def test_causal_lm_collator_requires_aligned_tokens_and_loss_mask(self):
+        collator = make_causal_lm_collator(max_tokens=5, pad_idx=0)
 
-        self.assertTrue(xp.array_equal(tokens, xp.array([11, 12, 13], dtype=xp.int32)))
-        self.assertTrue(xp.array_equal(loss_mask, xp.array([0, 1, 1], dtype=xp.int32)))
-
-    def test_pad_aligned_right_uses_field_specific_pad_values(self):
-        tokens, loss_mask = pad_aligned_right(
-            (
-                xp.array([10, 11], dtype=xp.int32),
-                xp.array([0, 1], dtype=xp.int32),
-            ),
-            max_tokens=4,
-            pad_values=(257, 0),
-        )
-
-        self.assertTrue(
-            xp.array_equal(tokens, xp.array([10, 11, 257, 257], dtype=xp.int32))
-        )
-        self.assertTrue(
-            xp.array_equal(loss_mask, xp.array([0, 1, 0, 0], dtype=xp.int32))
-        )
-
-    def test_greedy_pack_aligned_examples_preserves_selected_fields(self):
-        packed = greedy_pack_aligned_examples(
-            [
-                {
-                    "tokens": xp.array([10, 11, 12], dtype=xp.int32),
-                    "loss_mask": xp.array([0, 1, 1], dtype=xp.int32),
-                    "ignored": xp.array([100], dtype=xp.int32),
-                },
-                {
-                    "tokens": xp.array([20, 21, 22, 23], dtype=xp.int32),
-                    "loss_mask": xp.array([0, 0, 1, 1], dtype=xp.int32),
-                    "ignored": xp.array([200], dtype=xp.int32),
-                },
-                {
-                    "tokens": xp.array([30, 31], dtype=xp.int32),
-                    "loss_mask": xp.array([0, 1], dtype=xp.int32),
-                    "ignored": xp.array([300], dtype=xp.int32),
-                },
-            ],
-            fields=("tokens", "loss_mask"),
-            max_tokens=7,
-        )
-
-        self.assertEqual(len(packed), 2)
-        self.assertTrue(
-            xp.array_equal(
-                packed[0]["tokens"],
-                xp.array([10, 11, 12, 20, 21, 22, 23], dtype=xp.int32),
+        with self.assertRaisesRegex(
+            ValueError, "tokens and loss_mask must have the same length"
+        ):
+            collator(
+                [
+                    {
+                        "tokens": xp.array([10, 11, 12], dtype=xp.int32),
+                        "loss_mask": xp.array([1, 1], dtype=xp.int32),
+                    }
+                ]
             )
-        )
-        self.assertTrue(
-            xp.array_equal(
-                packed[0]["loss_mask"],
-                xp.array([0, 1, 1, 0, 0, 1, 1], dtype=xp.int32),
-            )
-        )
-        self.assertTrue(
-            xp.array_equal(packed[1]["tokens"], xp.array([30, 31], dtype=xp.int32))
-        )
-        self.assertNotIn("ignored", packed[0])
-
-    def test_build_causal_lm_inputs_and_labels_masks_shifted_targets(self):
-        input_ids, labels = build_causal_lm_inputs_and_labels(
-            xp.array([10, 20, 30, 40], dtype=xp.int32),
-            xp.array([0, 0, 1, 1], dtype=xp.int32),
-        )
-
-        self.assertTrue(
-            xp.array_equal(input_ids, xp.array([10, 20, 30], dtype=xp.int32))
-        )
-        self.assertTrue(
-            xp.array_equal(
-                labels,
-                xp.array([IGNORE_INDEX, 30, 40], dtype=xp.int32),
-            )
-        )
 
     def test_paired_collator_batches_examples(self):
         collator = PairedCollator()
@@ -232,7 +186,7 @@ class TestCollator(unittest.TestCase):
         self.assertTrue(xp.array_equal(batch_y, xp.array([1, 0], dtype=xp.int32)))
 
     @patch(
-        "autograd.data.collator.text_utils.create_padding_mask",
+        "autograd.data.collator.create_padding_mask",
         side_effect=mock_padding_mask,
     )
     def test_encoder_decoder_collator_uses_seq2seq_examples(self, mock_padding):
@@ -240,7 +194,6 @@ class TestCollator(unittest.TestCase):
             max_tokens=4,
             pad_idx=0,
             sos_idx=1,
-            packer=pack_tokens,
         )
 
         batch = collator(
@@ -329,6 +282,35 @@ def test_causal_lm_collator_builds_prompt_masked_batch():
         np.array([IGNORE_INDEX, IGNORE_INDEX, 68, 69, 2], dtype=np.int32),
     )
     assert not hasattr(batch, "loss_mask")
+
+
+def test_batch_max_length_causal_lm_collator_pads_to_longest_row():
+    batch = BatchMaxLengthCausalLMCollator(
+        max_tokens=8,
+        pad_idx=0,
+    )(
+        [
+            {
+                "tokens": xp.array([10, 11, 12], dtype=xp.int32),
+                "loss_mask": xp.array([0, 1, 1], dtype=xp.int32),
+            },
+            {
+                "tokens": xp.array([20, 21, 22, 23, 24], dtype=xp.int32),
+                "loss_mask": xp.array([0, 0, 1, 1, 1], dtype=xp.int32),
+            },
+        ]
+    )
+
+    assert batch.input_ids.shape == (2, 4)
+    assert batch.labels.shape == (2, 4)
+    np.testing.assert_array_equal(
+        xp.to_numpy(batch.input_ids[0]),
+        np.array([10, 11, 12, 0], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        xp.to_numpy(batch.labels[0]),
+        np.array([11, 12, IGNORE_INDEX, IGNORE_INDEX], dtype=np.int32),
+    )
 
 
 def test_causal_lm_collator_requires_max_tokens_at_least_two():

--- a/test/autograd/data/test_data_loader.py
+++ b/test/autograd/data/test_data_loader.py
@@ -7,6 +7,10 @@ from autograd.data.collator import (
     CausalLMWindowCollator,
     PairedCollator,
     Seq2SeqCollator,
+    build_causal_lm_inputs_and_labels,
+    pack_tokens,
+    pad_aligned_right,
+    truncate_aligned_left,
 )
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import (
@@ -16,11 +20,8 @@ from autograd.data.dataset import (
     TokenSequenceDataset,
     TokenWindowDataset,
 )
+from autograd.data.sft import tokenize_sft_messages
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch
-from autograd.data.utils import (
-    openai_chat_to_prompt_completion,
-    tokenize_prompt_completion,
-)
 from autograd.functional import IGNORE_INDEX
 
 
@@ -36,7 +37,23 @@ class MockBPE:
                 return [0]
             if token == "<SOS>":
                 return [1]
-        return [ord(char) for char in token]
+            if token == "<|endoftext|>":
+                return [2]
+        special_token = "<|endoftext|>"
+        if token == special_token:
+            return [2]
+
+        encoded = []
+        start = 0
+        while True:
+            special_index = token.find(special_token, start)
+            if special_index == -1:
+                encoded.extend(ord(char) for char in token[start:])
+                break
+            encoded.extend(ord(char) for char in token[start:special_index])
+            encoded.append(2)
+            start = special_index + len(special_token)
+        return encoded
 
 
 class EmptyDataset(IterableDataset):
@@ -113,6 +130,7 @@ class TestDataLoader(unittest.TestCase):
                 max_tokens=seq_len,
                 pad_idx=pad_idx,
                 sos_idx=self.bpe.encode("<SOS>", allowed_special={"<SOS>"})[0],
+                packer=pack_tokens,
             )
         else:
             dataset = TokenWindowDataset(
@@ -140,10 +158,7 @@ class TestDataLoader(unittest.TestCase):
         )
         pad_idx = self.bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
         tokenized_examples = [
-            tokenize_prompt_completion(
-                openai_chat_to_prompt_completion(example), self.bpe
-            )
-            for example in chat_examples
+            tokenize_sft_messages(example, self.bpe) for example in chat_examples
         ]
         return DataLoader(
             dataset=TokenSequenceDataset(
@@ -155,6 +170,9 @@ class TestDataLoader(unittest.TestCase):
             collate_fn=CausalLMCollator(
                 max_tokens=seq_len + 1,
                 pad_idx=pad_idx,
+                truncator=truncate_aligned_left,
+                padder=pad_aligned_right,
+                label_builder=build_causal_lm_inputs_and_labels,
             ),
         )
 
@@ -356,7 +374,7 @@ class TestDataLoader(unittest.TestCase):
             xp.array_equal(
                 batch.labels[0],
                 xp.array(
-                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, IGNORE_INDEX],
+                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, 2],
                     dtype=xp.int32,
                 ),
             )
@@ -385,14 +403,14 @@ class TestDataLoader(unittest.TestCase):
         self.assertTrue(
             xp.array_equal(
                 batch.input_ids[0],
-                xp.array([65, 66, 67, 68, 69], dtype=xp.int32),
+                xp.array([116, 58, 32, 68, 69], dtype=xp.int32),
             )
         )
         self.assertTrue(
             xp.array_equal(
                 batch.labels[0],
                 xp.array(
-                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, IGNORE_INDEX],
+                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, 2],
                     dtype=xp.int32,
                 ),
             )
@@ -417,13 +435,13 @@ class TestDataLoader(unittest.TestCase):
 
         self.assertTrue(
             xp.array_equal(
-                batch.input_ids[0], xp.array([67, 68, 69, 70], dtype=xp.int32)
+                batch.input_ids[0], xp.array([32, 69, 70, 71], dtype=xp.int32)
             )
         )
         self.assertTrue(
             xp.array_equal(
                 batch.labels[0],
-                xp.array([IGNORE_INDEX, 69, 70, 71], dtype=xp.int32),
+                xp.array([69, 70, 71, 2], dtype=xp.int32),
             )
         )
 

--- a/test/autograd/data/test_data_loader.py
+++ b/test/autograd/data/test_data_loader.py
@@ -3,31 +3,44 @@ from unittest.mock import patch
 
 from autograd.backend import xp
 from autograd.data.collator import (
-    CausalLMCollator,
     CausalLMWindowCollator,
     PairedCollator,
     Seq2SeqCollator,
-    build_causal_lm_inputs_and_labels,
-    pack_tokens,
-    pad_aligned_right,
-    truncate_aligned_left,
 )
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import (
-    IterableDataset,
-    PairedIterableDataset,
-    Seq2SeqDataset,
-    TokenSequenceDataset,
-    TokenWindowDataset,
+    MapDataset,
+    PairedMapDataset,
+    TokenWindowMapDataset,
 )
-from autograd.data.sft import tokenize_sft_messages
+from autograd.data.sampler import (
+    RandomSampler,
+    Sampler,
+    SequentialSampler,
+    TokenLengthGroupedRandomSampler,
+)
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch
-from autograd.functional import IGNORE_INDEX
 
 
-def mock_padding_mask(X_chunk, pad_idx):
+def mock_padding_mask(X_chunk, pad_idx, dims=None):
+    if dims is not None:
+        return xp.zeros(dims)
     batch_size, seq_len = X_chunk.shape
     return xp.zeros((batch_size, 1, 1, seq_len))
+
+
+def make_token_dataset(token_sequences, loss_masks=None):
+    if loss_masks is None:
+        loss_masks = [
+            xp.ones((len(tokens),), dtype=xp.int32) for tokens in token_sequences
+        ]
+    return PairedMapDataset(
+        token_sequences,
+        loss_masks,
+        input_key="tokens",
+        target_key="loss_mask",
+        dtype=xp.int32,
+    )
 
 
 class MockBPE:
@@ -56,28 +69,15 @@ class MockBPE:
         return encoded
 
 
-class EmptyDataset(IterableDataset):
+class StaticSampler(Sampler):
+    def __init__(self, indices):
+        self.indices = indices
+
     def __iter__(self):
-        return iter(())
+        return iter(self.indices)
 
     def __len__(self):
-        return 0
-
-
-class BuggyEmptyPassDataset(IterableDataset):
-    def __iter__(self):
-        return iter(())
-
-    def __len__(self):
-        return 3
-
-
-class ShortPassDataset(IterableDataset):
-    def __iter__(self):
-        return iter(range(2))
-
-    def __len__(self):
-        return 3
+        return len(self.indices)
 
 
 class TestDataLoader(unittest.TestCase):
@@ -85,20 +85,6 @@ class TestDataLoader(unittest.TestCase):
         self.X = xp.arange(20).reshape(10, 2)
         self.y = xp.arange(10)
         self.data = xp.arange(200)
-        self.chat_examples = [
-            {
-                "messages": [
-                    {"role": "system", "content": "ABC"},
-                    {"role": "assistant", "content": "DE"},
-                ]
-            },
-            {
-                "messages": [
-                    {"role": "user", "content": "Q"},
-                    {"role": "assistant", "content": "RS"},
-                ]
-            },
-        ]
         self.seq_len = 10
         self.batch_size_simple = 3
         self.batch_size_llm = 4
@@ -129,85 +115,59 @@ class TestDataLoader(unittest.TestCase):
                 data[offset + seq_len : offset + (2 * seq_len)]
                 for offset in range(window_count)
             ]
-            dataset = Seq2SeqDataset(
-                input_sequences=sources,
-                label_sequences=targets,
-                shuffle=shuffle,
+            dataset = PairedMapDataset(
+                sources,
+                targets,
+                input_key="input_ids",
+                target_key="labels",
+                dtype=xp.int32,
             )
+            sampler = RandomSampler(dataset) if shuffle else None
             collator = Seq2SeqCollator(
                 max_tokens=seq_len,
                 pad_idx=pad_idx,
                 sos_idx=self.bpe.encode("<SOS>", allowed_special={"<SOS>"})[0],
-                packer=pack_tokens,
             )
         else:
-            dataset = TokenWindowDataset(
+            dataset = TokenWindowMapDataset(
                 xp.array(data),
                 window_len=seq_len + 1,
-                sampling="random" if shuffle else "sequential",
+            )
+            sampler = (
+                RandomSampler(dataset, replacement=True, num_samples=len(dataset))
+                if shuffle
+                else SequentialSampler(dataset)
             )
             collator = CausalLMWindowCollator()
         return DataLoader(
             dataset,
             batch_size=batch_size,
-            collate_fn=collator,
-        )
-
-    def make_sft_loader(
-        self,
-        chat_examples=None,
-        *,
-        batch_size=1,
-        seq_len=5,
-        shuffle=False,
-    ):
-        chat_examples = (
-            chat_examples if chat_examples is not None else self.chat_examples
-        )
-        pad_idx = self.bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
-        tokenized_examples = [
-            tokenize_sft_messages(example, self.bpe) for example in chat_examples
-        ]
-        return DataLoader(
-            dataset=TokenSequenceDataset(
-                token_sequences=[example["tokens"] for example in tokenized_examples],
-                loss_masks=[example["loss_mask"] for example in tokenized_examples],
-                shuffle=shuffle,
-            ),
-            batch_size=batch_size,
-            collate_fn=CausalLMCollator(
-                max_tokens=seq_len + 1,
-                pad_idx=pad_idx,
-                truncator=truncate_aligned_left,
-                padder=pad_aligned_right,
-                label_builder=build_causal_lm_inputs_and_labels,
-            ),
+            collator=collator,
+            sampler=sampler,
         )
 
     def test_data_loader_no_shuffle(self):
-        dataset = PairedIterableDataset(self.X, self.y, shuffle=False)
+        dataset = PairedMapDataset(self.X, self.y)
         loader = DataLoader(
             dataset,
             batch_size=self.batch_size_simple,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
         )
 
-        expected_indices = xp.arange(len(self.X))
         batches = list(loader)
         expected_batches = (
             len(self.X) + self.batch_size_simple - 1
         ) // self.batch_size_simple
 
-        self.assertTrue(xp.array_equal(dataset.indices, expected_indices))
         self.assertEqual(len(batches), expected_batches)
         reconstructed_y = xp.concatenate([batch[1] for batch in batches])
         self.assertTrue(xp.array_equal(reconstructed_y, self.y))
 
     def test_data_loader_length(self):
         loader = DataLoader(
-            PairedIterableDataset(self.X, self.y, shuffle=False),
+            PairedMapDataset(self.X, self.y),
             batch_size=self.batch_size_simple,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
         )
 
         expected_batches = (
@@ -217,7 +177,7 @@ class TestDataLoader(unittest.TestCase):
         self.assertEqual(len(loader), expected_batches)
 
     def test_data_loader_rejects_empty_dataset_iteration(self):
-        loader = DataLoader(EmptyDataset(), batch_size=1)
+        loader = DataLoader(MapDataset([]), batch_size=1)
 
         with self.assertRaisesRegex(
             ValueError,
@@ -226,7 +186,7 @@ class TestDataLoader(unittest.TestCase):
             next(iter(loader))
 
     def test_data_loader_rejects_empty_dataset_length(self):
-        loader = DataLoader(EmptyDataset(), batch_size=1)
+        loader = DataLoader(MapDataset([]), batch_size=1)
 
         with self.assertRaisesRegex(
             ValueError,
@@ -234,29 +194,11 @@ class TestDataLoader(unittest.TestCase):
         ):
             len(loader)
 
-    def test_data_loader_rejects_dataset_that_yields_nothing_for_pass(self):
-        loader = DataLoader(BuggyEmptyPassDataset(), batch_size=2)
-
-        with self.assertRaisesRegex(
-            ValueError,
-            "DataLoader yielded no batches",
-        ):
-            next(iter(loader))
-
-    def test_data_loader_rejects_len_iteration_batch_count_mismatch(self):
-        loader = DataLoader(ShortPassDataset(), batch_size=1)
-
-        with self.assertRaisesRegex(
-            ValueError,
-            "DataLoader yielded a different number of batches than len",
-        ):
-            list(loader)
-
     def test_data_loader_rejects_drop_last_when_only_partial_batch_exists(self):
         loader = DataLoader(
-            PairedIterableDataset(self.X[:1], self.y[:1], shuffle=False),
+            PairedMapDataset(self.X[:1], self.y[:1]),
             batch_size=2,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
             drop_last=True,
         )
 
@@ -268,9 +210,9 @@ class TestDataLoader(unittest.TestCase):
 
     def test_data_loader_rejects_drop_last_zero_batch_length(self):
         loader = DataLoader(
-            PairedIterableDataset(self.X[:1], self.y[:1], shuffle=False),
+            PairedMapDataset(self.X[:1], self.y[:1]),
             batch_size=2,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
             drop_last=True,
         )
 
@@ -280,23 +222,43 @@ class TestDataLoader(unittest.TestCase):
         ):
             len(loader)
 
+    def test_data_loader_rejects_non_integer_sampler_index(self):
+        dataset = make_token_dataset([xp.arange(2, dtype=xp.int32)])
+        loader = DataLoader(dataset, batch_size=1, sampler=StaticSampler(["0"]))
+
+        with self.assertRaisesRegex(TypeError, "sampler yielded non-integer index"):
+            next(iter(loader))
+
+    def test_data_loader_rejects_out_of_range_sampler_index(self):
+        dataset = make_token_dataset([xp.arange(2, dtype=xp.int32)])
+        loader = DataLoader(dataset, batch_size=1, sampler=StaticSampler([1]))
+
+        with self.assertRaisesRegex(
+            IndexError,
+            "sampler yielded index 1 outside dataset length 1",
+        ):
+            next(iter(loader))
+
     def test_pretraining_data_loader_on_epoch_start_reseeds_without_crashing(self):
         loader = self.make_pretraining_loader(shuffle=True)
 
         loader.on_epoch_start()
 
     def test_pretraining_data_loader_length(self):
-        loader_infinite = self.make_pretraining_loader()
+        loader = self.make_pretraining_loader()
+        expected_windows = len(self.data) - self.seq_len
+        expected_batches = (
+            expected_windows + self.batch_size_llm - 1
+        ) // self.batch_size_llm
 
-        with self.assertRaises(TypeError):
-            _ = len(loader_infinite)
+        self.assertEqual(len(loader), expected_batches)
 
     def test_data_loader_batches_supervised_examples(self):
-        dataset = PairedIterableDataset(self.X, self.y, shuffle=False)
+        dataset = PairedMapDataset(self.X, self.y)
         loader = DataLoader(
             dataset,
             batch_size=4,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
         )
 
         batches = list(loader)
@@ -307,14 +269,12 @@ class TestDataLoader(unittest.TestCase):
         self.assertTrue(xp.array_equal(first_y, self.y[:4]))
 
     def test_causal_lm_window_loader_yields_expected_next_token_pairs(self):
+        dataset = TokenWindowMapDataset(xp.arange(20, dtype=xp.int32), window_len=5)
         loader = DataLoader(
-            dataset=TokenWindowDataset(
-                xp.arange(20, dtype=xp.int32),
-                window_len=5,
-                sampling="sequential",
-            ),
+            dataset=dataset,
             batch_size=2,
-            collate_fn=CausalLMWindowCollator(),
+            collator=CausalLMWindowCollator(),
+            sampler=SequentialSampler(dataset),
         )
 
         batch = next(iter(loader))
@@ -334,14 +294,12 @@ class TestDataLoader(unittest.TestCase):
         )
 
     def test_causal_lm_window_loader_allows_minimal_valid_stream(self):
+        dataset = TokenWindowMapDataset(xp.arange(5, dtype=xp.int32), window_len=5)
         loader = DataLoader(
-            dataset=TokenWindowDataset(
-                xp.arange(5, dtype=xp.int32),
-                window_len=5,
-                sampling="sequential",
-            ),
+            dataset=dataset,
             batch_size=1,
-            collate_fn=CausalLMWindowCollator(),
+            collator=CausalLMWindowCollator(),
+            sampler=SequentialSampler(dataset),
         )
 
         batch = next(iter(loader))
@@ -354,14 +312,12 @@ class TestDataLoader(unittest.TestCase):
         )
 
     def test_data_loader_returns_causal_lm_batch_with_window_collator(self):
+        dataset = TokenWindowMapDataset(xp.arange(20, dtype=xp.int32), window_len=5)
         loader = DataLoader(
-            dataset=TokenWindowDataset(
-                xp.arange(20, dtype=xp.int32),
-                window_len=5,
-                sampling="sequential",
-            ),
+            dataset=dataset,
             batch_size=2,
-            collate_fn=CausalLMWindowCollator(),
+            collator=CausalLMWindowCollator(),
+            sampler=SequentialSampler(dataset),
         )
 
         batch = next(iter(loader))
@@ -370,13 +326,11 @@ class TestDataLoader(unittest.TestCase):
         self.assertTrue(xp.array_equal(batch.input_ids[0], xp.array([0, 1, 2, 3])))
 
     def test_data_loader_without_collator_yields_raw_window_examples(self):
+        dataset = TokenWindowMapDataset(xp.arange(20, dtype=xp.int32), window_len=5)
         loader = DataLoader(
-            dataset=TokenWindowDataset(
-                xp.arange(20, dtype=xp.int32),
-                window_len=5,
-                sampling="sequential",
-            ),
+            dataset=dataset,
             batch_size=2,
+            sampler=SequentialSampler(dataset),
         )
 
         batch = next(iter(loader))
@@ -385,108 +339,73 @@ class TestDataLoader(unittest.TestCase):
         self.assertEqual(batch[0].offset, 0)
         self.assertEqual(batch[1].offset, 1)
 
-    def test_sft_dataloader_length(self):
-        loader = self.make_sft_loader(batch_size=1, seq_len=4, shuffle=False)
-
-        self.assertEqual(len(loader), 2)
-
-    def test_sft_dataloader_masks_prompt_targets(self):
-        loader = self.make_sft_loader(
-            chat_examples=[
-                {
-                    "messages": [
-                        {"role": "user", "content": "ABC"},
-                        {"role": "assistant", "content": "DE"},
-                    ]
-                }
+    def test_data_loader_can_use_length_grouped_sampler(self):
+        dataset = make_token_dataset(
+            [
+                xp.arange(2, dtype=xp.int32),
+                xp.arange(8, dtype=xp.int32),
+                xp.arange(3, dtype=xp.int32),
+                xp.arange(7, dtype=xp.int32),
             ],
-            batch_size=1,
-            seq_len=5,
-            shuffle=False,
+            [
+                xp.ones((2,), dtype=xp.int32),
+                xp.ones((8,), dtype=xp.int32),
+                xp.ones((3,), dtype=xp.int32),
+                xp.ones((7,), dtype=xp.int32),
+            ],
         )
 
-        batch = next(iter(loader))
-
-        self.assertIsInstance(batch, CausalLMBatch)
-        self.assertEqual(batch.input_ids.shape, (1, 5))
-        self.assertEqual(batch.labels.shape, (1, 5))
-        self.assertTrue(
-            xp.array_equal(
-                batch.labels[0],
-                xp.array(
-                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, 2],
-                    dtype=xp.int32,
+        batches = list(
+            DataLoader(
+                dataset,
+                batch_size=2,
+                sampler=TokenLengthGroupedRandomSampler(
+                    dataset,
+                    sort_buffer_size=4,
                 ),
             )
         )
+        batch_lengths = [
+            [len(example["tokens"]) for example in batch] for batch in batches
+        ]
 
-    def test_data_loader_can_use_sft_batch_and_label_primitives(self):
-        loader = self.make_sft_loader(
-            chat_examples=[
-                {
-                    "messages": [
-                        {"role": "user", "content": "ABC"},
-                        {"role": "assistant", "content": "DE"},
-                    ]
-                }
+        self.assertEqual(batch_lengths, [[2, 3], [7, 8]])
+
+    @patch("autograd.data.dataset.xp.random.permutation")
+    def test_length_grouped_sampler_shuffle_stays_on_cpu(
+        self,
+        backend_permutation,
+    ):
+        backend_permutation.side_effect = AssertionError(
+            "backend permutation should not be used"
+        )
+
+        dataset = make_token_dataset(
+            [
+                xp.arange(2, dtype=xp.int32),
+                xp.arange(8, dtype=xp.int32),
+                xp.arange(3, dtype=xp.int32),
+                xp.arange(7, dtype=xp.int32),
             ],
-            batch_size=1,
-            seq_len=5,
-            shuffle=False,
-        )
-
-        batch = next(iter(loader))
-
-        self.assertIsInstance(batch, CausalLMBatch)
-        self.assertEqual(batch.input_ids.shape, (1, 5))
-        self.assertEqual(batch.labels.shape, (1, 5))
-        self.assertTrue(
-            xp.array_equal(
-                batch.input_ids[0],
-                xp.array([116, 58, 32, 68, 69], dtype=xp.int32),
-            )
-        )
-        self.assertTrue(
-            xp.array_equal(
-                batch.labels[0],
-                xp.array(
-                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, 2],
-                    dtype=xp.int32,
-                ),
-            )
-        )
-
-    def test_sft_dataloader_left_truncates_to_keep_response_tokens(self):
-        loader = self.make_sft_loader(
-            chat_examples=[
-                {
-                    "messages": [
-                        {"role": "user", "content": "ABCD"},
-                        {"role": "assistant", "content": "EFG"},
-                    ]
-                }
+            [
+                xp.ones((2,), dtype=xp.int32),
+                xp.ones((8,), dtype=xp.int32),
+                xp.ones((3,), dtype=xp.int32),
+                xp.ones((7,), dtype=xp.int32),
             ],
-            batch_size=1,
-            seq_len=4,
-            shuffle=False,
+        )
+        sampler = TokenLengthGroupedRandomSampler(
+            dataset,
+            sort_buffer_size=4,
         )
 
-        batch = next(iter(loader))
+        sampler.on_epoch_start()
 
-        self.assertTrue(
-            xp.array_equal(
-                batch.input_ids[0], xp.array([32, 69, 70, 71], dtype=xp.int32)
-            )
-        )
-        self.assertTrue(
-            xp.array_equal(
-                batch.labels[0],
-                xp.array([69, 70, 71, 2], dtype=xp.int32),
-            )
-        )
+        self.assertIsInstance(sampler.indices, list)
+        backend_permutation.assert_not_called()
 
     @patch(
-        "autograd.data.collator.text_utils.create_padding_mask",
+        "autograd.data.collator.create_padding_mask",
         side_effect=mock_padding_mask,
     )
     def test_encoder_decoder_pretraining_loader_output(self, mock_padding):
@@ -500,11 +419,8 @@ class TestDataLoader(unittest.TestCase):
         self.assertEqual(
             batch.decoder_input_ids.shape, (self.batch_size_llm, self.seq_len)
         )
-        self.assertTrue(
-            xp.all(
-                xp.asarray(batch.decoder_input_ids[:, 0] == loader.collate_fn.sos_idx)
-            )
-        )
+        sos_idx = self.bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+        self.assertTrue(xp.all(xp.asarray(batch.decoder_input_ids[:, 0] == sos_idx)))
         self.assertFalse(hasattr(batch, "loss_mask"))
         self.assertEqual(
             batch.src_mask.shape, (self.batch_size_llm, 1, 1, self.seq_len)

--- a/test/autograd/data/test_data_loader.py
+++ b/test/autograd/data/test_data_loader.py
@@ -72,6 +72,14 @@ class BuggyEmptyPassDataset(IterableDataset):
         return 3
 
 
+class ShortPassDataset(IterableDataset):
+    def __iter__(self):
+        return iter(range(2))
+
+    def __len__(self):
+        return 3
+
+
 class TestDataLoader(unittest.TestCase):
     def setUp(self):
         self.X = xp.arange(20).reshape(10, 2)
@@ -217,6 +225,15 @@ class TestDataLoader(unittest.TestCase):
         ):
             next(iter(loader))
 
+    def test_data_loader_rejects_empty_dataset_length(self):
+        loader = DataLoader(EmptyDataset(), batch_size=1)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded no batches",
+        ):
+            len(loader)
+
     def test_data_loader_rejects_dataset_that_yields_nothing_for_pass(self):
         loader = DataLoader(BuggyEmptyPassDataset(), batch_size=2)
 
@@ -225,6 +242,15 @@ class TestDataLoader(unittest.TestCase):
             "DataLoader yielded no batches",
         ):
             next(iter(loader))
+
+    def test_data_loader_rejects_len_iteration_batch_count_mismatch(self):
+        loader = DataLoader(ShortPassDataset(), batch_size=1)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded a different number of batches than len",
+        ):
+            list(loader)
 
     def test_data_loader_rejects_drop_last_when_only_partial_batch_exists(self):
         loader = DataLoader(
@@ -239,6 +265,20 @@ class TestDataLoader(unittest.TestCase):
             "DataLoader yielded no batches",
         ):
             next(iter(loader))
+
+    def test_data_loader_rejects_drop_last_zero_batch_length(self):
+        loader = DataLoader(
+            PairedIterableDataset(self.X[:1], self.y[:1], shuffle=False),
+            batch_size=2,
+            collate_fn=PairedCollator(),
+            drop_last=True,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "DataLoader yielded no batches",
+        ):
+            len(loader)
 
     def test_pretraining_data_loader_on_epoch_start_reseeds_without_crashing(self):
         loader = self.make_pretraining_loader(shuffle=True)

--- a/test/autograd/data/test_dataset.py
+++ b/test/autograd/data/test_dataset.py
@@ -1,16 +1,12 @@
 import unittest
-from types import SimpleNamespace
 
 import pytest
 
 from autograd.backend import xp
 from autograd.data.dataset import (
-    IterableDataset,
-    PairedIterableDataset,
-    Seq2SeqDataset,
-    TokenSequenceDataset,
-    TokenWindowDataset,
-    TransformDataset,
+    MapDataset,
+    PairedMapDataset,
+    TokenWindowMapDataset,
 )
 
 
@@ -19,8 +15,8 @@ class TestDataset(unittest.TestCase):
         self.X = xp.arange(20).reshape(10, 2)
         self.y = xp.arange(10)
 
-    def test_paired_iterable_dataset_yields_single_example(self):
-        dataset = PairedIterableDataset(self.X, self.y, shuffle=False)
+    def test_paired_dataset_yields_single_example(self):
+        dataset = PairedMapDataset(self.X, self.y)
 
         example = next(iter(dataset))
 
@@ -28,58 +24,51 @@ class TestDataset(unittest.TestCase):
         self.assertTrue(xp.array_equal(example["inputs"], self.X[0]))
         self.assertEqual(int(example["targets"]), int(self.y[0]))
 
-    def test_paired_iterable_dataset_shuffle(self):
-        dataset = PairedIterableDataset(self.X, self.y, shuffle=True)
+    def test_map_dataset_iteration_stays_in_stored_order_after_epoch_start(self):
+        dataset = PairedMapDataset(self.X, self.y)
 
         dataset.on_epoch_start()
 
-        self.assertTrue(
-            xp.array_equal(xp.sort(dataset.indices), xp.arange(len(self.X)))
-        )
-
-    def test_transform_dataset_applies_example_transform(self):
-        dataset = TransformDataset(
-            PairedIterableDataset(
-                xp.array([[1, 2], [3, 4]]), xp.array([10, 20]), shuffle=False
-            ),
-            transform=lambda example: {
-                "inputs": example["inputs"] * 2,
-                "targets": example["targets"] * 3,
-            },
-        )
-
         examples = list(dataset)
 
-        self.assertTrue(xp.array_equal(examples[0]["inputs"], xp.array([2, 4])))
-        self.assertEqual(int(examples[0]["targets"]), 30)
-        self.assertTrue(xp.array_equal(examples[1]["inputs"], xp.array([6, 8])))
-        self.assertEqual(int(examples[1]["targets"]), 60)
+        self.assertTrue(xp.array_equal(examples[0]["inputs"], self.X[0]))
+        self.assertEqual(int(examples[0]["targets"]), int(self.y[0]))
 
-    def test_transform_dataset_can_transform_arbitrary_example_shape(self):
-        class DummyDataset(IterableDataset):
-            def __iter__(self):
-                yield {"foo": xp.array([1, 2], dtype=xp.int32)}
-
-            def __len__(self):
-                return 1
-
-        dataset = TransformDataset(
-            DummyDataset(),
-            transform=lambda example: {"bar": example["foo"] + 1},
+    def test_map_dataset_yields_pre_shaped_dicts(self):
+        dataset = MapDataset(
+            [
+                {
+                    "input_ids": xp.array([1, 2], dtype=xp.int32),
+                    "labels": xp.array([3, 4], dtype=xp.int32),
+                }
+            ]
         )
 
-        example = next(iter(dataset))
+        example = dataset[0]
 
-        self.assertEqual(tuple(example.keys()), ("bar",))
+        self.assertEqual(tuple(example.keys()), ("input_ids", "labels"))
         self.assertTrue(
-            xp.array_equal(example["bar"], xp.array([2, 3], dtype=xp.int32))
+            xp.array_equal(example["input_ids"], xp.array([1, 2], dtype=xp.int32))
         )
+        self.assertTrue(
+            xp.array_equal(example["labels"], xp.array([3, 4], dtype=xp.int32))
+        )
+
+    def test_token_window_dataset_is_map_style(self):
+        dataset = TokenWindowMapDataset(
+            xp.arange(10, dtype=xp.int32),
+            window_len=5,
+        )
+
+        self.assertIsInstance(dataset, MapDataset)
 
     def test_seq2seq_dataset_yields_single_example(self):
-        dataset = Seq2SeqDataset(
-            input_sequences=[xp.array([1, 2], dtype=xp.int32)],
-            label_sequences=[xp.array([3, 4], dtype=xp.int32)],
-            shuffle=False,
+        dataset = PairedMapDataset(
+            [xp.array([1, 2])],
+            [xp.array([3, 4])],
+            input_key="input_ids",
+            target_key="labels",
+            dtype=xp.int32,
         )
 
         example = next(iter(dataset))
@@ -92,9 +81,12 @@ class TestDataset(unittest.TestCase):
         )
 
     def test_token_sequence_dataset_yields_single_example(self):
-        dataset = TokenSequenceDataset(
-            token_sequences=[xp.arange(5, dtype=xp.int32)],
-            shuffle=False,
+        dataset = PairedMapDataset(
+            [xp.arange(5, dtype=xp.int32)],
+            [xp.ones((5,), dtype=xp.int32)],
+            input_key="tokens",
+            target_key="loss_mask",
+            dtype=xp.int32,
         )
 
         example = next(iter(dataset))
@@ -105,23 +97,13 @@ class TestDataset(unittest.TestCase):
             xp.array_equal(example["loss_mask"], xp.ones((5,), dtype=xp.int32))
         )
 
-    def test_token_sequence_dataset_requires_token_sequences(self):
-        with self.assertRaises(ValueError):
-            TokenSequenceDataset(shuffle=False)
-
-    def test_token_sequence_dataset_requires_matching_loss_mask_lengths(self):
-        with self.assertRaises(ValueError):
-            TokenSequenceDataset(
-                token_sequences=[xp.arange(5, dtype=xp.int32)],
-                loss_masks=[xp.ones((4,), dtype=xp.int32)],
-                shuffle=False,
-            )
-
     def test_token_sequence_dataset_holds_tokenized_causal_lm_examples(self):
-        dataset = TokenSequenceDataset(
-            token_sequences=[xp.array([65, 66, 67, 2, 68, 69, 2], dtype=xp.int32)],
-            loss_masks=[xp.array([0, 0, 0, 0, 1, 1, 1], dtype=xp.int32)],
-            shuffle=False,
+        dataset = PairedMapDataset(
+            [xp.array([65, 66, 67, 2, 68, 69, 2], dtype=xp.int32)],
+            [xp.array([0, 0, 0, 0, 1, 1, 1], dtype=xp.int32)],
+            input_key="tokens",
+            target_key="loss_mask",
+            dtype=xp.int32,
         )
 
         example = next(iter(dataset))
@@ -140,7 +122,7 @@ class TestDataset(unittest.TestCase):
 
 def test_minimal_token_stream_is_valid():
     data = xp.arange(5, dtype=xp.int32)
-    dataset = TokenWindowDataset(data, window_len=5, sampling="sequential")
+    dataset = TokenWindowMapDataset(data, window_len=5)
 
     examples = list(dataset)
 
@@ -151,93 +133,27 @@ def test_minimal_token_stream_is_valid():
 def test_last_offset_is_included():
     data = xp.arange(10, dtype=xp.int32)
     window_len = 5
-    dataset = TokenWindowDataset(data, window_len=window_len, sampling="sequential")
+    dataset = TokenWindowMapDataset(data, window_len=window_len)
 
     offsets = [example.offset for example in dataset]
 
     assert offsets[-1] == len(data) - window_len
 
 
-def test_token_window_dataset_rejects_unknown_sampling_mode():
-    with pytest.raises(ValueError, match="sampling must be 'random' or 'sequential'"):
-        TokenWindowDataset(
-            xp.arange(5, dtype=xp.int32),
-            window_len=5,
-            sampling="shuffle",
-        )
-
-
 def test_token_window_dataset_rejects_too_short_stream():
     with pytest.raises(ValueError, match="Need at least 6 tokens, got 5"):
-        TokenWindowDataset(
+        TokenWindowMapDataset(
             xp.arange(5, dtype=xp.int32),
             window_len=6,
-            sampling="sequential",
         )
 
 
-def test_token_window_dataset_rejects_zero_offset_buffer_size():
-    with pytest.raises(ValueError, match="offset_buffer_size must be >= 1"):
-        TokenWindowDataset(
-            xp.arange(10, dtype=xp.int32),
-            window_len=5,
-            sampling="random",
-            offset_buffer_size=0,
-        )
+def test_token_window_dataset_maps_offset_to_lazy_example():
+    data = xp.arange(10, dtype=xp.int32)
+    dataset = TokenWindowMapDataset(data, window_len=5)
 
+    example = dataset[3]
 
-@pytest.mark.parametrize("examples_per_epoch", [0, -1])
-def test_token_window_dataset_requires_positive_examples_per_epoch(
-    examples_per_epoch: int,
-):
-    with pytest.raises(
-        ValueError, match="examples_per_epoch must be >= 1 when provided"
-    ):
-        TokenWindowDataset(
-            xp.arange(10, dtype=xp.int32),
-            window_len=5,
-            sampling="random",
-            examples_per_epoch=examples_per_epoch,
-        )
-
-
-def test_token_window_dataset_rejects_examples_per_epoch_for_sequential_sampling():
-    with pytest.raises(
-        ValueError,
-        match="examples_per_epoch is only valid for sampling='random'",
-    ):
-        TokenWindowDataset(
-            xp.arange(10, dtype=xp.int32),
-            window_len=5,
-            sampling="sequential",
-            examples_per_epoch=3,
-        )
-
-
-def test_token_window_dataset_random_offsets_do_not_use_backend_scalar_rng(
-    monkeypatch,
-):
-    dataset = TokenWindowDataset(
-        xp.arange(20, dtype=xp.int32),
-        window_len=5,
-        sampling="random",
-        examples_per_epoch=4,
-        offset_buffer_size=2,
-    )
-    monkeypatch.setattr(
-        "autograd.data.dataset.xp",
-        SimpleNamespace(
-            random=SimpleNamespace(
-                randint=lambda *args, **kwargs: (_ for _ in ()).throw(
-                    AssertionError(
-                        "backend random offsets would require scalar readback"
-                    )
-                ),
-            ),
-        ),
-    )
-
-    offsets = [example.offset for example in dataset]
-
-    assert len(offsets) == 4
-    assert all(0 <= offset < dataset.valid_window_count for offset in offsets)
+    assert example.offset == 3
+    assert example.window_len == 5
+    assert example.stream is dataset.stream

--- a/test/autograd/data/test_sampler.py
+++ b/test/autograd/data/test_sampler.py
@@ -1,0 +1,133 @@
+import pytest
+
+from autograd.backend import xp
+from autograd.data.dataset import PairedMapDataset
+from autograd.data.sampler import (
+    RandomSampler,
+    SequentialSampler,
+    TokenLengthGroupedRandomSampler,
+)
+
+
+def make_token_dataset(token_sequences):
+    return PairedMapDataset(
+        token_sequences,
+        [xp.ones((len(tokens),), dtype=xp.int32) for tokens in token_sequences],
+        input_key="tokens",
+        target_key="loss_mask",
+        dtype=xp.int32,
+    )
+
+
+def test_sequential_sampler_yields_indices_in_order():
+    dataset = make_token_dataset([xp.arange(2), xp.arange(3), xp.arange(4)])
+
+    assert list(SequentialSampler(dataset)) == [0, 1, 2]
+
+
+def test_random_sampler_yields_cpu_permutation():
+    dataset = make_token_dataset([xp.arange(2), xp.arange(3), xp.arange(4)])
+
+    sampler = RandomSampler(dataset)
+
+    assert sorted(sampler) == [0, 1, 2]
+
+
+def test_random_sampler_replacement_respects_num_samples():
+    dataset = make_token_dataset([xp.arange(2), xp.arange(3), xp.arange(4)])
+
+    sampler = RandomSampler(dataset, replacement=True, num_samples=8)
+    indices = list(sampler)
+
+    assert len(sampler) == 8
+    assert len(indices) == 8
+    assert all(0 <= index < len(dataset) for index in indices)
+
+
+def test_random_sampler_without_replacement_respects_num_samples():
+    dataset = make_token_dataset([xp.arange(2), xp.arange(3), xp.arange(4)])
+
+    sampler = RandomSampler(dataset, num_samples=2)
+
+    assert len(sampler) == 2
+    assert len(list(sampler)) == 2
+
+
+def test_random_sampler_rejects_invalid_num_samples():
+    dataset = make_token_dataset([xp.arange(2)])
+
+    with pytest.raises(ValueError, match="num_samples must be >= 1"):
+        RandomSampler(dataset, num_samples=0)
+
+
+def test_random_sampler_rejects_empty_dataset():
+    with pytest.raises(ValueError, match="requires a non-empty dataset"):
+        RandomSampler(PairedMapDataset([], []))
+
+
+def test_sequential_sampler_requires_map_style_dataset():
+    class NonMapDataset:
+        def __iter__(self):
+            return iter(())
+
+    with pytest.raises(TypeError, match="SequentialSampler requires MapDataset"):
+        SequentialSampler(NonMapDataset())
+
+
+def test_length_grouped_sampler_shuffles_then_sorts_local_buffers(monkeypatch):
+    dataset = make_token_dataset(
+        [
+            xp.arange(2, dtype=xp.int32),
+            xp.arange(8, dtype=xp.int32),
+            xp.arange(3, dtype=xp.int32),
+            xp.arange(7, dtype=xp.int32),
+        ]
+    )
+
+    def fixed_shuffle(indices):
+        indices[:] = [1, 0, 3, 2]
+
+    monkeypatch.setattr("autograd.data.sampler.np.random.shuffle", fixed_shuffle)
+    sampler = TokenLengthGroupedRandomSampler(
+        dataset,
+        sort_buffer_size=2,
+    )
+
+    assert list(sampler) == [0, 1, 2, 3]
+
+
+def test_length_grouped_sampler_requires_sort_buffer_size():
+    with pytest.raises(TypeError, match="required keyword-only argument"):
+        TokenLengthGroupedRandomSampler(
+            make_token_dataset([xp.arange(2), xp.arange(3)]),
+        )
+
+
+def test_length_grouped_sampler_rejects_shuffle_arg():
+    with pytest.raises(TypeError, match="unexpected keyword argument 'shuffle'"):
+        TokenLengthGroupedRandomSampler(
+            make_token_dataset([xp.arange(2), xp.arange(3)]),
+            shuffle=True,
+            sort_buffer_size=2,
+        )
+
+
+def test_length_grouped_sampler_rejects_invalid_sort_buffer():
+    with pytest.raises(ValueError, match="sort_buffer_size must be >= 1"):
+        TokenLengthGroupedRandomSampler(
+            make_token_dataset([xp.arange(2), xp.arange(3)]),
+            sort_buffer_size=0,
+        )
+
+
+def test_length_grouped_sampler_requires_map_dataset():
+    with pytest.raises(TypeError, match="requires MapDataset"):
+        TokenLengthGroupedRandomSampler([10, 20], sort_buffer_size=2)
+
+
+def test_length_grouped_sampler_requires_tokens_field():
+    with pytest.raises(ValueError, match="requires examples with a 'tokens' field"):
+        TokenLengthGroupedRandomSampler(
+            PairedMapDataset([xp.arange(2)], [xp.arange(2)]),
+            sort_buffer_size=2,
+        )

--- a/test/autograd/data/test_utils.py
+++ b/test/autograd/data/test_utils.py
@@ -25,9 +25,21 @@ class MockBPE:
                 return [1]
             if token == "<|endoftext|>":
                 return [2]
-        if token == "<|endoftext|>":
+        special_token = "<|endoftext|>"
+        if token == special_token:
             return [2]
-        return [ord(char) for char in token]
+
+        encoded = []
+        start = 0
+        while True:
+            special_index = token.find(special_token, start)
+            if special_index == -1:
+                encoded.extend(ord(char) for char in token[start:])
+                break
+            encoded.extend(ord(char) for char in token[start:special_index])
+            encoded.append(2)
+            start = special_index + len(special_token)
+        return encoded
 
 
 class TestDataUtils(unittest.TestCase):

--- a/test/autograd/data/test_utils.py
+++ b/test/autograd/data/test_utils.py
@@ -6,7 +6,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from autograd.backend import xp
-from autograd.data.dataset import Seq2SeqDataset
+from autograd.data.dataset import PairedMapDataset
 from autograd.data.utils import (
     build_seq2seq_dataset_from_text_pairs,
     load_data,
@@ -142,11 +142,10 @@ class TestDataUtils(unittest.TestCase):
         dataset = build_seq2seq_dataset_from_text_pairs(
             [("ABC", "DE")],
             self.bpe,
-            shuffle=False,
             target_suffix="<|endoftext|>",
         )
 
-        self.assertIsInstance(dataset, Seq2SeqDataset)
+        self.assertIsInstance(dataset, PairedMapDataset)
         example = next(iter(dataset))
         self.assertTrue(
             xp.array_equal(example["input_ids"], xp.array([65, 66, 67], dtype=xp.int32))

--- a/test/autograd/performance_test.py
+++ b/test/autograd/performance_test.py
@@ -11,7 +11,13 @@ import psutil
 from autograd import functional, nn, optim
 from autograd.backend import IS_CUPY, NAME, xp
 from autograd.backend import eval as backend_eval
-from autograd.data.collator import CausalLMCollator, PairedCollator
+from autograd.data.collator import (
+    CausalLMCollator,
+    PairedCollator,
+    build_causal_lm_inputs_and_labels,
+    pad_aligned_right,
+    truncate_aligned_left,
+)
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import PairedIterableDataset, TokenSequenceDataset
 from autograd.tensor import Tensor
@@ -368,12 +374,18 @@ class CIPipelinePerformanceTest(TestCase):
         loader = DataLoader(
             dataset=TokenSequenceDataset(
                 token_sequences=token_sequences,
+                loss_masks=[
+                    xp.ones((seq_len + 1,), dtype=xp.int32) for _ in range(batch_size)
+                ],
                 shuffle=False,
             ),
             batch_size=batch_size,
             collate_fn=CausalLMCollator(
                 max_tokens=seq_len + 1,
                 pad_idx=0,
+                truncator=truncate_aligned_left,
+                padder=pad_aligned_right,
+                label_builder=build_causal_lm_inputs_and_labels,
             ),
         )
         batch = next(iter(loader))

--- a/test/autograd/performance_test.py
+++ b/test/autograd/performance_test.py
@@ -11,15 +11,9 @@ import psutil
 from autograd import functional, nn, optim
 from autograd.backend import IS_CUPY, NAME, xp
 from autograd.backend import eval as backend_eval
-from autograd.data.collator import (
-    CausalLMCollator,
-    PairedCollator,
-    build_causal_lm_inputs_and_labels,
-    pad_aligned_right,
-    truncate_aligned_left,
-)
+from autograd.data.collator import FixedLengthCausalLMCollator, PairedCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import PairedIterableDataset, TokenSequenceDataset
+from autograd.data.dataset import PairedMapDataset
 from autograd.tensor import Tensor
 from examples.gpt_2 import GPT2
 
@@ -348,9 +342,9 @@ class CIPipelinePerformanceTest(TestCase):
             dtype=xp.int64,
         )
         loader = DataLoader(
-            dataset=PairedIterableDataset(inputs, targets, shuffle=False),
+            dataset=PairedMapDataset(inputs, targets),
             batch_size=input_shape[0],
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
         )
         batch_inputs, batch_targets = next(iter(loader))
         return (
@@ -372,20 +366,17 @@ class CIPipelinePerformanceTest(TestCase):
             for _ in range(batch_size)
         ]
         loader = DataLoader(
-            dataset=TokenSequenceDataset(
-                token_sequences=token_sequences,
-                loss_masks=[
-                    xp.ones((seq_len + 1,), dtype=xp.int32) for _ in range(batch_size)
-                ],
-                shuffle=False,
+            dataset=PairedMapDataset(
+                token_sequences,
+                [xp.ones((seq_len + 1,), dtype=xp.int32) for _ in range(batch_size)],
+                input_key="tokens",
+                target_key="loss_mask",
+                dtype=xp.int32,
             ),
             batch_size=batch_size,
-            collate_fn=CausalLMCollator(
+            collator=FixedLengthCausalLMCollator(
                 max_tokens=seq_len + 1,
                 pad_idx=0,
-                truncator=truncate_aligned_left,
-                padder=pad_aligned_right,
-                label_builder=build_causal_lm_inputs_and_labels,
             ),
         )
         batch = next(iter(loader))

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -9,7 +9,8 @@ from autograd import functional, nn, optim
 from autograd.backend import xp
 from autograd.data.collator import PairedCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import PairedIterableDataset
+from autograd.data.dataset import PairedMapDataset
+from autograd.data.sampler import RandomSampler
 from autograd.tools.config_schema import GenericTrainingConfig
 from autograd.tools.metrics import accuracy, mean_squared_error
 from autograd.tools.trainer import SimpleTrainer
@@ -95,10 +96,12 @@ class TestTrain(TestCase):
                 "lr": 1e-3,
             },
         )
+        train_dataset = PairedMapDataset(X, y)
         train_data_loader = DataLoader(
-            PairedIterableDataset(X, y, shuffle=True),
+            train_dataset,
             batch_size=32,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
+            sampler=RandomSampler(train_dataset),
         )
         trainer = SimpleTrainer(
             model_cls=Classifier,
@@ -142,10 +145,12 @@ class TestTrain(TestCase):
         X = (X - X.mean(axis=0)) / (X.std(axis=0) + eps)
         y = (y - y.mean()) / (y.std() + eps)
 
+        train_dataset = PairedMapDataset(X, y)
         train_data_loader = DataLoader(
-            PairedIterableDataset(X, y, shuffle=True),
+            train_dataset,
             batch_size=32,
-            collate_fn=PairedCollator(),
+            collator=PairedCollator(),
+            sampler=RandomSampler(train_dataset),
         )
 
         trainer = SimpleTrainer(

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -6,7 +6,6 @@ from autograd.backend import xp
 from autograd.text.utils import (
     clean_and_tokenize,
     create_causal_mask,
-    create_padding_mask,
     create_vocabulary,
     inference,
     text_to_one_hot_and_sparse,
@@ -78,37 +77,6 @@ class TestTextUtils(TestCase):
         pad_idx = vocab["<PAD>"]
         # "I love apples" => 3 words => last index should be pad_idx
         self.assertEqual(matrix[0, 3], pad_idx)
-
-    def test_create_padding_mask_default_dims(self):
-        token_indices = xp.array(
-            [
-                [1, 2, 0, 0],  # 0 => pad
-                [3, 4, 5, 0],
-            ],
-            dtype=xp.int32,
-        )
-
-        mask = create_padding_mask(token_indices, pad_idx=0, dims=None)
-        # shape => (batch_size=2, 1, 1, seq_len=4)
-        self.assertEqual(mask.shape, (2, 1, 1, 4))
-
-        # 1.0 where token_indices==0
-        # first row => positions 2,3 are 1
-        assert xp.array_equal(mask[0, 0, 0], xp.array([0, 0, 1, 1]))
-        assert xp.array_equal(mask[1, 0, 0], xp.array([0, 0, 0, 1]))
-
-    def test_create_padding_mask_custom_dims(self):
-        token_indices = xp.array([[1, 0, 0], [2, 2, 0]], dtype=xp.int32)
-
-        # Suppose we want dims = (batch_size, 1, 3)
-        # i.e. (2, 1, 3) => effectively shape for broadcasting
-        mask = create_padding_mask(token_indices, pad_idx=0, dims=(2, 1, 3))
-
-        self.assertEqual(mask.shape, (2, 1, 3))
-        # For first row => [1,0,0] => pad=0 => positions 1,2 => mask=1 => [0,1,1]
-        assert xp.array_equal(mask[0, 0], xp.array([0, 1, 1]))
-        # For second row => [2,2,0] => only last is 0 => [0,0,1]
-        assert xp.array_equal(mask[1, 0], xp.array([0, 0, 1]))
 
     def test_create_causal_mask_lookforward(self):
         seq_len = 4

--- a/test/autograd/tools/test_config_schema.py
+++ b/test/autograd/tools/test_config_schema.py
@@ -20,20 +20,18 @@ class TestTransformerTrainingConfig(TestCase):
                 teacher_forcing=False,
             )
 
-    def test_rejects_checkpoint_before_gradient_accumulation_boundary(self):
-        with self.assertRaisesRegex(
-            ValueError,
-            "checkpoint_freq must be divisible by gradient_accumulation_steps",
-        ):
-            TransformerTrainingConfig(
-                training_run_name="test",
-                dataset_name="dataset",
-                max_steps=5,
-                checkpoint_freq=5,
-                global_batch_size=32,
-                micro_batch_size=4,
-                model_kwargs={},
-                optimizer_kwargs={"lr": 1e-3},
-                label_smoothing=0.0,
-                teacher_forcing=False,
-            )
+    def test_allows_checkpoint_frequency_before_accumulation_boundary(self):
+        config = TransformerTrainingConfig(
+            training_run_name="test",
+            dataset_name="dataset",
+            max_steps=5,
+            checkpoint_freq=5,
+            global_batch_size=32,
+            micro_batch_size=4,
+            model_kwargs={},
+            optimizer_kwargs={"lr": 1e-3},
+            label_smoothing=0.0,
+            teacher_forcing=False,
+        )
+
+        self.assertEqual(config.gradient_accumulation_steps, 8)

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -5,19 +5,9 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from autograd.backend import xp
-from autograd.data.collator import (
-    CausalLMCollator,
-    CausalLMWindowCollator,
-    build_causal_lm_inputs_and_labels,
-    pad_aligned_right,
-    truncate_aligned_left,
-)
+from autograd.data.collator import FixedLengthCausalLMCollator
 from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import (
-    IterableDataset,
-    TokenSequenceDataset,
-    TokenWindowDataset,
-)
+from autograd.data.dataset import MapDataset, PairedMapDataset
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch
 from autograd.functional import IGNORE_INDEX, cross_entropy
 from autograd.nn import AbstractLLMForwardFn, Module
@@ -43,41 +33,20 @@ def identity_collate(batch_items):
     return batch_items[0]
 
 
-class InMemoryBatchDataset(IterableDataset):
+class InMemoryBatchDataset(MapDataset):
     def __init__(self, data):
-        self.data = data
+        super().__init__(data)
         self.epoch_start_calls = 0
 
     def on_epoch_start(self):
         self.epoch_start_calls += 1
-
-    def __iter__(self):
-        return iter(self.data)
-
-    def __len__(self):
-        return len(self.data)
-
-
-class UnsizedInfiniteDataset(IterableDataset):
-    def __len__(self):
-        raise TypeError("infinite")
-
-    def __iter__(self):
-        raise RuntimeError(
-            "fit should reject unsized infinite loaders before iterating"
-        )
-
-
-class UnsizedEmptyPassDataset(IterableDataset):
-    def __iter__(self):
-        return iter(())
 
 
 def make_data_loader(data):
     return DataLoader(
         dataset=InMemoryBatchDataset(data),
         batch_size=1,
-        collate_fn=identity_collate,
+        collator=identity_collate,
     )
 
 
@@ -1078,30 +1047,13 @@ class TestSimpleTrainer(BaseTrainerTest):
         checkpoint = mock_save_checkpoint.call_args.args[0]
         self.assertEqual(checkpoint["step_count"], 2)
 
-    def test_fit_requires_max_steps_for_unsized_infinite_train_loader(self):
-        self.config.max_epochs = 1
-        self.config.max_steps = None
-
-        with self.assertRaisesRegex(
-            ValueError,
-            "Infinite training loaders require max_steps",
-        ):
-            self.trainer.fit(
-                DataLoader(
-                    dataset=UnsizedInfiniteDataset(),
-                    batch_size=1,
-                    collate_fn=identity_collate,
-                ),
-                self.val_loader,
-            )
-
     def test_fit_step_mode_rejects_loader_that_yields_no_batches(self):
         self.config.max_epochs = None
         self.config.max_steps = 1
         empty_loader = DataLoader(
-            dataset=UnsizedEmptyPassDataset(),
+            dataset=MapDataset([]),
             batch_size=1,
-            collate_fn=identity_collate,
+            collator=identity_collate,
         )
 
         with self.assertRaisesRegex(
@@ -1744,18 +1696,17 @@ class TestLLMTrainer(BaseTrainerTest):
         bpe = MockBPE()
         pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
         loader = DataLoader(
-            dataset=TokenSequenceDataset(
-                token_sequences=[xp.array([65, 66, 67, 2, 67, 66, 2], dtype=xp.int32)],
-                loss_masks=[xp.array([0, 0, 0, 0, 1, 1, 1], dtype=xp.int32)],
-                shuffle=False,
+            dataset=PairedMapDataset(
+                [xp.array([65, 66, 67, 2, 67, 66, 2], dtype=xp.int32)],
+                [xp.array([0, 0, 0, 0, 1, 1, 1], dtype=xp.int32)],
+                input_key="tokens",
+                target_key="loss_mask",
+                dtype=xp.int32,
             ),
             batch_size=1,
-            collate_fn=CausalLMCollator(
+            collator=FixedLengthCausalLMCollator(
                 max_tokens=6,
                 pad_idx=pad_idx,
-                truncator=truncate_aligned_left,
-                padder=pad_aligned_right,
-                label_builder=build_causal_lm_inputs_and_labels,
             ),
         )
         trainer = LLMTrainer(
@@ -1789,29 +1740,3 @@ class TestLLMTrainer(BaseTrainerTest):
             float(train_loss.item()), float(expected_loss.item()), places=6
         )
         self.assertAlmostEqual(val_loss.val_loss, float(expected_loss.item()), places=6)
-
-    def test_fit_supports_unsized_streaming_data_loaders(self):
-        self.config.max_epochs = None
-        self.config.max_steps = 1
-        self.config.max_eval_steps = 1
-
-        stream_loader = DataLoader(
-            dataset=TokenWindowDataset(
-                xp.arange(100, dtype=xp.int32),
-                window_len=5,
-                sampling="sequential",
-            ),
-            batch_size=2,
-            collate_fn=CausalLMWindowCollator(),
-        )
-        trainer = LLMTrainer(
-            model_cls=MockModelClass,
-            optimizer_cls=MockOptimizerClass,
-            loss_fn=cross_entropy,
-            forward_fn=PromptMaskAwareForwardFn(),
-            config=self.config,
-        )
-
-        trainer.fit(stream_loader, stream_loader)
-
-        self.assertEqual(trainer.optimizer.step_call_count, 1)

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -5,7 +5,13 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from autograd.backend import xp
-from autograd.data.collator import CausalLMCollator, CausalLMWindowCollator
+from autograd.data.collator import (
+    CausalLMCollator,
+    CausalLMWindowCollator,
+    build_causal_lm_inputs_and_labels,
+    pad_aligned_right,
+    truncate_aligned_left,
+)
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import (
     IterableDataset,
@@ -13,10 +19,6 @@ from autograd.data.dataset import (
     TokenWindowDataset,
 )
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch
-from autograd.data.utils import (
-    openai_chat_to_prompt_completion,
-    tokenize_prompt_completion,
-)
 from autograd.functional import IGNORE_INDEX, cross_entropy
 from autograd.nn import AbstractLLMForwardFn, Module
 from autograd.optim import SGD, Optimizer
@@ -175,7 +177,23 @@ class MockBPE:
                 return [0]
             if token == "<SOS>":
                 return [1]
-        return [ord(char) for char in token]
+            if token == "<|endoftext|>":
+                return [2]
+        special_token = "<|endoftext|>"
+        if token == special_token:
+            return [2]
+
+        encoded = []
+        start = 0
+        while True:
+            special_index = token.find(special_token, start)
+            if special_index == -1:
+                encoded.extend(ord(char) for char in token[start:])
+                break
+            encoded.extend(ord(char) for char in token[start:special_index])
+            encoded.append(2)
+            start = special_index + len(special_token)
+        return encoded
 
 
 class FakeTqdm:
@@ -468,6 +486,37 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertEqual(mock_tqdm.call_args.kwargs["desc"], "Training")
         self.assertEqual(sum(progress_bar.updates), 3)
         self.assertEqual(progress_bar.postfixes, [])
+
+    @patch("autograd.tools.trainer.tqdm")
+    def test_fit_updates_progress_after_accumulation_optimizer_step(self, mock_tqdm):
+        config = GenericTrainingConfig(
+            max_steps=2,
+            checkpoint_freq=10,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=2,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+        update_optimizer_counts = []
+
+        class RecordingProgress(FakeTqdm):
+            def update(self, n=1):
+                super().update(n)
+                update_optimizer_counts.append(trainer.optimizer.step_call_count)
+
+        mock_tqdm.return_value = RecordingProgress()
+        train_loader = make_data_loader(self.train_data)
+
+        trainer.fit(train_loader)
+
+        self.assertEqual(update_optimizer_counts, [0, 1])
 
     def test_fit_does_not_call_tensor_item_for_train_loss_each_batch(self):
         self.config.max_epochs = None
@@ -1613,30 +1662,22 @@ class TestLLMTrainer(BaseTrainerTest):
         self.assertAlmostEqual(avg_val_loss.val_loss, 1.23, places=5)
         self.assertEqual(self.loss_fn.call_count, 1)
 
-    def test_compute_loss_supports_sft_batches_from_generic_data_loader(self):
+    def test_compute_loss_supports_prompt_masked_causal_lm_batches(self):
         bpe = MockBPE()
         pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
-        tokenized_example = tokenize_prompt_completion(
-            openai_chat_to_prompt_completion(
-                {
-                    "messages": [
-                        {"role": "user", "content": "ABC"},
-                        {"role": "assistant", "content": "CB"},
-                    ]
-                }
-            ),
-            bpe,
-        )
         loader = DataLoader(
             dataset=TokenSequenceDataset(
-                token_sequences=[tokenized_example["tokens"]],
-                loss_masks=[tokenized_example["loss_mask"]],
+                token_sequences=[xp.array([65, 66, 67, 2, 67, 66, 2], dtype=xp.int32)],
+                loss_masks=[xp.array([0, 0, 0, 0, 1, 1, 1], dtype=xp.int32)],
                 shuffle=False,
             ),
             batch_size=1,
             collate_fn=CausalLMCollator(
                 max_tokens=6,
                 pad_idx=pad_idx,
+                truncator=truncate_aligned_left,
+                padder=pad_aligned_right,
+                label_builder=build_causal_lm_inputs_and_labels,
             ),
         )
         trainer = LLMTrainer(

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -421,7 +421,8 @@ class TestSimpleTrainer(BaseTrainerTest):
         )
         plan = TrainingPlan.for_epochs(
             max_epochs=self.config.max_epochs,
-            steps_per_epoch=len(self.train_loader),
+            batch_count=len(self.train_loader),
+            accumulation_steps=self.config.gradient_accumulation_steps,
             checkpoint_every=self.config.checkpoint_freq,
         )
         eval_state = TrainingState()
@@ -516,7 +517,7 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         trainer.fit(train_loader)
 
-        self.assertEqual(update_optimizer_counts, [0, 1])
+        self.assertEqual(update_optimizer_counts, [1, 2])
 
     def test_fit_does_not_call_tensor_item_for_train_loss_each_batch(self):
         self.config.max_epochs = None
@@ -1003,7 +1004,7 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         trainer.fit(self.train_loader, self.val_loader)
 
-        self.assertEqual(trainer.optimizer.step_call_count, 1)
+        self.assertEqual(trainer.optimizer.step_call_count, 2)
 
     def test_fit_restarts_epoch_lifecycle_when_step_budget_exhausts_loader(self):
         self.config.max_epochs = None
@@ -1036,8 +1037,46 @@ class TestSimpleTrainer(BaseTrainerTest):
         trainer.fit(train_loader)
 
         self.assertEqual(trainer.global_step, 3)
-        self.assertEqual(trainer.optimizer.step_call_count, 2)
-        self.assertEqual(train_loader.dataset.epoch_start_calls, 2)
+        self.assertEqual(trainer.optimizer.step_call_count, 3)
+        self.assertEqual(train_loader.dataset.epoch_start_calls, 3)
+
+    @patch("autograd.tools.trainer.save_checkpoint")
+    def test_fit_reports_after_final_partial_optimizer_step(self, mock_save_checkpoint):
+        mock_save_checkpoint.return_value = (
+            "checkpoints/default_MockModelClass_2.json",
+            "checkpoints/default_MockModelClass_2.npz",
+        )
+        config = GenericTrainingConfig(
+            max_steps=2,
+            checkpoint_freq=2,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=4,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+        eval_observed_step_counts = []
+
+        def record_eval(_):
+            eval_observed_step_counts.append(trainer.optimizer.step_call_count)
+            eval_state = TrainingState()
+            eval_state.record_eval_loss(1.23)
+            return eval_state
+
+        trainer._evaluate = MagicMock(side_effect=record_eval)
+        train_loader = make_data_loader(self.train_data * 2 + self.val_data)
+
+        trainer.fit(train_loader, self.val_loader)
+
+        self.assertEqual(eval_observed_step_counts, [2])
+        checkpoint = mock_save_checkpoint.call_args.args[0]
+        self.assertEqual(checkpoint["step_count"], 2)
 
     def test_fit_requires_max_steps_for_unsized_infinite_train_loader(self):
         self.config.max_epochs = 1
@@ -1114,7 +1153,30 @@ class TestSimpleTrainer(BaseTrainerTest):
         trainer.fit(train_loader)
 
         self.assertEqual(trainer.global_step, 40)
-        self.assertEqual(trainer.optimizer.step_call_count, 10)
+        self.assertEqual(trainer.optimizer.step_call_count, 40)
+
+    def test_fit_max_steps_counts_optimizer_steps_with_accumulation(self):
+        config = GenericTrainingConfig(
+            max_steps=3,
+            checkpoint_freq=10,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=2,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+        train_loader = make_data_loader(self.train_data * 3)
+
+        trainer.fit(train_loader)
+
+        self.assertEqual(trainer.global_step, 3)
+        self.assertEqual(trainer.optimizer.step_call_count, 3)
 
     def test_fit_flushes_leftover_gradients_at_epoch_end(self):
         config = GenericTrainingConfig(
@@ -1427,7 +1489,8 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.trainer.global_step = len(self.train_loader)
         plan = TrainingPlan.for_epochs(
             max_epochs=self.config.max_epochs,
-            steps_per_epoch=len(self.train_loader),
+            batch_count=len(self.train_loader),
+            accumulation_steps=self.config.gradient_accumulation_steps,
             checkpoint_every=self.config.checkpoint_freq,
         )
         state = TrainingState()
@@ -1452,7 +1515,8 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.trainer.global_step = len(self.train_loader)
         plan = TrainingPlan.for_epochs(
             max_epochs=self.config.max_epochs,
-            steps_per_epoch=len(self.train_loader),
+            batch_count=len(self.train_loader),
+            accumulation_steps=self.config.gradient_accumulation_steps,
             checkpoint_every=self.config.checkpoint_freq,
         )
         state = TrainingState()
@@ -1501,7 +1565,8 @@ class TestSimpleTrainer(BaseTrainerTest):
     def test_fit_plan_derives_epoch_mode_fields_from_config(self):
         plan = TrainingPlan.for_epochs(
             max_epochs=self.config.max_epochs,
-            steps_per_epoch=len(self.train_loader),
+            batch_count=len(self.train_loader),
+            accumulation_steps=self.config.gradient_accumulation_steps,
             checkpoint_every=self.config.checkpoint_freq,
         )
 
@@ -1514,6 +1579,19 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertEqual(plan.checkpoint_every, self.config.checkpoint_freq)
         self.assertEqual(plan.steps_per_epoch, len(self.train_loader))
         self.assertEqual(plan.metrics_interval, 1)
+
+    def test_fit_plan_converts_epochs_to_optimizer_steps_with_accumulation(self):
+        plan = TrainingPlan.for_epochs(
+            max_epochs=3,
+            batch_count=5,
+            accumulation_steps=2,
+            checkpoint_every=1,
+        )
+
+        self.assertEqual(plan.steps_per_epoch, 3)
+        self.assertEqual(plan.target_step, 9)
+        self.assertEqual(plan.report_every_steps, 3)
+        self.assertEqual(plan.completed_epochs(6), 2)
 
     def test_evaluate_does_not_mutate_trainer_metrics(self):
         eval_result = self.trainer.evaluate(self.val_loader)


### PR DESCRIPTION
## Description
### 1. Properly draw the boundary between Data Loader, Collator, Sampler (newly introduced), Dataset and Trainer.

- Datasets provide examples
- Samplers provide order (yield indices)
- DataLoader groups the examples together based on the order provided by Samplers. This is more of an orchestrator of Sampler and Collators. 
- Collator creates the batch-time shaping. Given N examples in a particular order, what exact batch object should the model/trainer use
- Trainer consumes batches, not construct them

Significantly cut down on duplicate responsibilities and unclear boundaries.

### 2. fix max_steps counts micro-batches, should be aligned with optimizer steps instead. 
Example:
```
max_steps = 64
micro_batch_size = 4
global_batch_size = 32
gradient_accumulation_steps = 32 / 4 = 8
```

| Concept | Before | After |
|---|---|---|
| One forward/backward pass | 1 micro-batch | 1 micro-batch |
| global_step += 1 | After every micro-batch | After every optimizer.step() |
| optimizer.step() | Every 8 micro-batches | Every 8 micro-batches |
| max_steps = 64 means | 64 micro-batches | 64 optimizer updates |
| Forward/backward passes | 64 | 64 × 8 = 512 |
| Micro-batches processed | 64 | 512 |
| Examples seen | 64 × 4 = 256 | 512 × 4 = 2048 |
| Optimizer updates | 64 ÷ 8 = 8 | 64 |

## Tests
Updated unit tests.


