### PR TITLE
Add more skeleton classes and implement RolloutGenerator and MathEnv

### DIFF
--- a/examples/grpo.py
+++ b/examples/grpo.py
@@ -1,12 +1,18 @@
+import re
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Sequence
 
+import numpy as np
+
 from autograd.backend import Array, ArrayLike, xp
 from autograd.data.collator import Collator, pad_right_1d
+from autograd.data.dataset import MapDataset
 from autograd.nn import Module
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.text.utils import generate
 from autograd.tools.model import load_checkpoint
+from autograd.tools.trainer import AbstractTrainer
 from examples.gpt_2 import GPT2, GPT2ForwardFn
 
 # Template for DeepSeek-R1-Zero. Table 1
@@ -19,23 +25,54 @@ and <answer>...</answer> tags, respectively, i.e., <think> reasoning process her
 <answer> answer here </answer>.
 """
 
-TASK_PROMPT = "What is 1 + 1?"
 EOS_TOKEN = "<|endoftext|>"
 CONFIG = {
-    "max_generation_tokens": 128,
+    "max_generation_tokens": 32,
     "temperature": 1.0,
     "top_k": None,
+    # GRPO group size G: number of completions sampled for one prompt.
     "num_generations": 2,
 }
+
+# 1. Caller code owns one Task for the first loop.
+# 2. Each outer GRPO iteration refreshes rollouts for that current task.
+# 3. RolloutGenerator samples group_size completions from the current
+#    policy, caching old_logprobs for the behavior policy, and computes group-relative advantages
+# 4. Environment scores each Sample in each RolloutGroup
+#    within each RolloutGroup.
+# 5. RolloutDataset stores the already-generated RolloutGroup.
+# 6. DataLoader batches RolloutGroup objects and calls GRPOCollator.
+# 7. GRPOCollator emits GRPOBatch, where rows = group_size for one task.
+# 8. GRPOTrainer(AbstractTrainer)._compute_loss computes the GRPO objective.
+# 9. AbstractTrainer.fit owns backward(), gradient accumulation, clipping,
+#     optimizer.step(), checkpointing, and reporting.
+#
+# Keep boundaries explicit:
+# - Environment: prompt rendering + reward design only
+# - RolloutGenerator: model sampling + old_logprobs + RolloutGroup creation + advantage calculation
+# - RolloutDataset: static container for already-generated rollout groups.
+# - GRPOCollator: padding, causal shift, action masks, and GRPOBatch assembly.
+# - GRPOTrainer: GRPO loss, and inherited optimizer mechanics.
 
 
 @dataclass
 class Sample:
+    """
+    One sampled completion for one prompt.
+
+    GRPO should not treat this as the standalone dataset item because the
+    advantage is relative to sibling samples from the same prompt.
+    """
+
     completion_tokens: Array
+    # This completion_text field is derivable from completion_tokens, but it has a
+    # separate purpose: tokens feed the trainer/collator, text feeds rewards and
+    # debugging without making Environment depend on a tokenizer.
+    completion_text: str
     old_logprobs: Array  # cached behavior-policy logprobs for the policy ratio
-    reward: Optional[float]
-    advantage: Optional[float]  # derived field
-    metadata: Optional[dict]  # env trace, verifier result etc...
+    reward: Optional[float] = None
+    advantage: Optional[float] = None  # derived field
+    metadata: Optional[dict] = None  # env trace, verifier result etc...
 
     def __post_init__(self) -> None:
         if len(self.completion_tokens) == 0:
@@ -48,13 +85,32 @@ class Sample:
 
 @dataclass
 class Task:
+    """
+    One environment task.
+
+    Attributes:
+        task_id: Stable identifier used to connect the task to its RolloutGroup.
+        raw_input: User-facing task text rendered into the model prompt.
+        answer: Reference target used by concrete environment rewards.
+        metadata: Optional source/debug details that are not part of reward.
+    """
+
     task_id: str
     raw_input: str
-    metadata: Optional[dict]
+    answer: str
+    metadata: Optional[dict] = None
 
 
 @dataclass
-class PromptGroup:
+class RolloutGroup:
+    """
+    Dataset item for GRPO.
+
+    One RolloutGroup is one rendered prompt plus G sampled completions. This
+    keeps the group structure intact so reward normalization can compare sibling
+    samples from the same prompt.
+    """
+
     prompt_id: str  # the dataset or prompt builder or rollout coordinate will fill this in. This should be 1-1 mapped to the rendered prompt instance, which can change if anything like the system prompt changes
     prompt_tokens: Array
     samples: List[Sample]
@@ -63,7 +119,7 @@ class PromptGroup:
         if len(self.prompt_tokens) == 0:
             raise ValueError("prompt_tokens must contain at least one token")
         if len(self.samples) == 0:
-            raise ValueError("PromptGroup must contain at least one sample")
+            raise ValueError("RolloutGroup must contain at least one sample")
 
 
 @dataclass(frozen=True)
@@ -78,11 +134,18 @@ class GRPOBatch:
 
 class GRPOCollator(Collator):
     """
-    Builds fixed-length GRPO batches from prompt groups.
+    Builds fixed-length GRPO batches from rollout groups.
+
+    A rollout group is one prompt plus G sampled completions. In the first
+    one-task loop, the collated batch has `group_size` training rows.
 
     `max_tokens` is the total row length before causal shifting:
     `len(prompt_tokens) + len(completion_tokens)`. It is not the rollout
     generation limit, which only caps completion length.
+
+    Boundary decision: DataLoader calls this with RolloutGroup objects and this
+    returns the trainer-facing GRPOBatch. The trainer should not need to know how
+    prompt/completion tokens are padded, shifted, or action-masked.
     """
 
     def __init__(self, max_tokens: int, pad_idx: int) -> None:
@@ -93,7 +156,7 @@ class GRPOCollator(Collator):
         self.max_tokens = max_tokens
         self.pad_idx = pad_idx
 
-    def __call__(self, prompt_groups: Sequence[PromptGroup]) -> GRPOBatch:
+    def __call__(self, rollout_groups: Sequence[RolloutGroup]) -> GRPOBatch:
         batch_input_ids = []
         batch_labels = []
         batch_old_logprobs = []
@@ -101,15 +164,15 @@ class GRPOCollator(Collator):
         batch_advantages = []
         loss_total_weight = xp.array(0.0, dtype=xp.float32)
 
-        for prompt_group in prompt_groups:
-            for sample in prompt_group.samples:
+        for rollout_group in rollout_groups:
+            for sample in rollout_group.samples:
                 (
                     input_ids,
                     labels,
                     old_logprobs,
                     action_mask,
                     advantages,
-                ) = self._build_row(prompt_group.prompt_tokens, sample)
+                ) = self._build_row(rollout_group.prompt_tokens, sample)
 
                 batch_input_ids.append(input_ids)
                 batch_labels.append(labels)
@@ -199,16 +262,189 @@ class GRPOCollator(Collator):
         )
 
 
-class Verifier:
-    def compute_reward(
-        self, prompt_tokens: ArrayLike, completion_tokens: ArrayLike
-    ) -> float:
-        # print(f"{prompt_tokens=}, {completion_tokens=}")
-        return 1.0
+class RolloutDataset(MapDataset):
+    """
+    Static container for already-generated on-policy rollout groups.
+
+    Rollout refresh is intentionally outside Dataset.on_epoch_start() for now:
+    caller code should generate fresh RolloutGroups from the current policy,
+    wrap them in RolloutDataset, then build a DataLoader with GRPOCollator.
+    That keeps model/tokenizer/environment dependencies out of this dataset.
+    """
+
+    pass
 
 
-def render_prompt(user_prompt: str) -> str:
-    return SYSTEM_PROMPT + f"User: {user_prompt}{EOS_TOKEN}Assistant: "
+class Environment:
+    """
+    Owns task rendering and reward design.
+
+    Concrete environments decide how to render tasks and score sampled
+    completions. They should not know about optimizers or loss.
+    """
+
+    def render_task(self, task: Task) -> str:
+        # Public prompt-rendering entry point. This is Task-aware so concrete
+        # environments can use task metadata or domain-specific wording later.
+        return self._render_prompt(task.raw_input)
+
+    def _render_prompt(self, user_prompt: str) -> str:
+        # Private template helper. This should stay string-in/string-out and not
+        # know about Task, rewards, or rollout state.
+        return SYSTEM_PROMPT + f"User: {user_prompt}{EOS_TOKEN}Assistant: "
+
+    @abstractmethod
+    def _compute_reward(self, task: Task, sample: Sample) -> float:  # pyright: ignore[reportReturnType]
+        raise NotImplementedError()
+
+    def score_group(self, task: Task, rollout_group: RolloutGroup) -> RolloutGroup:
+        # Keep Task explicit here: RolloutGroup stores the rendered prompt tokens
+        # used for training, but reward code may still need task-level reference
+        # data or metadata.
+        # Public scoring entry point. Expected to attach rewards to each Sample
+        # in the group, usually by calling _compute_reward per sample.
+        for sample in rollout_group.samples:
+            reward = self._compute_reward(task, sample)
+            sample.reward = reward
+
+        return rollout_group
+
+
+class MathEnvironment(Environment):
+    """
+    Concrete Environment target for the first working GRPO loop.
+
+    Math is chosen because rewards can be rule-based and fast: exact final-answer
+    checking is enough to prove the full loop learns.
+    """
+
+    # This regex should be consistent with the SYSTEM_PROMPT defined at the
+    # top of this module
+    ANSWER_RE = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.DOTALL)
+
+    def _compute_reward(self, task: Task, sample: Sample) -> float:
+        match = self.ANSWER_RE.search(sample.completion_text)
+        if match is None:
+            return 0.0
+
+        reward = 0.1
+        parsed_answer = match.group(1).strip()
+        expected_answer = task.answer.strip()
+        if parsed_answer == expected_answer:
+            reward += 1.0
+
+        return reward
+
+
+class RolloutGenerator:
+    """
+    Samples on-policy completions from the current model.
+
+    Given one Task, it should render the prompt via Environment, sample G
+    completions, cache behavior-policy old_logprobs, ask Environment to score
+    samples, and return one RolloutGroup. It should not perform optimizer work.
+    """
+
+    def rollout(
+        self,
+        model: Module,
+        task: Task,
+        tokenizer: BytePairEncoder,
+        environment: Environment,
+    ) -> RolloutGroup:
+        task_prompt: str = environment.render_task(task)
+        prompt_tokens = xp.array(tokenizer.encode(task_prompt), dtype=xp.int32)
+        samples: List[Sample] = []
+
+        for _ in range(CONFIG["num_generations"]):
+            sample = generation(
+                model,
+                prompt_tokens=prompt_tokens,
+                tokenizer=tokenizer,
+                max_generation_tokens=CONFIG["max_generation_tokens"],
+                temperature=CONFIG["temperature"],
+                top_k=CONFIG["top_k"],
+            )
+            samples.append(sample)
+
+        rollout_group = RolloutGroup(
+            prompt_id=task.task_id,
+            prompt_tokens=prompt_tokens,
+            samples=samples,
+        )
+
+        rollout_group = environment.score_group(task, rollout_group)
+        self._compute_advantages(rollout_group)
+
+        return rollout_group
+
+    def _compute_advantages(self, rollout_group: RolloutGroup) -> None:
+        r"""
+        Advantage normalization
+        G = group size
+        r = reward
+
+        1. Calculate the mean
+        2. Calcuate the standard deviation
+        3. Calculate the advantage
+
+        $A_i = \frac{r_i - \mu}{\sigma}$
+
+        """
+        rewards = []
+        for sample in rollout_group.samples:
+            if sample.reward is None:
+                raise ValueError(
+                    "sample.reward must be set before advantage calculation"
+                )
+            rewards.append(sample.reward)
+
+        rewards = np.array(rewards)
+        rewards_mean = rewards.mean()
+        rewards_std_dev = rewards.std()
+        for sample in rollout_group.samples:
+            if rewards_std_dev == 0.0:
+                sample.advantage = 0.0
+            else:
+                sample.advantage = (sample.reward - rewards_mean) / rewards_std_dev
+
+
+class GRPOTrainer(AbstractTrainer):
+    """
+    Trainer boundary for GRPOBatch optimization.
+
+    This can subclass AbstractTrainer because rollout has already happened by
+    the time DataLoader yields a GRPOBatch. The base trainer can keep owning
+    backward(), gradient accumulation, clipping, optimizer.step(), checkpointing,
+    and reporting.
+
+    It should not own raw tasks, Environment, or RolloutGenerator. A higher
+    level orchestration loop is responsible for:
+
+        Task -> RolloutGenerator.rollout(...) -> RolloutDataset
+        -> DataLoader(..., collator=GRPOCollator(...)) -> self.fit(...)
+
+    One optimizer step consumes one or more GRPOBatch objects depending on
+    gradient accumulation. Each one-task GRPOBatch contains group_size rows.
+    """
+
+    def _compute_loss(self, batch: GRPOBatch):
+        """
+        Compute the GRPO objective from a trainer-facing batch.
+
+        The loss should use current-policy logprobs from
+        `self.model(batch.input_ids)`, cached `batch.old_logprobs` for the
+        policy ratio, `batch.advantages` for the group-relative learning signal,
+        and `batch.action_mask` so prompt/pad tokens do not contribute.
+        """
+
+        pass
+
+    def _loss_total_weight(self, batch: GRPOBatch):
+        pass
+
+    def _evaluate(self, val_data_loader):
+        pass
 
 
 def generation(
@@ -260,11 +496,11 @@ def generation(
     # boundaries at the rendered-prompt/completion join.
     return Sample(
         completion_tokens=completion_array,
+        completion_text=tokenizer.decode(result.completion_tokens),
         old_logprobs=xp.array(result.logprobs, dtype=xp.float32),
         reward=None,
         advantage=None,
         metadata={
-            "completion_text": tokenizer.decode(result.completion_tokens),
             "stop_reason": result.stop_reason,
             "temperature": temperature,
             "top_k": top_k,
@@ -283,32 +519,17 @@ def main():
         num_merges=12000,
         vocab_file_path="training_data/wikipedia_simpleenglish_vocab_12000.pkl",
     )
-    verifier = Verifier()
+    environment = MathEnvironment()
+    task = Task(task_id="1", raw_input="What is 1 + 1?", answer="2")
+    rollout_generator = RolloutGenerator()
 
-    # PromptGroup stores the exact rendered prompt tokens used for generation,
-    # not just the raw task text.
-    prompt_tokens = xp.array(bpe.encode(render_prompt(TASK_PROMPT)), dtype=xp.int32)
-
-    samples = []
-
-    for _ in range(CONFIG["num_generations"]):
-        sample = generation(
-            model,
-            prompt_tokens,
-            bpe,
-            max_generation_tokens=CONFIG["max_generation_tokens"],
-            temperature=CONFIG["temperature"],
-            top_k=CONFIG["top_k"],
-        )
-        sample.reward = verifier.compute_reward(prompt_tokens, sample.completion_tokens)
-        # if sample.metadata is not None:
-        #     print(sample.metadata["completion_text"])
-        samples.append(sample)
-
-    prompt_group = PromptGroup(
-        prompt_id="1", prompt_tokens=prompt_tokens, samples=samples
+    rollout_group = rollout_generator.rollout(
+        model=model,
+        task=task,
+        tokenizer=bpe,
+        environment=environment,
     )
-    print(prompt_group)
+    print(rollout_group)
 
 
 if __name__ == "__main__":

--- a/test/test_grpo.py
+++ b/test/test_grpo.py
@@ -3,7 +3,15 @@ import pytest
 
 from autograd.backend import xp
 from autograd.data.collator import Collator
-from examples.grpo import GRPOCollator, PromptGroup, Sample, generation
+from examples.grpo import (
+    GRPOCollator,
+    MathEnvironment,
+    RolloutGenerator,
+    RolloutGroup,
+    Sample,
+    Task,
+    generation,
+)
 
 
 def test_grpo_collator_implements_collator_interface():
@@ -12,12 +20,13 @@ def test_grpo_collator_implements_collator_interface():
 
 def test_grpo_collator_aligns_actions_with_shifted_completion_labels():
     prompt_tokens = xp.array([10, 11], dtype=xp.int32)
-    group = PromptGroup(
+    group = RolloutGroup(
         prompt_id="prompt-1",
         prompt_tokens=prompt_tokens,
         samples=[
             Sample(
                 completion_tokens=xp.array([20, 21], dtype=xp.int32),
+                completion_text="",
                 old_logprobs=xp.array([-0.1, -0.2], dtype=xp.float32),
                 reward=1.0,
                 advantage=0.5,
@@ -25,6 +34,7 @@ def test_grpo_collator_aligns_actions_with_shifted_completion_labels():
             ),
             Sample(
                 completion_tokens=xp.array([30], dtype=xp.int32),
+                completion_text="",
                 old_logprobs=xp.array([-0.3], dtype=xp.float32),
                 reward=0.0,
                 advantage=-1.0,
@@ -68,6 +78,7 @@ def test_sample_requires_completion_logprob_alignment():
     with pytest.raises(ValueError, match="completion_tokens and old_logprobs"):
         Sample(
             completion_tokens=xp.array([20, 21], dtype=xp.int32),
+            completion_text="",
             old_logprobs=xp.array([-0.1], dtype=xp.float32),
             reward=1.0,
             advantage=0.5,
@@ -75,23 +86,24 @@ def test_sample_requires_completion_logprob_alignment():
         )
 
 
-def test_prompt_group_requires_samples():
+def test_rollout_group_requires_samples():
     with pytest.raises(ValueError, match="at least one sample"):
-        PromptGroup(
+        RolloutGroup(
             prompt_id="prompt-1",
             prompt_tokens=xp.array([10, 11], dtype=xp.int32),
             samples=[],
         )
 
 
-def test_prompt_group_requires_prompt_tokens():
+def test_rollout_group_requires_prompt_tokens():
     with pytest.raises(ValueError, match="prompt_tokens"):
-        PromptGroup(
+        RolloutGroup(
             prompt_id="prompt-1",
             prompt_tokens=xp.array([], dtype=xp.int32),
             samples=[
                 Sample(
                     completion_tokens=xp.array([20], dtype=xp.int32),
+                    completion_text="",
                     old_logprobs=xp.array([-0.1], dtype=xp.float32),
                     reward=1.0,
                     advantage=0.5,
@@ -102,12 +114,13 @@ def test_prompt_group_requires_prompt_tokens():
 
 
 def test_grpo_collator_rejects_rows_longer_than_max_tokens():
-    group = PromptGroup(
+    group = RolloutGroup(
         prompt_id="prompt-1",
         prompt_tokens=xp.array([10, 11], dtype=xp.int32),
         samples=[
             Sample(
                 completion_tokens=xp.array([20, 21], dtype=xp.int32),
+                completion_text="",
                 old_logprobs=xp.array([-0.1, -0.2], dtype=xp.float32),
                 reward=1.0,
                 advantage=0.5,
@@ -118,6 +131,82 @@ def test_grpo_collator_rejects_rows_longer_than_max_tokens():
 
     with pytest.raises(ValueError, match="exceeds max_tokens"):
         GRPOCollator(max_tokens=3, pad_idx=0)([group])
+
+
+def test_math_environment_parses_answer_tags_for_reward():
+    environment = MathEnvironment()
+    task = Task(task_id="math-1", raw_input="What is 1 + 1?", answer="2")
+
+    correct = Sample(
+        completion_tokens=xp.array([20], dtype=xp.int32),
+        completion_text="<think>1 + 1 = 2</think><answer>2</answer>",
+        old_logprobs=xp.array([-0.1], dtype=xp.float32),
+    )
+    wrong = Sample(
+        completion_tokens=xp.array([21], dtype=xp.int32),
+        completion_text="<answer>3</answer>",
+        old_logprobs=xp.array([-0.2], dtype=xp.float32),
+    )
+    unformatted = Sample(
+        completion_tokens=xp.array([22], dtype=xp.int32),
+        completion_text="2",
+        old_logprobs=xp.array([-0.3], dtype=xp.float32),
+    )
+
+    assert environment._compute_reward(task, correct) == 1.1
+    assert environment._compute_reward(task, wrong) == 0.1
+    assert environment._compute_reward(task, unformatted) == 0.0
+
+
+def test_score_group_attaches_rewards_without_advantages():
+    environment = MathEnvironment()
+    task = Task(task_id="math-1", raw_input="What is 1 + 1?", answer="2")
+    group = RolloutGroup(
+        prompt_id="math-1",
+        prompt_tokens=xp.array([10], dtype=xp.int32),
+        samples=[
+            Sample(
+                completion_tokens=xp.array([20], dtype=xp.int32),
+                completion_text="not tagged",
+                old_logprobs=xp.array([-0.1], dtype=xp.float32),
+            ),
+            Sample(
+                completion_tokens=xp.array([21], dtype=xp.int32),
+                completion_text="also not tagged",
+                old_logprobs=xp.array([-0.2], dtype=xp.float32),
+            ),
+        ],
+    )
+
+    scored_group = environment.score_group(task, group)
+
+    assert [sample.reward for sample in scored_group.samples] == [0.0, 0.0]
+    assert [sample.advantage for sample in scored_group.samples] == [None, None]
+
+
+def test_rollout_generator_uses_zero_advantage_when_rewards_have_no_variance():
+    group = RolloutGroup(
+        prompt_id="math-1",
+        prompt_tokens=xp.array([10], dtype=xp.int32),
+        samples=[
+            Sample(
+                completion_tokens=xp.array([20], dtype=xp.int32),
+                completion_text="",
+                old_logprobs=xp.array([-0.1], dtype=xp.float32),
+                reward=0.0,
+            ),
+            Sample(
+                completion_tokens=xp.array([21], dtype=xp.int32),
+                completion_text="",
+                old_logprobs=xp.array([-0.2], dtype=xp.float32),
+                reward=0.0,
+            ),
+        ],
+    )
+
+    RolloutGenerator()._compute_advantages(group)
+
+    assert [sample.advantage for sample in group.samples] == [0.0, 0.0]
 
 
 def test_generation_rejects_prompt_that_fills_context_window():


### PR DESCRIPTION
## Description
- Added more skeleton classes for GRPO
- Implemented Environment and MathEnvironment
- Implemented RolloutGenerator

## Tests
Added unit tests.

```
(ml-by-hand) ➜  ml-by-hand git:(grpo-2) ✗ python -m examples.grpo
2026-05-01 22:29:14,610 - INFO - Loading the vocabulary from disk.
Inference: 100%|████████████████████████████████████████████████| 32/32 [00:00<00:00, 43.56it/s]
Inference: 100%|████████████████████████████████████████████████| 32/32 [00:00<00:00, 55.75it/s]
RolloutGroup(prompt_id='1', prompt_tokens=array([10, 65, 10062, ..., 410, 58, 32], dtype=int32), samples=[

Sample(completion_tokens=array([60, 110, 2236, ..., 1222, 10, 60], dtype=int32), completion_text='<nabit semen headaches -scalar munitor to make "200phia, there are 60 other historically-beast processes zones."\n<', old_logprobs=array([-0.783967, -3.08916, -7.21378, ..., -3.26076, -0.707312, -2.02932], dtype=float32), reward=0.0, advantage=0.0, metadata={'stop_reason': 'max_new_tokens', 'temperature': 1.0, 'top_k': None}), 

Sample(completion_tokens=array([7957, 344, 314, ..., 32, 60, 496], dtype=int32), completion_text='So are 1 + 1?\nBy this time to Tracker. But to really get your attention is restrained, seal of <ans', old_logprobs=array([-7.37772, -4.85507, -2.62531, ..., -4.33519, -0.199519, -3.21033], dtype=float32), reward=0.0, advantage=0.0, metadata={'stop_reason': 'max_new_tokens', 'temperature': 1.0, 'top_k': None})

])
```