### PR TITLE
Fix dtype promotion and MLX training materialization

### DIFF
--- a/autograd/backend.py
+++ b/autograd/backend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import numpy as _host_np
@@ -81,28 +81,45 @@ LOW_PRECISION_FLOAT_DTYPES = tuple(
 # ---------------------------------------------------------------------------
 
 
-def eval(*xs: Any) -> None:
-    if IS_MLX and xs:
-        xp.eval(*xs)
+def _collect_arrays(value: Any) -> list[Any]:
+    if isinstance(value, ARRAY_TYPE):
+        return [value]
+
+    data = getattr(value, "data", None)
+    if isinstance(data, ARRAY_TYPE):
+        return [data]
+
+    if isinstance(value, Mapping):
+        arrays = []
+        for child in value.values():
+            arrays.extend(_collect_arrays(child))
+        return arrays
+
+    if isinstance(value, (list, tuple)):
+        arrays = []
+        for child in value:
+            arrays.extend(_collect_arrays(child))
+        return arrays
+
+    return []
 
 
-def eval_backend(*values: Any) -> None:
+def materialize(*values: Any) -> None:
+    """Force pending backend work at explicit execution boundaries.
+
+    For MLX this evaluates lazy arrays. For eager backends this is a no-op.
+    Accepts arrays, Tensor wrappers, dicts, lists, tuples, and nested mixtures.
+    Python scalars / None are ignored.
     """
-    Force MLX's lazy parameter/state updates at optimizer-step boundaries.
-
-    Without this explicit boundary, update graphs can be evaluated later at
-    less predictable synchronization points such as scalar reads or checkpoints.
-    """
-    if not IS_MLX:
+    if not IS_MLX or not values:
         return
 
-    from mlx.utils import tree_map
+    arrays: list[Any] = []
+    for value in values:
+        arrays.extend(_collect_arrays(value))
 
-    def unwrap_tensor(value: Any) -> Any:
-        data = getattr(value, "data", None)
-        return data if hasattr(data, "shape") else value
-
-    eval(tree_map(unwrap_tensor, values))
+    if arrays:
+        xp.eval(*arrays)
 
 
 def _scatter_add(dst: Any, idx: Any, updates: Any):
@@ -116,7 +133,7 @@ def _scatter_add(dst: Any, idx: Any, updates: Any):
 def _to_scalar(x: Any) -> Any:
     if hasattr(x, "detach") and hasattr(x, "cpu"):
         return x.detach().cpu().item()
-    eval(x)
+    materialize(x)
     return x.item() if hasattr(x, "item") else x
 
 
@@ -139,7 +156,7 @@ def _to_numpy(x: Any):
     if hasattr(x, "detach") and hasattr(x, "cpu"):
         return x.detach().cpu().numpy()
     if IS_MLX:
-        eval(x)
+        materialize(x)
         return _host_np.asarray(x)
     if IS_CUPY:
         if hasattr(xp, "asnumpy"):

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -1510,18 +1510,15 @@ class Dropout(Module):
             >>> x = Tensor(xp.ones((2, 2)))
             >>> y = dropout(x) # Approximately half of the values in y should be zero
         """
-        if self._is_training:
-            mask = xp.random.bernoulli(float(1 - self.p), shape=x.data.shape)
-            return (
-                x
-                * Tensor(mask, requires_grad=False)
-                / (
-                    1 - self.p
-                )  # we scale the output by 1/(1-p) to keep the expected output the same
-                if self.p < 1
-                else x * 0  # when p=1, drop everything by multiplying by 0
-            )
-        return x
+        if not self._is_training or self.p == 0:
+            return x
+
+        if self.p >= 1:
+            return x * 0
+
+        keep_prob = float(1 - self.p)
+        mask = xp.random.bernoulli(keep_prob, shape=x.data.shape).astype(x.data.dtype)
+        return x * Tensor(mask, requires_grad=False) / keep_prob
 
 
 class ScaledDotProductAttention(Module):

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -2,9 +2,9 @@ import logging
 import math
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict, Optional
 
-from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, eval_backend, xp
+from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, materialize, xp
 from autograd.tensor import Tensor
 
 logger = logging.getLogger(__name__)
@@ -216,33 +216,6 @@ class Optimizer:
         if self.lr_scheduler is not None:
             self.lr = self.lr_scheduler(self.timestep, self.initial_lr, self.lr)
 
-    def _recursive_param_op(
-        self, params: Any, update_fn: Callable[[Any], None]
-    ) -> None:
-        """
-        Recursively apply an update function to parameters.
-
-        This method traverses nested dictionaries, lists, or tuples of parameters,
-        and applies the update function to each parameter that has a 'grad' attribute.
-
-        Args:
-            params (Any): The parameters to update; can be a dict, list, tuple, or a single parameter.
-            update_fn (Callable[[Any], None]): The function to apply to each parameter.
-        """
-        # 1) If params is a dict
-        if isinstance(params, dict):
-            for _, v in params.items():
-                self._recursive_param_op(v, update_fn)
-
-        # 2) If params is a list or tuple
-        elif isinstance(params, (list, tuple)):
-            for p in params:
-                self._recursive_param_op(p, update_fn)
-
-        # 3) If params is a single parameter with a .grad
-        elif hasattr(params, "grad"):
-            update_fn(params)
-
     def clip_grad_norm(
         self,
         max_norm: float,
@@ -291,10 +264,8 @@ class Optimizer:
         Set the gradients of all optimized tensors to zero.
         """
 
-        def update_fn(x: Any) -> None:
-            x.grad = None
-
-        self._recursive_param_op(self.model_parameters, update_fn)
+        for param in self.model_parameters.values():
+            param.grad = None
 
     def scale_gradients(self, scale: Array) -> None:
         """Scale all parameter gradients in-place by ``scale``."""
@@ -309,6 +280,14 @@ class Optimizer:
             if param.grad is not None:
                 grad_norm += (param.grad.data**2).sum()
         return float(xp.to_scalar(grad_norm**0.5))
+
+    def gradient_arrays(self) -> Dict[str, Array]:
+        """Current accumulated gradient arrays, keyed by parameter name."""
+        return {
+            name: param.grad.data
+            for name, param in self.model_parameters.items()
+            if param.grad is not None
+        }
 
     def state_dict(self) -> Dict[str, Any]:
         """
@@ -373,9 +352,6 @@ class Optimizer:
         """
         raise NotImplementedError
 
-    def _eval_backend(self) -> None:
-        eval_backend(self.model_parameters, self._states)
-
 
 class SGD(Optimizer):
     """
@@ -408,8 +384,9 @@ class SGD(Optimizer):
                 return
             param.data -= self.lr * param.grad.data
 
-        self._recursive_param_op(self.model_parameters, update_fn)
-        self._eval_backend()
+        for param in self.model_parameters.values():
+            update_fn(param)
+        materialize(self.model_parameters, self._states)
         return None
 
 
@@ -483,7 +460,7 @@ class Adam(Optimizer):
             m_old = self._states["m"][name]
             v_old = self._states["v"][name]
 
-            grad = param.grad.data  # or param.grad if it's np array
+            grad = param.grad.data
 
             # For mixed precision, keep Adam statistics in fp32 for stability.
             param_dtype = param.data.dtype
@@ -510,5 +487,5 @@ class Adam(Optimizer):
             # For mixed precision, return to the param_dtype so the following dense ops stay low precision.
             if param_dtype in LOW_PRECISION_FLOAT_DTYPES:
                 param.data = param.data.astype(param_dtype)
-        self._eval_backend()
+        materialize(self.model_parameters, self._states)
         return None

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -16,6 +16,7 @@ from typing import (
 
 from autograd.backend import (
     ARRAY_TYPE,
+    LOW_PRECISION_FLOAT_DTYPES,
     Array,
     ArrayLike,
     get_random_state,
@@ -384,8 +385,7 @@ class Tensor:
         Returns:
             Tensor: The result of addition.
         """
-        if not isinstance(other, Tensor):
-            other = Tensor(other, requires_grad=False)
+        other = self._wrap_scalar_like_self(other)
 
         return Add.apply(self, other)
 
@@ -402,8 +402,7 @@ class Tensor:
         Returns:
             Tensor: The result of multiplication.
         """
-        if not isinstance(other, Tensor):
-            other = Tensor(other, requires_grad=False)
+        other = self._wrap_scalar_like_self(other)
 
         return Mul.apply(self, other)
 
@@ -450,8 +449,7 @@ class Tensor:
                 result = result * self
             return result
 
-        if not isinstance(other, Tensor):
-            other = Tensor(other, requires_grad=False)
+        other = self._wrap_scalar_like_self(other)
 
         return Pow.apply(self, other)
 
@@ -468,13 +466,23 @@ class Tensor:
         Returns:
             Tensor: This tensor, after in-place addition.
         """
-        if not isinstance(other, Tensor):
-            other = Tensor(other, requires_grad=False)
+        other = self._wrap_scalar_like_self(other)
 
         # Use expand for broadcasting
         broadcast_shape = xp.broadcast_shapes(self.shape, other.shape)
         expanded_other = other.expand(broadcast_shape)
         return IAdd.apply(self, expanded_other)
+
+    def _wrap_scalar_like_self(self, value: Union["Tensor", float, int]) -> "Tensor":
+        if isinstance(value, Tensor):
+            return value
+
+        # Python scalar constants should behave like constants in this tensor's
+        # dtype. Without this, bf16/fp16 activations mixed with `0`, `0.5`, etc.
+        # get promoted through Tensor(float)'s default fp32 construction.
+        if self.data.dtype in LOW_PRECISION_FLOAT_DTYPES:
+            value = xp.array(value, dtype=self.data.dtype)
+        return Tensor(value, requires_grad=False)
 
     def __getitem__(self, idx: Union[int, slice, tuple]) -> "Tensor":
         """

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -20,7 +20,7 @@ from tqdm import tqdm
 from autograd import nn, optim
 from autograd.backend import (
     Array,
-    eval,
+    materialize,
     xp,
 )
 from autograd.data.data_loader import DataLoader
@@ -85,8 +85,10 @@ class TrainingState:
         self,
         loss_sum: float | Tensor,
         *,
-        total_weight: Array = xp.array(1.0, dtype=xp.float32),
+        total_weight: Optional[Array] = None,
     ) -> None:
+        if total_weight is None:
+            total_weight = xp.array(1.0, dtype=xp.float32)
         loss_data = loss_sum.data if isinstance(loss_sum, Tensor) else float(loss_sum)
         if self.report_loss_sum is None:
             self.report_loss_sum = loss_data
@@ -102,8 +104,10 @@ class TrainingState:
         self,
         loss_sum: float | Tensor,
         *,
-        total_weight: Array = xp.array(1.0, dtype=xp.float32),
+        total_weight: Optional[Array] = None,
     ) -> None:
+        if total_weight is None:
+            total_weight = xp.array(1.0, dtype=xp.float32)
         loss_value = (
             loss_sum.item() if isinstance(loss_sum, Tensor) else float(loss_sum)
         )
@@ -145,9 +149,8 @@ class TrainingState:
 class TrainingPlan:
     by_epoch: bool
     target_step: int
-    # Note that the reporting frequency also dictates the MLX lazy-to-materialize trigger
-    # Don't set this too high, otherwise, MLX could accumulate a lot of operations and
-    # might directly reach "RuntimeError: [metal::malloc] Resource limit exceeded"
+    # Controls log/eval/checkpoint cadence. Microbatch eval boundaries are
+    # handled in the trainer loop and do not depend on reporting frequency.
     report_every_steps: int
     checkpoint_every: int
     steps_per_epoch: Optional[int] = None
@@ -339,12 +342,6 @@ class AbstractTrainer(ABC):
                     loss = self._compute_loss(batch)
                     total_weight = self._loss_total_weight(batch)
                     loss.backward()
-                    # MLX is lazy: during accumulation, materialize each
-                    # microbatch's grads so one optimizer step does not retain
-                    # a large graph spanning all backward passes. With no
-                    # accumulation, optimizer.step() is the natural eval point.
-                    if accumulation_steps > 1:
-                        self._eval_accumulated_gradients()
                     state.record_loss(loss, total_weight=total_weight)
 
                     if state.has_enough_batches(accumulation_steps):
@@ -361,6 +358,16 @@ class AbstractTrainer(ABC):
 
                             if should_report:
                                 report_current_step()
+                    else:
+                        # Non-step microbatch boundary.
+                        # Materialize retained loss accumulators and accumulated grads so MLX does
+                        # not keep backward graphs across microbatches.
+                        materialize(
+                            state.report_loss_sum,
+                            state.report_loss_total_weight,
+                            state.accumulated_loss_total_weight,
+                            self.optimizer.gradient_arrays(),
+                        )
 
                     if plan.is_done(self.global_step):
                         break
@@ -389,6 +396,16 @@ class AbstractTrainer(ABC):
         if state.accumulated_batches == 0:
             return False
 
+        # Step microbatch boundary.
+        # Do not materialize gradients here; optimizer.step() will consume them and
+        # materialize parameter/state updates. But do materialize retained loss stats,
+        # because report_loss_sum is not otherwise consumed by optimizer.step().
+        materialize(
+            state.report_loss_sum,
+            state.report_loss_total_weight,
+            state.accumulated_loss_total_weight,
+        )
+
         self.optimizer.scale_gradients(
             1.0
             / xp.maximum(
@@ -408,15 +425,6 @@ class AbstractTrainer(ABC):
         state.accumulated_batches = 0
         state.accumulated_loss_total_weight = xp.array(0.0, dtype=xp.float32)
         return True
-
-    def _eval_accumulated_gradients(self) -> None:
-        grads = [
-            parameter.grad.data
-            for parameter in self.model.parameters.values()
-            if parameter.grad is not None
-        ]
-        if grads:
-            eval(*grads)
 
     def evaluate(self, val_data_loader: DataLoader) -> TrainingState:
         val_data_loader.on_epoch_start()
@@ -606,7 +614,7 @@ class AbstractTrainer(ABC):
                 metrics_mx[key] = xp.array(values, dtype=xp.float32)
             else:
                 metrics_mx[key] = xp.array(values)
-        eval(*metrics_mx.values())
+        materialize(*metrics_mx.values())
         xp.savez_compressed(path, **metrics_mx)
 
     def _validate_fit_inputs(self, train_data_loader: DataLoader) -> None:

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pprint import pformat
@@ -78,6 +79,7 @@ class TrainingState:
     )
     eval_loss_batches: int = 0
     eval_metric_totals: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    report_started_at_s: float = field(default_factory=time.perf_counter)
 
     def record_loss(
         self,
@@ -126,6 +128,14 @@ class TrainingState:
     def reset_report(self) -> None:
         self.report_loss_sum = None
         self.report_loss_total_weight = xp.array(0.0, dtype=xp.float32)
+        self.report_started_at_s = time.perf_counter()
+
+    def report_tokens_per_second(self, *, now_s: Optional[float] = None) -> float:
+        elapsed_s = (now_s or time.perf_counter()) - self.report_started_at_s
+        if elapsed_s <= 0:
+            return 0.0
+        token_count = xp.to_scalar(self.report_loss_total_weight)
+        return float(token_count) / elapsed_s
 
     def has_enough_batches(self, accumulation_steps: int):
         return self.accumulated_batches >= accumulation_steps
@@ -329,6 +339,12 @@ class AbstractTrainer(ABC):
                     loss = self._compute_loss(batch)
                     total_weight = self._loss_total_weight(batch)
                     loss.backward()
+                    # MLX is lazy: during accumulation, materialize each
+                    # microbatch's grads so one optimizer step does not retain
+                    # a large graph spanning all backward passes. With no
+                    # accumulation, optimizer.step() is the natural eval point.
+                    if accumulation_steps > 1:
+                        self._eval_accumulated_gradients()
                     state.record_loss(loss, total_weight=total_weight)
 
                     if state.has_enough_batches(accumulation_steps):
@@ -392,6 +408,15 @@ class AbstractTrainer(ABC):
         state.accumulated_batches = 0
         state.accumulated_loss_total_weight = xp.array(0.0, dtype=xp.float32)
         return True
+
+    def _eval_accumulated_gradients(self) -> None:
+        grads = [
+            parameter.grad.data
+            for parameter in self.model.parameters.values()
+            if parameter.grad is not None
+        ]
+        if grads:
+            eval(*grads)
 
     def evaluate(self, val_data_loader: DataLoader) -> TrainingState:
         val_data_loader.on_epoch_start()
@@ -471,6 +496,7 @@ class AbstractTrainer(ABC):
                 state.report_loss_sum,
                 state.report_loss_total_weight,
             ),
+            "tokens_per_s": state.report_tokens_per_second(),
             "val_loss": None
             if eval_state is None
             else self._weighted_mean(

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -262,20 +262,20 @@ if __name__ == "__main__":
     WIKI_CONFIG = TransformerTrainingConfig(
         training_run_name="wiki",
         dataset_name="wiki_simple_english",
-        max_steps=200000,
+        max_steps=25000,
         max_eval_steps=20,
-        checkpoint_freq=2000,
-        report_every_steps=100,
+        checkpoint_freq=1000,
+        report_every_steps=50,
         global_batch_size=32,
-        micro_batch_size=4,
+        micro_batch_size=8,
         max_grad_norm=1.0,
         model_kwargs={
-            "num_attention_heads": 12,  # GPT-2 small uses 12
-            "hidden_size": 1536,  # GPT-2 small uses 768, must be divisible by num_attention_heads
-            "dropout_prob": 0.2,
+            "num_attention_heads": 9,  # GPT-2 small uses 12
+            "hidden_size": 576,  # GPT-2 small uses 768, must be divisible by num_attention_heads
+            "dropout_prob": 0.1,
             "max_seq_len": 1024,  # GPT-2 uses 1024
-            "num_decoder_layers": 12,  # GPT-2 uses 12
-            "activation_checkpointing": True,
+            "num_decoder_layers": 8,  # GPT-2 uses 12
+            "activation_checkpointing": False,
             "parameter_dtype": "bfloat16",
         },
         optimizer_kwargs={
@@ -284,11 +284,11 @@ if __name__ == "__main__":
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": optim.CosineScheduler,
-                "warmup_steps": 30000,  # 15% of max_steps
-                "lr_decay_iters": 160000,  # 80% of max_steps
+                "warmup_steps": 3750,  # 15% of max_steps
+                "lr_decay_iters": 20000,  # 80% of max_steps
             },
         },
-        resume_epoch=62000,  # Set this to None if you don't want to load from checkpoint
+        resume_epoch=None,  # Set this to None if you don't want to load from checkpoint
         teacher_forcing=False,
         label_smoothing=0.1,
         eval_start_string="April is",

--- a/examples/sft_gpt_2.py
+++ b/examples/sft_gpt_2.py
@@ -50,35 +50,37 @@ if __name__ == "__main__":
     from gpt_2 import GPT2, GPT2ForwardFn
 
     CONFIG = TransformerTrainingConfig(
-        training_run_name="sft_demo",
+        training_run_name="sft_0426",
         dataset_name="no_robots",
-        max_steps=500,
+        max_steps=900,
         max_eval_steps=10,
-        checkpoint_freq=32,
+        checkpoint_freq=300,
+        report_every_steps=20,
         global_batch_size=32,
-        micro_batch_size=4,
+        micro_batch_size=8,
         model_kwargs={
-            "num_attention_heads": 12,  # GPT-2 small uses 12
-            "hidden_size": 1536,  # GPT-2 small uses 768, must be divisible by num_attention_heads
-            "dropout_prob": 0.2,
+            "num_attention_heads": 9,  # GPT-2 small uses 12
+            "hidden_size": 576,  # GPT-2 small uses 768, must be divisible by num_attention_heads
+            "dropout_prob": 0.1,
             "max_seq_len": 1024,  # GPT-2 uses 1024
-            "num_decoder_layers": 12,  # GPT-2 uses 12
-            "activation_checkpointing": True,
+            "num_decoder_layers": 8,  # GPT-2 uses 12
+            "activation_checkpointing": False,
+            "parameter_dtype": "bfloat16",
         },
         optimizer_kwargs={
-            "lr": 1e-4,
+            "lr": 5e-5,
             "beta2": 0.99,
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": optim.CosineScheduler,
-                "warmup_steps": 75,  # 15% of max_steps
-                "lr_decay_iters": 400,  # 80% of max_steps
+                "warmup_steps": 90,  # 15% of max_steps
+                "lr_decay_iters": 720,  # 80% of max_steps
             },
         },
         max_grad_norm=1.0,
         # Basename without .json/.npz. The configured model architecture below
         # must match this checkpoint; load_state_dict will fail otherwise.
-        pretrained_checkpoint_path=project_path("checkpoints", "wiki_GPT2_62000"),
+        pretrained_checkpoint_path=project_path("checkpoints", "wiki_GPT2_6000"),
         label_smoothing=0.1,
         teacher_forcing=False,
         eval_start_string="User: What is the weather today?<|endoftext|>Assistant: ",

--- a/test/autograd/performance_test.py
+++ b/test/autograd/performance_test.py
@@ -10,7 +10,7 @@ import psutil
 
 from autograd import functional, nn, optim
 from autograd.backend import IS_CUPY, NAME, xp
-from autograd.backend import eval as backend_eval
+from autograd.backend import materialize as backend_materialize
 from autograd.data.collator import FixedLengthCausalLMCollator, PairedCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import PairedMapDataset
@@ -62,7 +62,7 @@ def synchronize_trees(*values):
     for value in values:
         arrays.extend(_flatten_sync_targets(value))
     if arrays:
-        backend_eval(*arrays)
+        backend_materialize(*arrays)
     if IS_CUPY:
         cuda = getattr(xp, "cuda", None)
         device_cls = getattr(cuda, "Device", None)

--- a/test/autograd/test_backend.py
+++ b/test/autograd/test_backend.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 
 from autograd.backend import (
-    eval_backend,
     get_random_state,
+    materialize,
     set_random_state,
     xp,
 )
@@ -75,11 +75,33 @@ def test_scatter_add_accumulates_repeated_indices():
     assert np.array_equal(xp.to_numpy(out), np.array([0.0, 5.0, 0.0], dtype=np.float32))
 
 
-def test_eval_backend_accepts_nested_arrays_and_tensors():
-    tensor = Tensor(xp.asarray([1.0], dtype=xp.float32))
-    nested = {"tensor": tensor, "array": xp.asarray([2.0], dtype=xp.float32)}
+def test_materialize_collects_nested_arrays_and_tensor_data(monkeypatch):
+    import autograd.backend as backend
 
-    eval_backend(nested, [xp.asarray([3.0], dtype=xp.float32)], None)
+    arrays = [
+        np.asarray([1.0], dtype=np.float32),
+        np.asarray([2.0], dtype=np.float32),
+        np.asarray([3.0], dtype=np.float32),
+    ]
+    observed = []
+
+    monkeypatch.setattr(backend, "IS_MLX", True)
+    monkeypatch.setattr(backend, "ARRAY_TYPE", np.ndarray)
+    monkeypatch.setattr(
+        backend,
+        "xp",
+        SimpleNamespace(eval=lambda *xs: observed.extend(xs)),
+    )
+
+    nested = {
+        "tensor": SimpleNamespace(data=arrays[0]),
+        "array": arrays[1],
+        "ignored": [None, "abc", 7],
+    }
+
+    materialize(nested, (arrays[2],))
+
+    assert observed == arrays
 
 
 def test_as_strided_view_matches_explicit_windows():

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -653,6 +653,14 @@ class TestLayerNorm(TestCase):
                 output.data, torch_output.detach().numpy(), rtol=1e-4, atol=1e-4
             ), f"Output mismatch for input shape {shape}"
 
+    def test_low_precision_output_dtype_is_preserved(self):
+        dtype = getattr(xp, "bfloat16", xp.float16)
+        x = Tensor(xp.ones((2, 3, self.input_size), dtype=dtype))
+
+        output = self.layer_norm(x)
+
+        assert output.data.dtype == dtype
+
 
 class TestDropout(TestCase):
     def test_forward(self):
@@ -670,6 +678,22 @@ class TestDropout(TestCase):
         dropout.train()
         output = dropout(x)
         assert allclose(output.data, xp.array([[1, 2], [3, 4], [5, 6]]))
+
+    def test_low_precision_output_dtype_is_preserved(self):
+        dtype = getattr(xp, "bfloat16", xp.float16)
+        dropout = Dropout(p=0.25)
+        dropout.train()
+        x = Tensor(xp.ones((8, 8), dtype=dtype))
+
+        output = dropout(x)
+
+        assert output.data.dtype == dtype
+
+        drop_all = Dropout(p=1)
+        drop_all.train()
+        output = drop_all(x)
+
+        assert output.data.dtype == dtype
 
 
 class TestConv2d(TestCase):

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -145,6 +145,16 @@ class TestOptimizer(TestCase):
 
         self.assertAlmostEqual(grad_norm, 13.0, places=6)
 
+    def test_gradient_arrays_returns_current_gradients_by_parameter_name(self):
+        grad = xp.array([3.0, 4.0], dtype=xp.float32)
+        self.params["param1"].grad = Tensor(grad)
+        self.params["param2"].grad = None
+
+        grads = self.optimizer.gradient_arrays()
+
+        self.assertEqual(list(grads), ["param1"])
+        self.assertIs(grads["param1"], self.params["param1"].grad.data)
+
     def test_scheduler_accepts_class_object(self):
         optimizer = Optimizer(
             self.params,
@@ -314,7 +324,8 @@ class TestSGD(TestCase):
         self.params = [self.param1, self.param2]
         self.optimizer = SGD(
             model_parameters={
-                "sample_module": {"weight": self.param1, "bias": self.param2},
+                "sample_module.weight": self.param1,
+                "sample_module.bias": self.param2,
             },
             lr=0.01,
         )
@@ -370,7 +381,7 @@ class TestSGD(TestCase):
         def record_eval(params, states):
             observed.append((self.param1.data, states["timestep"]))
 
-        with patch("autograd.optim.eval_backend", side_effect=record_eval):
+        with patch("autograd.optim.materialize", side_effect=record_eval):
             self.optimizer.step()
 
         self.assertEqual(len(observed), 1)

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -87,6 +87,26 @@ class TestTensorOps(TestTensor):
 
         assert x.data.dtype == xp.float16
 
+    def test_low_precision_python_scalar_ops_preserve_tensor_dtype(self):
+        dtype = getattr(xp, "bfloat16", xp.float16)
+        x = Tensor(xp.ones((2,), dtype=dtype), requires_grad=True)
+
+        assert (x + 1.0).data.dtype == dtype
+        assert (1.0 + x).data.dtype == dtype
+        assert (x - 1.0).data.dtype == dtype
+        assert (1.0 - x).data.dtype == dtype
+        assert (x * 0.5).data.dtype == dtype
+        assert (x / 2.0).data.dtype == dtype
+        assert (x**0.5).data.dtype == dtype
+        assert (-x).data.dtype == dtype
+
+    def test_explicit_scalar_tensor_keeps_its_dtype(self):
+        dtype = getattr(xp, "bfloat16", xp.float16)
+        x = Tensor(xp.ones((2,), dtype=dtype), requires_grad=True)
+        scale = Tensor(xp.array(0.5, dtype=xp.float32), requires_grad=False)
+
+        assert (x * scale).data.dtype == xp.float32
+
     def test_tensor_negation(self):
         assert (-self.x_scalar).data == -2.0
 

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -22,6 +22,7 @@ from autograd.tools.config_schema import (
     TransformerTrainingConfig,
 )
 from autograd.tools.trainer import (
+    AbstractTrainer,
     LLMTrainer,
     SimpleTrainer,
     TrainingPlan,
@@ -394,21 +395,50 @@ class TestSimpleTrainer(BaseTrainerTest):
 
     def test_metrics_row_derives_metrics_from_training_state_aggregates(self):
         state = TrainingState()
+        state.report_started_at_s = 10.0
         state.record_loss(1.23)
         eval_state = TrainingState()
         eval_state.record_eval_loss(0.5)
         eval_state.record_eval_metric("accuracy", numerator=3, denominator=4)
 
-        row = self.trainer._metrics_row(state, eval_state=eval_state)
+        with patch("autograd.tools.trainer.time.perf_counter", return_value=11.0):
+            row = self.trainer._metrics_row(state, eval_state=eval_state)
 
         self.assertEqual(
             row,
             {
                 "train_loss": 1.23,
+                "tokens_per_s": 1.0,
                 "val_loss": 0.5,
                 "val_accuracy": 0.75,
             },
         )
+
+    def test_training_state_resets_report_timer(self):
+        state = TrainingState()
+        state.record_loss(1.0, total_weight=xp.array(4.0, dtype=xp.float32))
+        with patch("autograd.tools.trainer.time.perf_counter", return_value=12.0):
+            state.reset_report()
+
+        self.assertIsNone(state.report_loss_sum)
+        self.assertEqual(float(xp.to_scalar(state.report_loss_total_weight)), 0.0)
+        self.assertEqual(state.report_started_at_s, 12.0)
+
+    def test_training_state_default_weights_are_created_at_call_time(self):
+        self.assertIsNone(TrainingState.record_loss.__kwdefaults__["total_weight"])
+        self.assertIsNone(TrainingState.record_eval_loss.__kwdefaults__["total_weight"])
+
+        state = TrainingState()
+        state.record_loss(1.0)
+        state.record_eval_loss(2.0)
+
+        self.assertEqual(float(xp.to_scalar(state.report_loss_total_weight)), 1.0)
+        self.assertEqual(float(xp.to_scalar(state.eval_loss_total_weight)), 1.0)
+
+    def test_training_boundaries_are_direct_materialize_calls(self):
+        self.assertFalse(hasattr(TrainingState, "eval_accumulators"))
+        self.assertFalse(hasattr(AbstractTrainer, "_eval_microbatch_accumulators"))
+        self.assertFalse(hasattr(AbstractTrainer, "_eval_accumulated_gradients"))
 
     @patch("autograd.tools.trainer.save_checkpoint")
     def test_save_checkpoint_saves_first_validation_loss(self, mock_save_checkpoint):
@@ -1207,6 +1237,62 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         self.assertEqual(trainer.optimizer.step_call_count, 2)
 
+    def test_fit_materializes_non_step_microbatch_state_and_gradients(self):
+        config = GenericTrainingConfig(
+            max_epochs=1,
+            checkpoint_freq=10,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=2,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+        grad_arrays = {"weight": xp.array([1.0], dtype=xp.float32)}
+        trainer.optimizer.gradient_arrays = MagicMock(return_value=grad_arrays)
+        trainer.report = MagicMock()
+
+        with patch("autograd.tools.trainer.materialize") as mock_materialize:
+            trainer.fit(self.train_loader)
+
+        self.assertEqual(trainer.optimizer.gradient_arrays.call_count, 1)
+        self.assertEqual(mock_materialize.call_count, 2)
+        self.assertIs(mock_materialize.call_args_list[0].args[3], grad_arrays)
+        self.assertEqual(len(mock_materialize.call_args_list[1].args), 3)
+
+    def test_fit_without_accumulation_uses_only_step_boundary(self):
+        config = GenericTrainingConfig(
+            max_epochs=1,
+            checkpoint_freq=10,
+            model_kwargs={"hidden_size": 256},
+            optimizer_kwargs={"lr": 0.01},
+            global_batch_size=1,
+            micro_batch_size=1,
+        )
+        trainer = SimpleTrainer(
+            model_cls=MockModelClass,
+            optimizer_cls=MockOptimizerClass,
+            loss_fn=self.loss_fn,
+            config=config,
+            output_type="logits",
+        )
+        trainer.optimizer.gradient_arrays = MagicMock(return_value={})
+        trainer.report = MagicMock()
+
+        with patch("autograd.tools.trainer.materialize") as mock_materialize:
+            trainer.fit(self.train_loader)
+
+        trainer.optimizer.gradient_arrays.assert_not_called()
+        self.assertEqual(mock_materialize.call_count, 2)
+        self.assertTrue(
+            all(len(call.args) == 3 for call in mock_materialize.call_args_list)
+        )
+
     def test_optimizer_step_is_no_op_when_no_batches_accumulated(self):
         state = TrainingState()
         self.trainer.last_grad_l2_norm = 7.0
@@ -1518,6 +1604,7 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         row = self.trainer.metric_rows[0]
         self.assertEqual(row["train_loss"], 1.23)
+        self.assertIn("tokens_per_s", row)
         self.assertEqual(row["val_loss"], 0.5)
         self.assertEqual(row["val_accuracy"], 0.75)
 


### PR DESCRIPTION
## Description

1. Fix scalar constants defaulting to fp32 when they are used with bf16/fp16 tensors. Previously, expressions like `x + 0`, `x * 0.5`, or dropout masks could promote low precision activations back to fp32. Now scalar constants and dropout masks preserve the tensor dtype.
2. Update the GPT-2 pre-training config based on the smaller Chinchilla-law ([paper](https://arxiv.org/abs/2203.15556))  training target.
3. Update SFT to use the same model architecture as the pre-trained checkpoint, switch to the `wiki_GPT2_6000` checkpoint, and adjust SFT steps/lr/checkpoint cadence around that model size.
4. Remove the recursive optimizer parameter traversal now that model parameters are flat. This makes gradient reset / optimizer step behavior simpler and easier to reason about.
5. Add explicit MLX materialization boundaries after non-step microbatches and optimizer updates. Without this, MLX can hold onto lazy backward/update graphs across microbatches and eventually materialize too much work at a later sync point. Previously, memory can spike (or even OOM) suddenly at the "materialize" steps, which is not obvious.
6. Add `tokens_per_s` to trainer reports so we can see training throughput directly in the normal logs.

## Tests

Added unit tests.

New pre-training run using a much smaller model based on the chinchilla scaling law ([paper](https://arxiv.org/abs/2203.15556))
```
(ml-by-hand) ➜  ml-by-hand git:(main) ✗ python -m examples.gpt_2
2026-04-26 14:06:15,425 - INFO - 178255102 characters in the entire dataset. Sample:

April

April (Apr.) is the fourth month of the year in the Julian and Gregorian calendars, and come
2026-04-26 14:06:15,425 - INFO - Loading the vocabulary from disk.
2026-04-26 14:06:15,430 - INFO - Found existing encoded data at 'training_data/bpe_12000_wiki_simple_encoded_data.npz', loading it instead of re-encoding.
2026-04-26 14:06:15,431 - INFO - Vocabulary size: 12260
2026-04-26 14:06:15,431 - INFO - Encoded data length: 47193131
Data length: len(train_data)=42473817 len(test_data)=4719314
2026-04-26 14:06:15,431 - INFO - No resume_epoch given; initializing model & optimizer from scratch.
2026-04-26 14:06:16,268 - INFO - Training GPT2 with 39.56M parameters.
2026-04-26 14:06:16,268 - INFO - Fit plan:
{'mode': 'steps',
 'target_step': 25000,
 'report_every_steps': 50,
 'global_batch_size': 32,
 'micro_batch_size': 8,
 'gradient_accumulation_steps': 4}
Training:   0%|▏                   2026-04-26 14:08:43,189 - INFO - [Step 50]                 | 50/25000 [02:24<19:37:57,  2.83s/it]

...

Training:  24%|██████████████████  2026-04-26 18:54:41,977 - INFO - Saved checkpoint to checkpoints/wiki_GPT2_6000.json and checkpoints/wiki_GPT2_6000.npz
2026-04-26 18:54:41,978 - INFO - [Step 6000]
{'step': 6000,
 'train_loss': '3.9651',
 'tokens_per_s': '11220.3798',
 'val_loss': '3.5655',
 'grad_l2_norm': '0.3601',
 'lr': '0.000958'}

...

> python scripts/inference.py checkpoints/wiki_GPT2_6000.npz 128
2026-04-26 21:24:34,709 - INFO - Loading the vocabulary from disk.
2026-04-26 21:24:34,716 - INFO - Model:

Spring is

Yunya Abis

Yunya Abis (born November 13, 1982) is a Nigerian politician. He is a member of the House of Representatives of the Nigeria National Guard.

Abidjan was born in Ibrahimaki, Nigeria. He studied at the University of Zano University and studied at the Kubaraya Gentino University of Zavira.

Abidjan was married to Gamba Abisiband from 2003 until 2001 and they had six children. He lives in Mangad, Nigeria, Kenya,
```


**SFT run using the pre-trained checkpoint**
```
(ml-by-hand) ➜  ml-by-hand git:(fix-dtype-bugs) ✗ python -m examples.sft_gpt_2
2026-04-26 20:34:06,446 - INFO - Loading the vocabulary from disk.
2026-04-26 20:34:06,450 - INFO - Attempting to load pretrained weights from checkpoint: /Users/henry/Git/ml-by-hand/checkpoints/wiki_GPT2_6000.json, /Users/henry/Git/ml-by-hand/checkpoints/wiki_GPT2_6000.npz
2026-04-26 20:34:06,484 - INFO - Loaded pretrained GPT2 weights from /Users/henry/Git/ml-by-hand/checkpoints/wiki_GPT2_6000
2026-04-26 20:34:06,519 - INFO - Found SFT cache at '/Users/henry/Git/ml-by-hand/training_data/bpe_12000_no_robots_encoded_data_sft.npz'; validating metadata before loading.
2026-04-26 20:34:06,524 - INFO - SFT cache metadata matched; loading cached tokenized data.
Data length: raw_train=9500 raw_val=500 fit_train=9248 fit_val=487
2026-04-26 20:34:06,974 - INFO - Training GPT2 with 39.56M parameters.
2026-04-26 20:34:06,974 - INFO - Fit plan:
{'mode': 'steps',
 'target_step': 900,
 'report_every_steps': 20,
 'global_batch_size': 32,
 'micro_batch_size': 8,
 'gradient_accumulation_steps': 4}
Training:   2%|█                  2026-04-26 20:34:48,477 - INFO - [Step 20]40<23:34,  1.61s/it]
{'step': 20,
 'train_loss': '4.9537',
 'tokens_per_s': '3220.3493',
 'val_loss': '4.1394',
 'grad_l2_norm': '1.0961',
 'lr': '0.000012'}

...


Training:  33%|███████████████▋    2026-04-26 20:41:50,897 - INFO - Saved checkpoint to checkpoints/sft_0426_GPT2_300.json and checkpoints/sft_0426_GPT2_300.npz
2026-04-26 20:41:50,897 - INFO - [Step 300]
{'step': 300,
 'train_loss': '4.7636',
 'tokens_per_s': '3946.2367',
 'val_loss': '3.8768',
 'grad_l2_norm': '0.7094',
 'lr': '0.000063'}

...

> python scripts/inference.py checkpoints/sft_0426_GPT2_300.npz 128
2026-04-26 20:43:18,692 - INFO - Loading the vocabulary from disk.
2026-04-26 20:43:18,702 - INFO - Model:

User: What is the weather today?<|endoftext|>Assistant:

The weather is usually very warm; the cold and moistest climates are hot and dry. It grows in hot weather or cold temperatures. Tropical Depression Twelve months later, in the day it gets cold to .

Sleep on Earth is about 30 degrees Celsius, but it becomes hot and dry.

Sleep on Earth is an average weather event. It is the average temperature recorded by the air. There are two different weather events: