### PR TITLE
Working training loop for GRPO

### DIFF
--- a/autograd/functional.py
+++ b/autograd/functional.py
@@ -72,6 +72,25 @@ def softmax(x: Tensor) -> Tensor:
     return Softmax.apply(x)
 
 
+def log_softmax(x: Tensor, dim: int = -1) -> Tensor:
+    r"""
+    Applies the log-softmax function.
+
+    Args:
+        x (Tensor): The input tensor containing logits.
+        dim (int): The dimension along which logprobs are computed.
+
+    Returns:
+        Tensor: The tensor with token logprobs.
+
+    Examples:
+        >>> from autograd.tensor import Tensor
+        >>> x = Tensor(xp.array([2.0, 1.0, 0.1]))
+        >>> y = log_softmax(x) # Expected output: logprobs that exponentiate to probabilities summing to 1
+    """
+    return LogSoftmax.apply(x, dim=dim)
+
+
 def tanh(x: Tensor) -> Tensor:
     """
     Applies the hyperbolic tangent (tanh) activation function.
@@ -366,6 +385,118 @@ class Softmax(Function):
         sum_term = xp.sum(grad.data * self.probs, axis=-1, keepdims=True)
         dLdx = self.probs * (grad.data - sum_term)
         return dLdx
+
+
+class LogSoftmax(Function):
+    r"""
+    Log-softmax activation function.
+
+    The log-softmax function is defined as:
+        $$
+        \log \pi_i = x_i - \log \sum_j e^{x_j}
+        $$
+
+    Note:
+        Use `log_softmax` when logprobs are needed; it is more stable than
+        computing `log(softmax(x))`.
+    """
+
+    def forward(self, x: Array, *, dim: int = -1) -> Array:
+        r"""
+        Computes the forward pass of the log-softmax activation function.
+
+        Args:
+            x (xp.ndarray): Input array of logits.
+            dim (int): Dimension along which logprobs are computed.
+
+        Returns:
+            xp.ndarray: The logprobs.
+        """
+        r"""
+        Shift logits by their maximum along the class/token dimension:
+        $$
+        m = \max_j x_j,\qquad \text{max\_shifted\_logits}_i = x_i - m
+        $$
+        This leaves softmax probabilities unchanged because:
+        $$
+        \frac{e^{x_i}}{\sum_j e^{x_j}}
+        =
+        \frac{e^{x_i-c}}{\sum_j e^{x_j-c}}
+        $$
+        while keeping exponentials numerically bounded.
+        """
+        max_shifted_logits = x - xp.max(x, axis=dim, keepdims=True)
+
+        r"""
+        Compute the log of the sum of exponentiated max-shifted logits:
+        $$
+        \log \operatorname{softmax}(x)_i
+        = x_i - \log \sum_j e^{x_j}
+        $$
+        $$
+        = x_i - \log\left(e^m \sum_j e^{x_j-m}\right)
+        = (x_i-m) - \log \sum_j e^{x_j-m}
+        $$
+
+        Since:
+
+        $\text{max\_shifted\_logits}_i = x_i-m$
+
+        $$
+        \log \operatorname{softmax}(x)_i = \text{max\_shifted\_logits}_i - \log \sum_j e^{\text{max\_shifted\_logits}_j}
+        $$
+
+        """
+        log_sum_exp_max_shifted_logits = xp.log(
+            xp.sum(xp.exp(max_shifted_logits), axis=dim, keepdims=True)
+        )
+
+        self.dim = dim
+        r"""
+        Store probabilities for backward:
+        $$
+        p_i = \operatorname{softmax}(x)_i
+        = \exp\left(
+            \text{max\_shifted\_logits}_i
+            - \log \sum_j e^{\text{max\_shifted\_logits}_j}
+        \right)
+        $$
+        """
+        self.probs = xp.exp(max_shifted_logits - log_sum_exp_max_shifted_logits)
+        return max_shifted_logits - log_sum_exp_max_shifted_logits
+
+    def backward(self, grad: Tensor) -> Array:
+        r"""
+        Computes the backward pass of the log-softmax activation function.
+
+        Args:
+            grad (Tensor): Upstream gradient.
+
+        Returns:
+            xp.ndarray: The gradient of the loss with respect to the input logits.
+        """
+        r"""
+        For:
+        $$
+        y_i = \log \operatorname{softmax}(x)_i = x_i - \log \sum_k e^{x_k}
+        $$
+        the Jacobian is:
+        $$
+        \frac{\partial y_i}{\partial x_j}
+        = \mathbf{1}[i=j] - p_j
+        $$
+        Given upstream gradient $g_i = \frac{\partial L}{\partial y_i}$:
+        $$
+        \frac{\partial L}{\partial x_j}
+        = \sum_i g_i(\mathbf{1}[i=j] - p_j)
+        = g_j - p_j \sum_i g_i
+        $$
+        """
+        return grad.data - self.probs * xp.sum(
+            grad.data,
+            axis=self.dim,
+            keepdims=True,
+        )
 
 
 class Tanh(Function):

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -45,8 +45,10 @@ def generate(
     temperature: float,
     top_k: Optional[int],
     eos_token_id: int,
+    *,
     show_progress: bool = True,
-) -> GenerationResult:
+    num_generations: int,
+) -> list[GenerationResult]:
     """Generate token ids autoregressively and record sampled-token logprobs.
 
     This is the structured generation primitive: callers pass already-tokenized
@@ -63,62 +65,85 @@ def generate(
         top_k: Optional top-k filter applied before sampling.
         eos_token_id: Token id that stops generation when sampled.
         show_progress: Whether to show token-level inference progress.
+        num_generations: Number of independent completions to generate in
+            parallel for the same prompt.
 
     Returns:
-        Generated completion token ids, sampled-token logprobs, and stop reason.
+        One result per generated completion.
     """
-    output_ids = [int(token) for token in prompt_tokens]
-    completion_tokens: list[int] = []
-    logprobs: list[float] = []
-    stop_reason = "max_new_tokens"
+    if num_generations < 1:
+        raise ValueError(f"num_generations must be >= 1, got {num_generations}")
+
+    prompt_token_list = [int(token) for token in prompt_tokens]
+    output_ids = [prompt_token_list.copy() for _ in range(num_generations)]
+    completion_tokens: list[list[int]] = [[] for _ in range(num_generations)]
+    logprobs: list[list[float]] = [[] for _ in range(num_generations)]
+    stop_reasons = ["max_new_tokens" for _ in range(num_generations)]
+    active = [True for _ in range(num_generations)]
 
     for _ in tqdm(range(max_new_tokens), desc="Inference", disable=not show_progress):
+        if not any(active):
+            break
+
         # Auto-regressive generation feeds the full prompt plus all tokens sampled
         # so far back into the model, then samples from the final position.
-        batch_data = xp.expand_dims(xp.array(output_ids, dtype=xp.int32), axis=0)
+        # Shape: (num_generations, current_seq_len). Each row is one completion
+        # being advanced in parallel for this decoding step.
+        batch_data = xp.array(output_ids, dtype=xp.int32)
         prediction = prediction_func(model=model, batch_data=batch_data, mode="sample")
         if isinstance(prediction, tuple):
             prediction = prediction[0]
-        logits = prediction.data[0, -1]
+        next_token_logits = prediction.data[:, -1]
 
-        if temperature <= 0:
-            # greedy decoding: choose the highest-logit token directly.
-            token_id = int(xp.argmax(logits))
-            logprob = 0.0
-        else:
-            # Temperature rescales the distribution before sampling.
-            # Larger values flatten it; smaller values make it sharper.
-            behavior_logits = xp.array(logits, dtype=xp.float32) / temperature
-            if top_k is not None and top_k < len(behavior_logits):
-                # Top-k keeps only the k most likely tokens and masks the rest.
-                threshold = xp.sort(behavior_logits)[-top_k]
-                behavior_logits = xp.where(
-                    behavior_logits >= threshold,
-                    behavior_logits,
-                    xp.full(
-                        behavior_logits.shape,
-                        -float("inf"),
-                        dtype=behavior_logits.dtype,
-                    ),
-                )
-            token_id = int(xp.to_scalar(xp.sample_categorical(behavior_logits)))
-            # Store the logprob from the same distribution that sampled the token
-            shifted = behavior_logits - xp.max(behavior_logits)
-            log_denom = xp.log(xp.sum(xp.exp(shifted)))
-            logprob = float(xp.to_scalar(shifted[token_id] - log_denom))
+        for row_idx, is_active in enumerate(active):
+            if not is_active:
+                output_ids[row_idx].append(eos_token_id)
+                continue
 
-        output_ids.append(token_id)
-        completion_tokens.append(token_id)
-        logprobs.append(logprob)
-        if token_id == eos_token_id:
-            stop_reason = "eos"
-            break
+            logits = next_token_logits[row_idx]
+            if temperature <= 0:
+                # greedy decoding: choose the highest-logit token directly.
+                token_id = int(xp.argmax(logits))
+                logprob = 0.0
+            else:
+                # Temperature rescales the distribution before sampling.
+                # Larger values flatten it; smaller values make it sharper.
+                behavior_logits = xp.array(logits, dtype=xp.float32) / temperature
+                if top_k is not None and top_k < len(behavior_logits):
+                    # Top-k keeps only the k most likely tokens and masks the rest.
+                    threshold = xp.sort(behavior_logits)[-top_k]
+                    behavior_logits = xp.where(
+                        behavior_logits >= threshold,
+                        behavior_logits,
+                        xp.full(
+                            behavior_logits.shape,
+                            -float("inf"),
+                            dtype=behavior_logits.dtype,
+                        ),
+                    )
+                token_id = int(xp.to_scalar(xp.sample_categorical(behavior_logits)))
+                # Store the logprob from the same distribution that sampled the token
+                shifted = behavior_logits - xp.max(behavior_logits)
+                log_denom = xp.log(xp.sum(xp.exp(shifted)))
+                logprob = float(xp.to_scalar(shifted[token_id] - log_denom))
 
-    return GenerationResult(
-        completion_tokens=completion_tokens,
-        logprobs=logprobs,
-        stop_reason=stop_reason,
-    )
+            output_ids[row_idx].append(token_id)
+            completion_tokens[row_idx].append(token_id)
+            logprobs[row_idx].append(logprob)
+            if token_id == eos_token_id:
+                stop_reasons[row_idx] = "eos"
+                active[row_idx] = False
+
+    return [
+        GenerationResult(
+            completion_tokens=tokens,
+            logprobs=result_logprobs,
+            stop_reason=stop_reasons[row_idx],
+        )
+        for row_idx, (tokens, result_logprobs) in enumerate(
+            zip(completion_tokens, logprobs)
+        )
+    ]
 
 
 def generate_text(
@@ -161,7 +186,8 @@ def generate_text(
             temperature=temperature,
             top_k=top_k,
             eos_token_id=bpe.encode("<|endoftext|>")[0],
-        )
+            num_generations=1,
+        )[0]
         output_ids.extend(result.completion_tokens)
         for next_token in result.completion_tokens:
             print(bpe.decode([next_token]), end="", flush=True)

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -45,6 +45,7 @@ def generate(
     temperature: float,
     top_k: Optional[int],
     eos_token_id: int,
+    show_progress: bool = True,
 ) -> GenerationResult:
     """Generate token ids autoregressively and record sampled-token logprobs.
 
@@ -61,6 +62,7 @@ def generate(
         temperature: Sampling temperature. Values <= 0 use argmax.
         top_k: Optional top-k filter applied before sampling.
         eos_token_id: Token id that stops generation when sampled.
+        show_progress: Whether to show token-level inference progress.
 
     Returns:
         Generated completion token ids, sampled-token logprobs, and stop reason.
@@ -70,7 +72,7 @@ def generate(
     logprobs: list[float] = []
     stop_reason = "max_new_tokens"
 
-    for _ in tqdm(range(max_new_tokens), desc="Inference"):
+    for _ in tqdm(range(max_new_tokens), desc="Inference", disable=not show_progress):
         # Auto-regressive generation feeds the full prompt plus all tokens sampled
         # so far back into the model, then samples from the final position.
         batch_data = xp.expand_dims(xp.array(output_ids, dtype=xp.int32), axis=0)

--- a/examples/grpo.py
+++ b/examples/grpo.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Sequence
 
 import numpy as np
 
+from autograd import functional
 from autograd.backend import Array, ArrayLike, xp
 from autograd.data.collator import Collator, pad_right_1d
 from autograd.data.data_loader import DataLoader
@@ -449,6 +450,14 @@ class GRPOTrainer(AbstractTrainer):
         return self.loss_fn(logits, batch)
 
     def _loss_total_weight(self, batch: GRPOBatch):
+        """
+        Currently this is token-level loss.
+        $$
+        \frac{1}{\sum_i T_i} \sum_{i=1}^G \sum_{t=1}^T \text{Advantage}_i \log \text{prob}_{i, t}
+        $$
+        Long bad outputs -> large negative influence
+        Long verbose correct outputs -> large positive influence
+        """
         return xp.sum(batch.generated_token_mask)
 
     def _evaluate(self, val_data_loader):
@@ -459,12 +468,47 @@ def grpo_loss(logits: Tensor, batch: GRPOBatch) -> Tensor:
     """
     Compute the summed simplified GRPO objective from a model-facing batch.
 
-    The loss should use current-policy logprobs from `model(batch.input_ids)`,
-    cached `batch.old_logprobs` for the policy ratio, `batch.advantages` for the
-    group-relative learning signal, and `batch.action_mask` so prompt/pad tokens
-    do not contribute.
+    `batch.advantages` and `batch.generated_token_mask` are rollout-time
+    constants. Only `logits` participates in autograd.
     """
-    raise NotImplementedError()
+    labels = xp.asarray(batch.labels, dtype=xp.int32)
+    generated_token_mask = xp.asarray(batch.generated_token_mask, dtype=xp.float32)
+    advantages = xp.asarray(batch.advantages, dtype=xp.float32)
+
+    if logits.ndim != 3:
+        raise ValueError("logits must have shape (batch, seq_len, vocab_size)")
+    if labels.shape != logits.shape[:2]:
+        raise ValueError("labels must have shape (batch, seq_len)")
+    if generated_token_mask.shape != labels.shape:
+        raise ValueError("generated_token_mask must have shape (batch, seq_len)")
+    if advantages.shape != labels.shape:
+        raise ValueError("advantages must have shape (batch, seq_len)")
+
+    logprobs = functional.log_softmax(logits, dim=-1)
+    batch_idx = xp.arange(labels.shape[0])[:, None]
+    seq_idx = xp.arange(labels.shape[1])[None, :]
+
+    r"""
+    Gather the current-policy logprob for each sampled token:
+    $$
+    \ell_{i,t}(\theta)
+    = \log \pi_\theta(\text{token}_{i,t}\mid \text{prompt},\text{token}_{i,<t})
+    $$
+
+    TODO: add KL regularization against a reference policy once this example
+    introduces a separate reference model.
+    TODO: add a clipped surrogate once sampled-token logprobs are meant to
+    represent a distinct behavior policy.
+    TODO: add the policy-gradient/policy-ratio surrogate when old/current policy
+    ownership is explicit in the training loop.
+
+    Advantage-weighted token objective:
+    $$
+    Loss(\theta) = -\sum_{i,t} mask_{i,t} \text{Advantage}_i \ell_{i,t}(\theta)
+    $$
+    """
+    sampled_token_logprobs = logprobs[batch_idx, seq_idx, labels]
+    return -(sampled_token_logprobs * advantages * generated_token_mask).sum()
 
 
 def generation(
@@ -477,7 +521,7 @@ def generation(
     top_k: Optional[int] = None,
     eos_token: str = EOS_TOKEN,
 ) -> Sample:
-    # GRPO old_logprobs must be raw-policy logprobs. With temperature=1 and no
+    # Sampled-token logprobs must be raw-policy logprobs. With temperature=1 and no
     # top-k, the current generate() sampling logprobs match raw model logprobs.
     # TODO: split sampling-logprobs from raw-policy logprobs if we add rollout
     # temperature/top-k exploration.
@@ -517,7 +561,7 @@ def generation(
     return Sample(
         completion_tokens=completion_array,
         completion_text=tokenizer.decode(result.completion_tokens),
-        old_logprobs=xp.array(result.logprobs, dtype=xp.float32),
+        sampled_token_logprobs=xp.array(result.logprobs, dtype=xp.float32),
         reward=None,
         advantage=None,
         metadata={

--- a/examples/grpo.py
+++ b/examples/grpo.py
@@ -7,10 +7,14 @@ import numpy as np
 
 from autograd.backend import Array, ArrayLike, xp
 from autograd.data.collator import Collator, pad_right_1d
+from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import MapDataset
 from autograd.nn import Module
+from autograd.optim import Adam
+from autograd.tensor import Tensor
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.text.utils import generate
+from autograd.tools.config_schema import GenericTrainingConfig
 from autograd.tools.model import load_checkpoint
 from autograd.tools.trainer import AbstractTrainer
 from examples.gpt_2 import GPT2, GPT2ForwardFn
@@ -26,13 +30,29 @@ and <answer>...</answer> tags, respectively, i.e., <think> reasoning process her
 """
 
 EOS_TOKEN = "<|endoftext|>"
-CONFIG = {
-    "max_generation_tokens": 32,
-    "temperature": 1.0,
-    "top_k": None,
+
+
+@dataclass(kw_only=True)
+class GRPOTrainingConfig(GenericTrainingConfig):
+    max_generation_tokens: int
+    temperature: float
+    top_k: Optional[int]
     # GRPO group size G: number of completions sampled for one prompt.
-    "num_generations": 2,
-}
+    num_generations: int
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.max_generation_tokens < 1:
+            raise ValueError(
+                f"max_generation_tokens must be >= 1, got {self.max_generation_tokens}"
+            )
+        if self.temperature != 1.0 or self.top_k is not None:
+            raise ValueError("GRPO rollout requires temperature=1.0 and top_k=None")
+        if self.num_generations < 1:
+            raise ValueError(
+                f"num_generations must be >= 1, got {self.num_generations}"
+            )
+
 
 # 1. Caller code owns one Task for the first loop.
 # 2. Each outer GRPO iteration refreshes rollouts for that current task.
@@ -40,7 +60,7 @@ CONFIG = {
 #    policy, caching old_logprobs for the behavior policy, and computes group-relative advantages
 # 4. Environment scores each Sample in each RolloutGroup
 #    within each RolloutGroup.
-# 5. RolloutDataset stores the already-generated RolloutGroup.
+# 5. MapDataset stores the already-generated RolloutGroup.
 # 6. DataLoader batches RolloutGroup objects and calls GRPOCollator.
 # 7. GRPOCollator emits GRPOBatch, where rows = group_size for one task.
 # 8. GRPOTrainer(AbstractTrainer)._compute_loss computes the GRPO objective.
@@ -50,7 +70,7 @@ CONFIG = {
 # Keep boundaries explicit:
 # - Environment: prompt rendering + reward design only
 # - RolloutGenerator: model sampling + old_logprobs + RolloutGroup creation + advantage calculation
-# - RolloutDataset: static container for already-generated rollout groups.
+# - MapDataset: static container for already-generated rollout groups.
 # - GRPOCollator: padding, causal shift, action masks, and GRPOBatch assembly.
 # - GRPOTrainer: GRPO loss, and inherited optimizer mechanics.
 
@@ -129,7 +149,6 @@ class GRPOBatch:
     old_logprobs: ArrayLike
     action_mask: ArrayLike
     advantages: ArrayLike
-    loss_total_weight: ArrayLike
 
 
 class GRPOCollator(Collator):
@@ -162,7 +181,6 @@ class GRPOCollator(Collator):
         batch_old_logprobs = []
         batch_action_mask = []
         batch_advantages = []
-        loss_total_weight = xp.array(0.0, dtype=xp.float32)
 
         for rollout_group in rollout_groups:
             for sample in rollout_group.samples:
@@ -180,15 +198,12 @@ class GRPOCollator(Collator):
                 batch_action_mask.append(action_mask)
                 batch_advantages.append(advantages)
 
-                loss_total_weight = loss_total_weight + xp.sum(action_mask)
-
         return GRPOBatch(
             input_ids=xp.stack(batch_input_ids, axis=0),
             labels=xp.stack(batch_labels, axis=0),
             old_logprobs=xp.stack(batch_old_logprobs, axis=0),
             action_mask=xp.stack(batch_action_mask, axis=0),
             advantages=xp.stack(batch_advantages, axis=0),
-            loss_total_weight=loss_total_weight,
         )
 
     def _build_row(
@@ -262,19 +277,6 @@ class GRPOCollator(Collator):
         )
 
 
-class RolloutDataset(MapDataset):
-    """
-    Static container for already-generated on-policy rollout groups.
-
-    Rollout refresh is intentionally outside Dataset.on_epoch_start() for now:
-    caller code should generate fresh RolloutGroups from the current policy,
-    wrap them in RolloutDataset, then build a DataLoader with GRPOCollator.
-    That keeps model/tokenizer/environment dependencies out of this dataset.
-    """
-
-    pass
-
-
 class Environment:
     """
     Owns task rendering and reward design.
@@ -345,6 +347,9 @@ class RolloutGenerator:
     samples, and return one RolloutGroup. It should not perform optimizer work.
     """
 
+    def __init__(self, config: GRPOTrainingConfig) -> None:
+        self.config = config
+
     def rollout(
         self,
         model: Module,
@@ -356,14 +361,14 @@ class RolloutGenerator:
         prompt_tokens = xp.array(tokenizer.encode(task_prompt), dtype=xp.int32)
         samples: List[Sample] = []
 
-        for _ in range(CONFIG["num_generations"]):
+        for _ in range(self.config.num_generations):
             sample = generation(
                 model,
                 prompt_tokens=prompt_tokens,
                 tokenizer=tokenizer,
-                max_generation_tokens=CONFIG["max_generation_tokens"],
-                temperature=CONFIG["temperature"],
-                top_k=CONFIG["top_k"],
+                max_generation_tokens=self.config.max_generation_tokens,
+                temperature=self.config.temperature,
+                top_k=self.config.top_k,
             )
             samples.append(sample)
 
@@ -421,7 +426,7 @@ class GRPOTrainer(AbstractTrainer):
     It should not own raw tasks, Environment, or RolloutGenerator. A higher
     level orchestration loop is responsible for:
 
-        Task -> RolloutGenerator.rollout(...) -> RolloutDataset
+        Task -> RolloutGenerator.rollout(...) -> MapDataset
         -> DataLoader(..., collator=GRPOCollator(...)) -> self.fit(...)
 
     One optimizer step consumes one or more GRPOBatch objects depending on
@@ -445,6 +450,18 @@ class GRPOTrainer(AbstractTrainer):
 
     def _evaluate(self, val_data_loader):
         pass
+
+
+def grpo_loss() -> Tensor:
+    """
+    Compute the GRPO objective from a model-facing batch.
+
+    The loss should use current-policy logprobs from `model(batch.input_ids)`,
+    cached `batch.old_logprobs` for the policy ratio, `batch.advantages` for the
+    group-relative learning signal, and `batch.action_mask` so prompt/pad tokens
+    do not contribute.
+    """
+    raise NotImplementedError()
 
 
 def generation(
@@ -509,11 +526,35 @@ def generation(
 
 
 def main():
-    CHECKPOINT_PATH = "checkpoints/sft_0428_GPT2_300"
-    ckpt = load_checkpoint(f"{CHECKPOINT_PATH}.json", f"{CHECKPOINT_PATH}.npz")
-    model = GPT2(**ckpt["model_init_kwargs"])
-    model.load_state_dict(ckpt["model_state_dict"])
-    model.eval()
+    pretrained_checkpoint_path = "checkpoints/sft_0428_GPT2_300"
+    ckpt = load_checkpoint(
+        f"{pretrained_checkpoint_path}.json",
+        f"{pretrained_checkpoint_path}.npz",
+    )
+
+    TRAIN_CONFIG = GRPOTrainingConfig(
+        max_steps=10,
+        max_eval_steps=5,
+        checkpoint_freq=10,
+        report_every_steps=5,
+        global_batch_size=32,
+        micro_batch_size=8,
+        max_grad_norm=1.0,
+        model_kwargs=ckpt["model_init_kwargs"],
+        optimizer_kwargs={"lr": 5e-5},
+        pretrained_checkpoint_path=pretrained_checkpoint_path,
+        max_generation_tokens=32,
+        temperature=1.0,
+        top_k=None,
+        num_generations=2,
+    )
+
+    trainer = GRPOTrainer(
+        model_cls=GPT2,
+        optimizer_cls=Adam,
+        loss_fn=grpo_loss,
+        config=TRAIN_CONFIG,
+    )
 
     bpe = BytePairEncoder(
         num_merges=12000,
@@ -521,15 +562,27 @@ def main():
     )
     environment = MathEnvironment()
     task = Task(task_id="1", raw_input="What is 1 + 1?", answer="2")
-    rollout_generator = RolloutGenerator()
+    rollout_generator = RolloutGenerator(TRAIN_CONFIG)
 
     rollout_group = rollout_generator.rollout(
-        model=model,
+        model=trainer.model,
         task=task,
         tokenizer=bpe,
         environment=environment,
     )
-    print(rollout_group)
+
+    ds = MapDataset([rollout_group])
+
+    data_loader = DataLoader(
+        dataset=ds,
+        batch_size=8,
+        collator=GRPOCollator(
+            max_tokens=trainer.model.max_seq_len,
+            pad_idx=bpe.encode("<|pad|>")[0],
+        ),
+    )
+
+    trainer.fit(data_loader)
 
 
 if __name__ == "__main__":

--- a/examples/grpo.py
+++ b/examples/grpo.py
@@ -1,23 +1,22 @@
 import re
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional, Sequence
 
 import numpy as np
+from tqdm import tqdm
 
 from autograd import functional
 from autograd.backend import Array, ArrayLike, xp
 from autograd.data.collator import Collator, pad_right_1d
-from autograd.data.data_loader import DataLoader
-from autograd.data.dataset import MapDataset
 from autograd.nn import Module
 from autograd.optim import Adam
-from autograd.tensor import Tensor
+from autograd.tensor import Tensor, no_grad
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.text.utils import generate
 from autograd.tools.config_schema import GenericTrainingConfig
 from autograd.tools.model import load_checkpoint
-from autograd.tools.trainer import AbstractTrainer
+from autograd.tools.trainer import AbstractTrainer, TrainingState
 from examples.gpt_2 import GPT2, GPT2ForwardFn
 
 # Template for DeepSeek-R1-Zero. Table 1
@@ -35,6 +34,7 @@ EOS_TOKEN = "<|endoftext|>"
 
 @dataclass(kw_only=True)
 class GRPOTrainingConfig(GenericTrainingConfig):
+    max_steps: int = field()  # pyright: ignore[reportGeneralTypeIssues, reportIncompatibleVariableOverride]
     max_generation_tokens: int
     temperature: float
     top_k: Optional[int]
@@ -328,11 +328,20 @@ class MathEnvironment(Environment):
     ANSWER_RE = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.DOTALL)
 
     def _compute_reward(self, task: Task, sample: Sample) -> float:
+        reward = 0.0
+        if "<think>" in sample.completion_text:
+            reward += 0.1
+        if "</think>" in sample.completion_text:
+            reward += 0.1
+        if "<answer>" in sample.completion_text:
+            reward += 0.1
+        if "</answer>" in sample.completion_text:
+            reward += 0.1
+
         match = self.ANSWER_RE.search(sample.completion_text)
         if match is None:
-            return 0.0
+            return reward
 
-        reward = 0.1
         parsed_answer = match.group(1).strip()
         expected_answer = task.answer.strip()
         if parsed_answer == expected_answer:
@@ -362,18 +371,15 @@ class RolloutGenerator:
     ) -> RolloutGroup:
         task_prompt: str = environment.render_task(task)
         prompt_tokens = xp.array(tokenizer.encode(task_prompt), dtype=xp.int32)
-        samples: List[Sample] = []
-
-        for _ in range(self.config.num_generations):
-            sample = generation(
-                model,
-                prompt_tokens=prompt_tokens,
-                tokenizer=tokenizer,
-                max_generation_tokens=self.config.max_generation_tokens,
-                temperature=self.config.temperature,
-                top_k=self.config.top_k,
-            )
-            samples.append(sample)
+        samples = generation(
+            model,
+            prompt_tokens=prompt_tokens,
+            tokenizer=tokenizer,
+            num_generations=self.config.num_generations,
+            max_generation_tokens=self.config.max_generation_tokens,
+            temperature=self.config.temperature,
+            top_k=self.config.top_k,
+        )
 
         rollout_group = RolloutGroup(
             prompt_id=task.task_id,
@@ -422,18 +428,15 @@ class GRPOTrainer(AbstractTrainer):
     Trainer boundary for GRPOBatch optimization.
 
     This can subclass AbstractTrainer because rollout has already happened by
-    the time DataLoader yields a GRPOBatch. The base trainer can keep owning
-    backward(), gradient accumulation, clipping, optimizer.step(), checkpointing,
-    and reporting.
+    the time it receives a GRPOBatch. The trainer can keep owning backward(),
+    gradient scaling, clipping, optimizer.step(), and step bookkeeping.
 
     It should not own raw tasks, Environment, or RolloutGenerator. A higher
     level orchestration loop is responsible for:
 
-        Task -> RolloutGenerator.rollout(...) -> MapDataset
-        -> DataLoader(..., collator=GRPOCollator(...)) -> self.fit(...)
+        Task -> RolloutGenerator.rollout(...) -> GRPOCollator -> self.train_step(...)
 
-    One optimizer step consumes one or more GRPOBatch objects depending on
-    gradient accumulation. Each one-task GRPOBatch contains group_size rows.
+    Each one-task GRPOBatch contains group_size rows.
     """
 
     def _compute_loss(self, batch: GRPOBatch):
@@ -450,7 +453,7 @@ class GRPOTrainer(AbstractTrainer):
         return self.loss_fn(logits, batch)
 
     def _loss_total_weight(self, batch: GRPOBatch):
-        """
+        r"""
         Currently this is token-level loss.
         $$
         \frac{1}{\sum_i T_i} \sum_{i=1}^G \sum_{t=1}^T \text{Advantage}_i \log \text{prob}_{i, t}
@@ -462,6 +465,30 @@ class GRPOTrainer(AbstractTrainer):
 
     def _evaluate(self, val_data_loader):
         pass
+
+    def train_step(self, batch: GRPOBatch) -> Tensor:
+        """
+        Apply one optimizer update to one already-generated GRPO batch.
+
+        Online GRPO refreshes rollout data outside the trainer. This method keeps
+        the optimization boundary here: forward, loss, backward, gradient
+        scaling/clipping, optimizer step, and global step bookkeeping.
+
+        We might want to resort back to the normal trainer.fit() way of training later, after we decide to go off-policy with a separate generation policy and trained policy
+        """
+        self.model.train()
+        self.optimizer.zero_grad()
+
+        state = TrainingState()
+        loss = self._compute_loss(batch)
+        total_weight = self._loss_total_weight(batch)
+        loss.backward()
+        state.record_loss(loss, total_weight=total_weight)
+
+        if self.optimizer_step(state):
+            self.global_step += 1
+
+        return loss
 
 
 def grpo_loss(logits: Tensor, batch: GRPOBatch) -> Tensor:
@@ -516,11 +543,12 @@ def generation(
     prompt_tokens: Array,
     tokenizer: BytePairEncoder,
     *,
+    num_generations: int,
     max_generation_tokens: int,
     temperature: float,
     top_k: Optional[int] = None,
     eos_token: str = EOS_TOKEN,
-) -> Sample:
+) -> List[Sample]:
     # Sampled-token logprobs must be raw-policy logprobs. With temperature=1 and no
     # top-k, the current generate() sampling logprobs match raw model logprobs.
     # TODO: split sampling-logprobs from raw-policy logprobs if we add rollout
@@ -542,7 +570,7 @@ def generation(
     was_training = getattr(model, "_is_training", None)
     model.eval()
     try:
-        result = generate(
+        results = generate(
             model=model,
             prediction_func=GPT2ForwardFn(),
             prompt_tokens=prompt_token_list,
@@ -550,26 +578,30 @@ def generation(
             temperature=temperature,
             top_k=top_k,
             eos_token_id=eos_token_id,
+            show_progress=False,
+            num_generations=num_generations,
         )
     finally:
         if was_training:
             model.train()
 
-    completion_array = xp.array(result.completion_tokens, dtype=xp.int32)
     # Keep sampled token ids directly. Decoding and re-encoding can change BPE
     # boundaries at the rendered-prompt/completion join.
-    return Sample(
-        completion_tokens=completion_array,
-        completion_text=tokenizer.decode(result.completion_tokens),
-        sampled_token_logprobs=xp.array(result.logprobs, dtype=xp.float32),
-        reward=None,
-        advantage=None,
-        metadata={
-            "stop_reason": result.stop_reason,
-            "temperature": temperature,
-            "top_k": top_k,
-        },
-    )
+    return [
+        Sample(
+            completion_tokens=xp.array(result.completion_tokens, dtype=xp.int32),
+            completion_text=tokenizer.decode(result.completion_tokens),
+            sampled_token_logprobs=xp.array(result.logprobs, dtype=xp.float32),
+            reward=None,
+            advantage=None,
+            metadata={
+                "stop_reason": result.stop_reason,
+                "temperature": temperature,
+                "top_k": top_k,
+            },
+        )
+        for result in results
+    ]
 
 
 def main():
@@ -590,10 +622,10 @@ def main():
         model_kwargs=ckpt["model_init_kwargs"],
         optimizer_kwargs={"lr": 5e-5},
         pretrained_checkpoint_path=pretrained_checkpoint_path,
-        max_generation_tokens=32,
+        max_generation_tokens=64,
         temperature=1.0,
         top_k=None,
-        num_generations=2,
+        num_generations=8,
     )
 
     trainer = GRPOTrainer(
@@ -610,26 +642,70 @@ def main():
     environment = MathEnvironment()
     task = Task(task_id="1", raw_input="What is 1 + 1?", answer="2")
     rollout_generator = RolloutGenerator(TRAIN_CONFIG)
-
-    rollout_group = rollout_generator.rollout(
-        model=trainer.model,
-        task=task,
-        tokenizer=bpe,
-        environment=environment,
+    collator = GRPOCollator(
+        max_tokens=trainer.model.max_seq_len,
+        pad_idx=bpe.encode("<|pad|>")[0],
     )
+    report_every_steps = TRAIN_CONFIG.report_every_steps or TRAIN_CONFIG.checkpoint_freq
 
-    ds = MapDataset([rollout_group])
+    with tqdm(
+        total=TRAIN_CONFIG.max_steps,
+        initial=trainer.global_step,
+        desc="GRPO training",
+    ) as progress_bar:
+        while trainer.global_step < TRAIN_CONFIG.max_steps:
+            step_before = trainer.global_step
+            rollout_group = rollout_generator.rollout(
+                model=trainer.model,
+                task=task,
+                tokenizer=bpe,
+                environment=environment,
+            )
+            loss = trainer.train_step(collator([rollout_group]))
 
-    data_loader = DataLoader(
-        dataset=ds,
-        batch_size=8,
-        collator=GRPOCollator(
-            max_tokens=trainer.model.max_seq_len,
-            pad_idx=bpe.encode("<|pad|>")[0],
-        ),
-    )
+            rewards = []
+            for sample in rollout_group.samples:
+                if sample.reward is None:
+                    raise ValueError("sample.reward must be set before logging")
+                rewards.append(sample.reward)
+            rewards_array = np.array(rewards, dtype=np.float32)
+            progress_bar.update(trainer.global_step - step_before)
+            progress_bar.set_postfix(
+                loss=f"{float(xp.to_scalar(loss.data)):.4f}",
+                reward_mean=f"{float(rewards_array.mean()):.3f}",
+                reward_std=f"{float(rewards_array.std()):.3f}",
+            )
 
-    trainer.fit(data_loader)
+            if trainer.global_step != step_before:
+                should_validate = trainer.global_step % report_every_steps == 0
+                if should_validate or trainer.global_step >= TRAIN_CONFIG.max_steps:
+                    with no_grad():
+                        validation_group = rollout_generator.rollout(
+                            model=trainer.model,
+                            task=task,
+                            tokenizer=bpe,
+                            environment=environment,
+                        )
+                    validation_rewards = []
+                    for sample in validation_group.samples:
+                        if sample.reward is None:
+                            raise ValueError(
+                                "validation sample reward must be set before logging"
+                            )
+                        validation_rewards.append(sample.reward)
+                    validation_rewards_array = np.array(
+                        validation_rewards,
+                        dtype=np.float32,
+                    )
+                    best_sample_idx = int(np.argmax(validation_rewards_array))
+                    best_sample = validation_group.samples[best_sample_idx]
+                    progress_bar.write(
+                        "validation "
+                        f"step={trainer.global_step} "
+                        f"reward_mean={float(validation_rewards_array.mean()):.3f} "
+                        f"reward_max={float(validation_rewards_array.max()):.3f} "
+                        f"completion={best_sample.completion_text!r}"
+                    )
 
 
 if __name__ == "__main__":

--- a/examples/grpo.py
+++ b/examples/grpo.py
@@ -57,7 +57,7 @@ class GRPOTrainingConfig(GenericTrainingConfig):
 # 1. Caller code owns one Task for the first loop.
 # 2. Each outer GRPO iteration refreshes rollouts for that current task.
 # 3. RolloutGenerator samples group_size completions from the current
-#    policy, caching old_logprobs for the behavior policy, and computes group-relative advantages
+#    policy, caching sampled-token logprobs, and computes group-relative advantages
 # 4. Environment scores each Sample in each RolloutGroup
 #    within each RolloutGroup.
 # 5. MapDataset stores the already-generated RolloutGroup.
@@ -69,9 +69,9 @@ class GRPOTrainingConfig(GenericTrainingConfig):
 #
 # Keep boundaries explicit:
 # - Environment: prompt rendering + reward design only
-# - RolloutGenerator: model sampling + old_logprobs + RolloutGroup creation + advantage calculation
+# - RolloutGenerator: model sampling + sampled-token logprobs + RolloutGroup creation + advantage calculation
 # - MapDataset: static container for already-generated rollout groups.
-# - GRPOCollator: padding, causal shift, action masks, and GRPOBatch assembly.
+# - GRPOCollator: padding, causal shift, generated-token masks, and GRPOBatch assembly.
 # - GRPOTrainer: GRPO loss, and inherited optimizer mechanics.
 
 
@@ -89,7 +89,7 @@ class Sample:
     # separate purpose: tokens feed the trainer/collator, text feeds rewards and
     # debugging without making Environment depend on a tokenizer.
     completion_text: str
-    old_logprobs: Array  # cached behavior-policy logprobs for the policy ratio
+    sampled_token_logprobs: Array
     reward: Optional[float] = None
     advantage: Optional[float] = None  # derived field
     metadata: Optional[dict] = None  # env trace, verifier result etc...
@@ -97,9 +97,9 @@ class Sample:
     def __post_init__(self) -> None:
         if len(self.completion_tokens) == 0:
             raise ValueError("completion_tokens must contain at least one token")
-        if len(self.completion_tokens) != len(self.old_logprobs):
+        if len(self.completion_tokens) != len(self.sampled_token_logprobs):
             raise ValueError(
-                "completion_tokens and old_logprobs must have the same length"
+                "completion_tokens and sampled_token_logprobs must have the same length"
             )
 
 
@@ -146,8 +146,8 @@ class RolloutGroup:
 class GRPOBatch:
     input_ids: ArrayLike
     labels: ArrayLike
-    old_logprobs: ArrayLike
-    action_mask: ArrayLike
+    sampled_token_logprobs: ArrayLike
+    generated_token_mask: ArrayLike
     advantages: ArrayLike
 
 
@@ -164,7 +164,7 @@ class GRPOCollator(Collator):
 
     Boundary decision: DataLoader calls this with RolloutGroup objects and this
     returns the trainer-facing GRPOBatch. The trainer should not need to know how
-    prompt/completion tokens are padded, shifted, or action-masked.
+    prompt/completion tokens are padded, shifted, or masked.
     """
 
     def __init__(self, max_tokens: int, pad_idx: int) -> None:
@@ -178,8 +178,8 @@ class GRPOCollator(Collator):
     def __call__(self, rollout_groups: Sequence[RolloutGroup]) -> GRPOBatch:
         batch_input_ids = []
         batch_labels = []
-        batch_old_logprobs = []
-        batch_action_mask = []
+        batch_sampled_token_logprobs = []
+        batch_generated_token_mask = []
         batch_advantages = []
 
         for rollout_group in rollout_groups:
@@ -187,22 +187,22 @@ class GRPOCollator(Collator):
                 (
                     input_ids,
                     labels,
-                    old_logprobs,
-                    action_mask,
+                    sampled_token_logprobs,
+                    generated_token_mask,
                     advantages,
                 ) = self._build_row(rollout_group.prompt_tokens, sample)
 
                 batch_input_ids.append(input_ids)
                 batch_labels.append(labels)
-                batch_old_logprobs.append(old_logprobs)
-                batch_action_mask.append(action_mask)
+                batch_sampled_token_logprobs.append(sampled_token_logprobs)
+                batch_generated_token_mask.append(generated_token_mask)
                 batch_advantages.append(advantages)
 
         return GRPOBatch(
             input_ids=xp.stack(batch_input_ids, axis=0),
             labels=xp.stack(batch_labels, axis=0),
-            old_logprobs=xp.stack(batch_old_logprobs, axis=0),
-            action_mask=xp.stack(batch_action_mask, axis=0),
+            sampled_token_logprobs=xp.stack(batch_sampled_token_logprobs, axis=0),
+            generated_token_mask=xp.stack(batch_generated_token_mask, axis=0),
             advantages=xp.stack(batch_advantages, axis=0),
         )
 
@@ -230,9 +230,9 @@ class GRPOCollator(Collator):
         # Before padding and causal shift, align all per-token rows on the
         # prompt+completion sequence. Example:
         # tokens       = [prompt_token_0, prompt_token_1, completion_token_0]
-        # action_mask  = [             0,              0,                  1]
-        # old_logprobs = [           0.0,            0.0,  completion_logprob_0]
-        action_mask = xp.concatenate(
+        # generated_token_mask = [             0,              0,                  1]
+        # sampled_token_logprobs = [           0.0,            0.0,  completion_logprob_0]
+        generated_token_mask = xp.concatenate(
             [
                 xp.zeros(prompt_len, dtype=xp.int32),
                 xp.ones(completion_len, dtype=xp.int32),
@@ -240,10 +240,10 @@ class GRPOCollator(Collator):
             axis=0,
         )
 
-        aligned_old_logprobs = xp.concatenate(
+        aligned_sampled_token_logprobs = xp.concatenate(
             [
                 xp.zeros(prompt_len, dtype=xp.float32),
-                sample.old_logprobs,
+                sample.sampled_token_logprobs,
             ],
             axis=0,
         )
@@ -251,14 +251,16 @@ class GRPOCollator(Collator):
         if sample.advantage is None:
             raise ValueError("sample.advantage must be set before collation")
 
-        aligned_advantages = action_mask.astype(xp.float32) * float(sample.advantage)
+        aligned_advantages = generated_token_mask.astype(xp.float32) * float(
+            sample.advantage
+        )
 
         # Fixed padding keeps this first GRPO collator simple. We can switch to
         # dynamic padding later if padding waste becomes a measured bottleneck.
         tokens = pad_right_1d(tokens, self.max_tokens, self.pad_idx)
-        action_mask = pad_right_1d(action_mask, self.max_tokens, 0)
-        aligned_old_logprobs = pad_right_1d(
-            aligned_old_logprobs,
+        generated_token_mask = pad_right_1d(generated_token_mask, self.max_tokens, 0)
+        aligned_sampled_token_logprobs = pad_right_1d(
+            aligned_sampled_token_logprobs,
             self.max_tokens,
             0.0,
         )
@@ -271,8 +273,8 @@ class GRPOCollator(Collator):
         return (
             tokens[:-1],
             tokens[1:],
-            aligned_old_logprobs[1:],
-            action_mask[1:],
+            aligned_sampled_token_logprobs[1:],
+            generated_token_mask[1:],
             aligned_advantages[1:],
         )
 
@@ -343,7 +345,7 @@ class RolloutGenerator:
     Samples on-policy completions from the current model.
 
     Given one Task, it should render the prompt via Environment, sample G
-    completions, cache behavior-policy old_logprobs, ask Environment to score
+    completions, cache sampled-token logprobs, ask Environment to score
     samples, and return one RolloutGroup. It should not perform optimizer work.
     """
 
@@ -438,23 +440,24 @@ class GRPOTrainer(AbstractTrainer):
         Compute the GRPO objective from a trainer-facing batch.
 
         The loss should use current-policy logprobs from
-        `self.model(batch.input_ids)`, cached `batch.old_logprobs` for the
-        policy ratio, `batch.advantages` for the group-relative learning signal,
-        and `batch.action_mask` so prompt/pad tokens do not contribute.
+        `self.model(batch.input_ids)`, `batch.advantages` for the group-relative
+        learning signal, and `batch.generated_token_mask` so prompt/pad/forced
+        tokens do not contribute.
         """
 
-        pass
+        logits = self.model(batch.input_ids)
+        return self.loss_fn(logits, batch)
 
     def _loss_total_weight(self, batch: GRPOBatch):
-        pass
+        return xp.sum(batch.generated_token_mask)
 
     def _evaluate(self, val_data_loader):
         pass
 
 
-def grpo_loss() -> Tensor:
+def grpo_loss(logits: Tensor, batch: GRPOBatch) -> Tensor:
     """
-    Compute the GRPO objective from a model-facing batch.
+    Compute the summed simplified GRPO objective from a model-facing batch.
 
     The loss should use current-policy logprobs from `model(batch.input_ids)`,
     cached `batch.old_logprobs` for the policy ratio, `batch.advantages` for the

--- a/examples/grpo.py
+++ b/examples/grpo.py
@@ -1,7 +1,9 @@
+import json
+import os
 import re
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Optional, Sequence
+from typing import Any, List, Optional, Sequence, cast
 
 import numpy as np
 from tqdm import tqdm
@@ -9,6 +11,7 @@ from tqdm import tqdm
 from autograd import functional
 from autograd.backend import Array, ArrayLike, xp
 from autograd.data.collator import Collator, pad_right_1d
+from autograd.data.utils import load_data, load_parquet_rows
 from autograd.nn import Module
 from autograd.optim import Adam
 from autograd.tensor import Tensor, no_grad
@@ -326,6 +329,80 @@ class MathEnvironment(Environment):
     # This regex should be consistent with the SYSTEM_PROMPT defined at the
     # top of this module
     ANSWER_RE = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.DOTALL)
+    GSM8K_FINAL_ANSWER_RE = re.compile(r"####\s*(.+?)\s*$")
+    GSM8K_PARQUET_MANIFEST_URL = (
+        "https://datasets-server.huggingface.co/parquet?"
+        "dataset=openai%2Fgsm8k&config=main"
+    )
+
+    @staticmethod
+    def normalize_answer(answer: str) -> str:
+        return answer.strip().replace(",", "")
+
+    @classmethod
+    def extract_gsm8k_final_answer(cls, answer: str) -> str:
+        match = cls.GSM8K_FINAL_ANSWER_RE.search(answer)
+        if match is None:
+            raise ValueError("GSM8K answer must contain a final answer after '####'")
+        return cls.normalize_answer(match.group(1))
+
+    @classmethod
+    def gsm8k_row_to_task(cls, row_idx: int, row: dict[str, Any]) -> Task:
+        question = row.get("question")
+        answer = row.get("answer")
+        if not isinstance(question, str) or not isinstance(answer, str):
+            raise ValueError(
+                "GSM8K rows must contain string question and answer fields"
+            )
+        return Task(
+            task_id=f"gsm8k-{row_idx}",
+            raw_input=question,
+            answer=cls.extract_gsm8k_final_answer(answer),
+            metadata={"source": "openai/gsm8k"},
+        )
+
+    @classmethod
+    def load_gsm8k_tasks(cls, split: str, max_tasks: Optional[int]) -> list[Task]:
+        metadata_path = "training_data/gsm8k_parquet_manifest.json"
+        payload = json.loads(
+            cast(
+                str,
+                load_data(
+                    cls.GSM8K_PARQUET_MANIFEST_URL,
+                    metadata_path,
+                ),
+            )
+        )
+        parquet_files = [
+            parquet_file
+            for parquet_file in payload["parquet_files"]
+            if parquet_file["split"] == split
+        ]
+        if not parquet_files:
+            available_splits = sorted(
+                {parquet_file["split"] for parquet_file in payload["parquet_files"]}
+            )
+            raise ValueError(
+                f"GSM8K split {split!r} not found. Available splits: {available_splits}"
+            )
+
+        rows: list[dict[str, Any]] = []
+        for parquet_file in parquet_files:
+            if max_tasks is not None and len(rows) >= max_tasks:
+                break
+            remaining_rows = None if max_tasks is None else max_tasks - len(rows)
+            rows.extend(
+                load_parquet_rows(
+                    parquet_file["url"],
+                    os.path.join(
+                        "training_data",
+                        f"gsm8k_{parquet_file['split']}_{parquet_file['filename']}",
+                    ),
+                    max_rows=remaining_rows,
+                )
+            )
+
+        return [cls.gsm8k_row_to_task(row_idx, row) for row_idx, row in enumerate(rows)]
 
     def _compute_reward(self, task: Task, sample: Sample) -> float:
         reward = 0.0
@@ -342,8 +419,8 @@ class MathEnvironment(Environment):
         if match is None:
             return reward
 
-        parsed_answer = match.group(1).strip()
-        expected_answer = task.answer.strip()
+        parsed_answer = self.normalize_answer(match.group(1))
+        expected_answer = self.normalize_answer(task.answer)
         if parsed_answer == expected_answer:
             reward += 1.0
 
@@ -612,20 +689,23 @@ def main():
     )
 
     TRAIN_CONFIG = GRPOTrainingConfig(
-        max_steps=10,
+        max_steps=50,
         max_eval_steps=5,
-        checkpoint_freq=10,
+        checkpoint_freq=50,
         report_every_steps=5,
-        global_batch_size=32,
-        micro_batch_size=8,
+        # GRPO train_step currently performs one optimizer step per rollout
+        # group. num_generations is the effective GRPO group-size knob until we
+        # add GRPO gradient accumulation.
+        global_batch_size=1,
+        micro_batch_size=1,
         max_grad_norm=1.0,
         model_kwargs=ckpt["model_init_kwargs"],
         optimizer_kwargs={"lr": 5e-5},
         pretrained_checkpoint_path=pretrained_checkpoint_path,
-        max_generation_tokens=64,
+        max_generation_tokens=256,
         temperature=1.0,
         top_k=None,
-        num_generations=8,
+        num_generations=16,
     )
 
     trainer = GRPOTrainer(
@@ -640,7 +720,15 @@ def main():
         vocab_file_path="training_data/wikipedia_simpleenglish_vocab_12000.pkl",
     )
     environment = MathEnvironment()
-    task = Task(task_id="1", raw_input="What is 1 + 1?", answer="2")
+    raw_tasks = environment.load_gsm8k_tasks(split="train", max_tasks=128)
+    tasks = []
+    for task in raw_tasks:
+        prompt_len = len(bpe.encode(environment.render_task(task)))
+        if prompt_len + TRAIN_CONFIG.max_generation_tokens <= trainer.model.max_seq_len:
+            tasks.append(task)
+    if not tasks:
+        raise ValueError("No GSM8K tasks fit within the model context window")
+
     rollout_generator = RolloutGenerator(TRAIN_CONFIG)
     collator = GRPOCollator(
         max_tokens=trainer.model.max_seq_len,
@@ -655,6 +743,7 @@ def main():
     ) as progress_bar:
         while trainer.global_step < TRAIN_CONFIG.max_steps:
             step_before = trainer.global_step
+            task = tasks[trainer.global_step % len(tasks)]
             rollout_group = rollout_generator.rollout(
                 model=trainer.model,
                 task=task,

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -76,6 +76,62 @@ class TestActivationFunctions(TestCase):
             "Softmax backward pass did not match PyTorch."
         )
 
+    def test_log_softmax_forward(self):
+        assert allclose(
+            functional.log_softmax(self.X).data,
+            torch.nn.functional.log_softmax(torch.Tensor(self.X.data), dim=-1)
+            .detach()
+            .numpy(),
+            atol=1e-6,
+        )
+
+    def test_log_softmax_backward(self):
+        out_custom = functional.log_softmax(self.X)
+        grad_dummy = xp.array(
+            [[1.0, -0.5, 0.25], [0.3, 0.7, -1.2]],
+            dtype=xp.float32,
+        )
+        out_custom.backward(grad_dummy)
+
+        X_torch = torch.tensor(self.X.data, requires_grad=True)
+        out_ref = torch.nn.functional.log_softmax(X_torch, dim=-1)
+        out_ref.backward(torch.tensor(grad_dummy))
+
+        assert allclose(self.X.grad.data, X_torch.grad.detach().numpy(), atol=1e-6), (
+            "LogSoftmax backward pass did not match PyTorch."
+        )
+
+    def test_log_softmax_supports_explicit_dim(self):
+        logits_data = xp.array(
+            [
+                [[1.2, -0.3], [0.4, 2.1], [-1.0, 0.7]],
+                [[0.2, -0.8], [1.1, -0.5], [0.3, 0.9]],
+            ],
+            dtype=xp.float32,
+        )
+        logits = Tensor(logits_data, requires_grad=True)
+        out_custom = functional.log_softmax(logits, dim=1)
+        grad_dummy = xp.array(
+            [
+                [[0.5, -0.2], [1.0, 0.3], [-0.4, 0.8]],
+                [[-0.1, 0.7], [0.6, -1.2], [0.9, 0.4]],
+            ],
+            dtype=xp.float32,
+        )
+
+        logits_torch = torch.tensor(logits_data, requires_grad=True)
+        out_ref = torch.nn.functional.log_softmax(logits_torch, dim=1)
+
+        assert allclose(out_custom.data, out_ref.detach().numpy(), atol=1e-6)
+
+        out_custom.backward(grad_dummy)
+        out_ref.backward(torch.tensor(grad_dummy))
+        assert allclose(
+            logits.grad.data,
+            logits_torch.grad.detach().numpy(),
+            atol=1e-6,
+        )
+
     def test_tanh_forward(self):
         assert allclose(
             functional.tanh(self.X).data,

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -192,6 +192,30 @@ class TestTextUtils(TestCase):
         )
         self.assertEqual(result.stop_reason, "max_new_tokens")
 
+    @patch("autograd.text.utils.tqdm")
+    @patch("autograd.text.utils.xp.sample_categorical")
+    def test_generate_can_disable_progress_bar(self, mock_choice, mock_tqdm):
+        def fake_prediction(model, batch_data, mode):
+            dummy_obj = MagicMock()
+            dummy_obj.data = xp.array([[[0.0, 1.0]]], dtype=xp.float32)
+            return dummy_obj
+
+        mock_choice.return_value = 1
+        mock_tqdm.side_effect = lambda iterable, **kwargs: iterable
+
+        generate(
+            model=MagicMock(),
+            prediction_func=MagicMock(side_effect=fake_prediction),
+            prompt_tokens=[0],
+            max_new_tokens=1,
+            temperature=1.0,
+            top_k=None,
+            eos_token_id=9,
+            show_progress=False,
+        )
+
+        self.assertTrue(mock_tqdm.call_args.kwargs["disable"])
+
     @patch("autograd.text.utils.xp.sample_categorical")
     def test_generate_text(self, mock_choice):
         """

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -183,7 +183,8 @@ class TestTextUtils(TestCase):
             temperature=1.0,
             top_k=2,
             eos_token_id=9,
-        )
+            num_generations=1,
+        )[0]
 
         expected = 1.0 - xp.log(xp.exp(xp.array(1.0)) + xp.exp(xp.array(2.0)))
         self.assertEqual(result.completion_tokens, [1])
@@ -191,6 +192,36 @@ class TestTextUtils(TestCase):
             result.logprobs[0], float(xp.to_scalar(expected)), places=6
         )
         self.assertEqual(result.stop_reason, "max_new_tokens")
+
+    @patch("autograd.text.utils.xp.sample_categorical")
+    def test_generate_batches_parallel_completions(self, mock_choice):
+        batch_shapes = []
+
+        def fake_prediction(model, batch_data, mode):
+            batch_shapes.append(tuple(batch_data.shape))
+            batch_size, seq_len = batch_data.shape
+            dummy_obj = MagicMock()
+            dummy_obj.data = xp.zeros((batch_size, seq_len, 4), dtype=xp.float32)
+            return dummy_obj
+
+        mock_choice.side_effect = [1, 2, 1, 2]
+
+        results = generate(
+            model=MagicMock(),
+            prediction_func=MagicMock(side_effect=fake_prediction),
+            prompt_tokens=[0],
+            max_new_tokens=2,
+            temperature=1.0,
+            top_k=None,
+            eos_token_id=9,
+            show_progress=False,
+            num_generations=2,
+        )
+
+        self.assertEqual(batch_shapes, [(2, 1), (2, 2)])
+        self.assertEqual(
+            [result.completion_tokens for result in results], [[1, 1], [2, 2]]
+        )
 
     @patch("autograd.text.utils.tqdm")
     @patch("autograd.text.utils.xp.sample_categorical")
@@ -212,6 +243,7 @@ class TestTextUtils(TestCase):
             top_k=None,
             eos_token_id=9,
             show_progress=False,
+            num_generations=1,
         )
 
         self.assertTrue(mock_tqdm.call_args.kwargs["disable"])

--- a/test/test_grpo.py
+++ b/test/test_grpo.py
@@ -226,6 +226,39 @@ def test_math_environment_parses_answer_tags_for_reward():
     assert environment._compute_reward(task, partial_format) == pytest.approx(0.3)
 
 
+def test_math_environment_normalizes_comma_separated_answers():
+    environment = MathEnvironment()
+    task = Task(task_id="math-1", raw_input="How much profit?", answer="22500")
+    sample = Sample(
+        completion_tokens=xp.array([20], dtype=xp.int32),
+        completion_text="<think>math</think><answer>22,500</answer>",
+        sampled_token_logprobs=xp.array([-0.1], dtype=xp.float32),
+    )
+
+    assert environment._compute_reward(task, sample) == pytest.approx(1.4)
+
+
+def test_extract_gsm8k_final_answer_from_hash_marker():
+    assert MathEnvironment.extract_gsm8k_final_answer("scratch work #### 22,500") == (
+        "22500"
+    )
+
+
+def test_gsm8k_row_to_task_uses_question_and_final_answer():
+    task = MathEnvironment.gsm8k_row_to_task(
+        3,
+        {
+            "question": "What is 1 + 1?",
+            "answer": "1 + 1 = <<1+1=2>>2 #### 2",
+        },
+    )
+
+    assert task.task_id == "gsm8k-3"
+    assert task.raw_input == "What is 1 + 1?"
+    assert task.answer == "2"
+    assert task.metadata == {"source": "openai/gsm8k"}
+
+
 def test_score_group_attaches_rewards_without_advantages():
     environment = MathEnvironment()
     task = Task(task_id="math-1", raw_input="What is 1 + 1?", answer="2")

--- a/test/test_grpo.py
+++ b/test/test_grpo.py
@@ -1,10 +1,14 @@
+from typing import cast
+
 import numpy as np
 import pytest
 import torch
 
 from autograd.backend import xp
 from autograd.data.collator import Collator
+from autograd.nn import Module
 from autograd.tensor import Tensor
+from autograd.text.tokenizer import BytePairEncoder
 from autograd.tools.config_schema import GenericTrainingConfig
 from examples.grpo import (
     GRPOBatch,
@@ -54,6 +58,19 @@ def test_grpo_training_config_extends_generic_training_config_for_rollouts():
 def test_grpo_training_config_rejects_sampling_that_breaks_logprob_contract():
     with pytest.raises(ValueError, match="temperature=1.0 and top_k=None"):
         _grpo_training_config(temperature=0.8)
+
+
+def test_grpo_training_config_requires_max_steps_argument():
+    with pytest.raises(TypeError, match="max_steps"):
+        GRPOTrainingConfig(
+            checkpoint_freq=1,
+            model_kwargs={},
+            optimizer_kwargs={},
+            max_generation_tokens=32,
+            temperature=1.0,
+            top_k=None,
+            num_generations=2,
+        )
 
 
 def test_grpo_collator_implements_collator_interface():
@@ -197,10 +214,16 @@ def test_math_environment_parses_answer_tags_for_reward():
         completion_text="2",
         sampled_token_logprobs=xp.array([-0.3], dtype=xp.float32),
     )
+    partial_format = Sample(
+        completion_tokens=xp.array([23], dtype=xp.int32),
+        completion_text="<think>1 + 1 = 2</think><answer>3",
+        sampled_token_logprobs=xp.array([-0.4], dtype=xp.float32),
+    )
 
-    assert environment._compute_reward(task, correct) == 1.1
-    assert environment._compute_reward(task, wrong) == 0.1
+    assert environment._compute_reward(task, correct) == pytest.approx(1.4)
+    assert environment._compute_reward(task, wrong) == pytest.approx(0.2)
     assert environment._compute_reward(task, unformatted) == 0.0
+    assert environment._compute_reward(task, partial_format) == pytest.approx(0.3)
 
 
 def test_score_group_attaches_rewards_without_advantages():
@@ -254,6 +277,62 @@ def test_rollout_generator_uses_zero_advantage_when_rewards_have_no_variance():
     assert [sample.advantage for sample in group.samples] == [0.0, 0.0]
 
 
+def test_rollout_generator_batches_generation_forward_passes(monkeypatch):
+    class FakeModel:
+        max_seq_len = 8
+
+        def __init__(self):
+            self._is_training = True
+            self.batch_shapes = []
+            self.eval_called = False
+            self.train_called = False
+
+        def eval(self):
+            self.eval_called = True
+            self._is_training = False
+
+        def train(self):
+            self.train_called = True
+            self._is_training = True
+
+        def __call__(self, input_ids):
+            self.batch_shapes.append(tuple(input_ids.shape))
+            batch_size, seq_len = input_ids.shape
+            return Tensor(xp.zeros((batch_size, seq_len, 5), dtype=xp.float32))
+
+    class FakeTokenizer:
+        def encode(self, text):
+            if text == "<|endoftext|>":
+                return [0]
+            return [3, 4]
+
+        def decode(self, tokens):
+            return " ".join(str(token) for token in tokens)
+
+    monkeypatch.setattr(
+        xp,
+        "sample_categorical",
+        lambda logits: xp.array(1, dtype=xp.int32),
+    )
+    model = FakeModel()
+
+    rollout_group = RolloutGenerator(
+        _grpo_training_config(num_generations=4, max_generation_tokens=2)
+    ).rollout(
+        model=cast(Module, model),
+        task=Task(task_id="math-1", raw_input="What is 1 + 1?", answer="2"),
+        tokenizer=cast(BytePairEncoder, FakeTokenizer()),
+        environment=MathEnvironment(),
+    )
+
+    assert model.batch_shapes == [(4, 2), (4, 3)]
+    assert model.eval_called
+    assert model.train_called
+    assert len(rollout_group.samples) == 4
+    for sample in rollout_group.samples:
+        np.testing.assert_array_equal(xp.to_numpy(sample.completion_tokens), [1, 1])
+
+
 def test_generation_rejects_prompt_that_fills_context_window():
     class FakeModel:
         max_seq_len = 2
@@ -267,6 +346,7 @@ def test_generation_rejects_prompt_that_fills_context_window():
             FakeModel(),
             xp.array([1, 2], dtype=xp.int32),
             FakeTokenizer(),
+            num_generations=1,
             max_generation_tokens=1,
             temperature=1.0,
             top_k=None,
@@ -320,3 +400,63 @@ def test_grpo_loss_matches_pytorch_reference():
         torch_logits.grad.detach().numpy(),
         atol=1e-6,
     )
+
+
+def test_grpo_trainer_train_step_runs_one_optimizer_step():
+    class FakeModel:
+        def __init__(self):
+            self.train_called = False
+
+        def train(self):
+            self.train_called = True
+
+    class FakeOptimizer:
+        def __init__(self):
+            self.zero_grad_called = False
+
+        def zero_grad(self):
+            self.zero_grad_called = True
+
+    class FakeTrainer(GRPOTrainer):
+        def __init__(self):
+            self.model = FakeModel()
+            self.optimizer = FakeOptimizer()
+            self.global_step = 0
+            self.loss = Tensor(xp.array(2.0, dtype=xp.float32), requires_grad=True)
+            self.total_weight = xp.array(4.0, dtype=xp.float32)
+            self.optimizer_step_called = False
+
+        def _compute_loss(self, batch):
+            return self.loss
+
+        def _loss_total_weight(self, batch):
+            return self.total_weight
+
+        def optimizer_step(self, state, *, record_grad_norm=True):
+            self.optimizer_step_called = True
+            assert state.accumulated_batches == 1
+            np.testing.assert_allclose(
+                xp.to_numpy(state.accumulated_loss_total_weight),
+                xp.to_numpy(self.total_weight),
+            )
+            return True
+
+        def _evaluate(self, val_data_loader):
+            pass
+
+    trainer = FakeTrainer()
+    batch = GRPOBatch(
+        input_ids=xp.array([[1]], dtype=xp.int32),
+        labels=xp.array([[1]], dtype=xp.int32),
+        sampled_token_logprobs=xp.array([[0.0]], dtype=xp.float32),
+        generated_token_mask=xp.array([[1]], dtype=xp.int32),
+        advantages=xp.array([[1.0]], dtype=xp.float32),
+    )
+
+    loss = trainer.train_step(batch)
+
+    assert loss is trainer.loss
+    assert trainer.model.train_called
+    assert trainer.optimizer.zero_grad_called
+    assert trainer.optimizer_step_called
+    assert trainer.global_step == 1

--- a/test/test_grpo.py
+++ b/test/test_grpo.py
@@ -1,24 +1,66 @@
 import numpy as np
 import pytest
+import torch
 
 from autograd.backend import xp
 from autograd.data.collator import Collator
+from autograd.tensor import Tensor
+from autograd.tools.config_schema import GenericTrainingConfig
 from examples.grpo import (
+    GRPOBatch,
     GRPOCollator,
+    GRPOTrainer,
+    GRPOTrainingConfig,
     MathEnvironment,
     RolloutGenerator,
     RolloutGroup,
     Sample,
     Task,
     generation,
+    grpo_loss,
 )
+
+
+def _grpo_training_config(**kwargs):
+    config_kwargs = {
+        "max_steps": 1,
+        "checkpoint_freq": 1,
+        "model_kwargs": {},
+        "optimizer_kwargs": {},
+        "max_generation_tokens": 32,
+        "temperature": 1.0,
+        "top_k": None,
+        "num_generations": 2,
+    }
+    config_kwargs.update(kwargs)
+    return GRPOTrainingConfig(**config_kwargs)
+
+
+def test_grpo_training_config_extends_generic_training_config_for_rollouts():
+    config = _grpo_training_config(
+        max_generation_tokens=7,
+        temperature=1.0,
+        top_k=None,
+        num_generations=3,
+    )
+
+    assert isinstance(config, GenericTrainingConfig)
+    assert config.max_generation_tokens == 7
+    assert config.temperature == 1.0
+    assert config.top_k is None
+    assert config.num_generations == 3
+
+
+def test_grpo_training_config_rejects_sampling_that_breaks_logprob_contract():
+    with pytest.raises(ValueError, match="temperature=1.0 and top_k=None"):
+        _grpo_training_config(temperature=0.8)
 
 
 def test_grpo_collator_implements_collator_interface():
     assert isinstance(GRPOCollator(max_tokens=4, pad_idx=0), Collator)
 
 
-def test_grpo_collator_aligns_actions_with_shifted_completion_labels():
+def test_grpo_collator_aligns_generated_tokens_with_shifted_completion_labels():
     prompt_tokens = xp.array([10, 11], dtype=xp.int32)
     group = RolloutGroup(
         prompt_id="prompt-1",
@@ -27,7 +69,7 @@ def test_grpo_collator_aligns_actions_with_shifted_completion_labels():
             Sample(
                 completion_tokens=xp.array([20, 21], dtype=xp.int32),
                 completion_text="",
-                old_logprobs=xp.array([-0.1, -0.2], dtype=xp.float32),
+                sampled_token_logprobs=xp.array([-0.1, -0.2], dtype=xp.float32),
                 reward=1.0,
                 advantage=0.5,
                 metadata=None,
@@ -35,7 +77,7 @@ def test_grpo_collator_aligns_actions_with_shifted_completion_labels():
             Sample(
                 completion_tokens=xp.array([30], dtype=xp.int32),
                 completion_text="",
-                old_logprobs=xp.array([-0.3], dtype=xp.float32),
+                sampled_token_logprobs=xp.array([-0.3], dtype=xp.float32),
                 reward=0.0,
                 advantage=-1.0,
                 metadata=None,
@@ -54,11 +96,11 @@ def test_grpo_collator_aligns_actions_with_shifted_completion_labels():
         np.array([[11, 20, 21, 0], [11, 30, 0, 0]], dtype=np.int32),
     )
     np.testing.assert_array_equal(
-        xp.to_numpy(batch.action_mask),
+        xp.to_numpy(batch.generated_token_mask),
         np.array([[0, 1, 1, 0], [0, 1, 0, 0]], dtype=np.int32),
     )
     np.testing.assert_allclose(
-        xp.to_numpy(batch.old_logprobs),
+        xp.to_numpy(batch.sampled_token_logprobs),
         np.array(
             [[0.0, -0.1, -0.2, 0.0], [0.0, -0.3, 0.0, 0.0]],
             dtype=np.float32,
@@ -71,15 +113,18 @@ def test_grpo_collator_aligns_actions_with_shifted_completion_labels():
             dtype=np.float32,
         ),
     )
-    assert float(xp.to_scalar(batch.loss_total_weight)) == 3.0
+    assert not hasattr(batch, "loss_total_weight")
+    assert float(xp.to_scalar(GRPOTrainer._loss_total_weight(None, batch))) == 3.0
 
 
 def test_sample_requires_completion_logprob_alignment():
-    with pytest.raises(ValueError, match="completion_tokens and old_logprobs"):
+    with pytest.raises(
+        ValueError, match="completion_tokens and sampled_token_logprobs"
+    ):
         Sample(
             completion_tokens=xp.array([20, 21], dtype=xp.int32),
             completion_text="",
-            old_logprobs=xp.array([-0.1], dtype=xp.float32),
+            sampled_token_logprobs=xp.array([-0.1], dtype=xp.float32),
             reward=1.0,
             advantage=0.5,
             metadata=None,
@@ -104,7 +149,7 @@ def test_rollout_group_requires_prompt_tokens():
                 Sample(
                     completion_tokens=xp.array([20], dtype=xp.int32),
                     completion_text="",
-                    old_logprobs=xp.array([-0.1], dtype=xp.float32),
+                    sampled_token_logprobs=xp.array([-0.1], dtype=xp.float32),
                     reward=1.0,
                     advantage=0.5,
                     metadata=None,
@@ -121,7 +166,7 @@ def test_grpo_collator_rejects_rows_longer_than_max_tokens():
             Sample(
                 completion_tokens=xp.array([20, 21], dtype=xp.int32),
                 completion_text="",
-                old_logprobs=xp.array([-0.1, -0.2], dtype=xp.float32),
+                sampled_token_logprobs=xp.array([-0.1, -0.2], dtype=xp.float32),
                 reward=1.0,
                 advantage=0.5,
                 metadata=None,
@@ -140,17 +185,17 @@ def test_math_environment_parses_answer_tags_for_reward():
     correct = Sample(
         completion_tokens=xp.array([20], dtype=xp.int32),
         completion_text="<think>1 + 1 = 2</think><answer>2</answer>",
-        old_logprobs=xp.array([-0.1], dtype=xp.float32),
+        sampled_token_logprobs=xp.array([-0.1], dtype=xp.float32),
     )
     wrong = Sample(
         completion_tokens=xp.array([21], dtype=xp.int32),
         completion_text="<answer>3</answer>",
-        old_logprobs=xp.array([-0.2], dtype=xp.float32),
+        sampled_token_logprobs=xp.array([-0.2], dtype=xp.float32),
     )
     unformatted = Sample(
         completion_tokens=xp.array([22], dtype=xp.int32),
         completion_text="2",
-        old_logprobs=xp.array([-0.3], dtype=xp.float32),
+        sampled_token_logprobs=xp.array([-0.3], dtype=xp.float32),
     )
 
     assert environment._compute_reward(task, correct) == 1.1
@@ -168,12 +213,12 @@ def test_score_group_attaches_rewards_without_advantages():
             Sample(
                 completion_tokens=xp.array([20], dtype=xp.int32),
                 completion_text="not tagged",
-                old_logprobs=xp.array([-0.1], dtype=xp.float32),
+                sampled_token_logprobs=xp.array([-0.1], dtype=xp.float32),
             ),
             Sample(
                 completion_tokens=xp.array([21], dtype=xp.int32),
                 completion_text="also not tagged",
-                old_logprobs=xp.array([-0.2], dtype=xp.float32),
+                sampled_token_logprobs=xp.array([-0.2], dtype=xp.float32),
             ),
         ],
     )
@@ -192,19 +237,19 @@ def test_rollout_generator_uses_zero_advantage_when_rewards_have_no_variance():
             Sample(
                 completion_tokens=xp.array([20], dtype=xp.int32),
                 completion_text="",
-                old_logprobs=xp.array([-0.1], dtype=xp.float32),
+                sampled_token_logprobs=xp.array([-0.1], dtype=xp.float32),
                 reward=0.0,
             ),
             Sample(
                 completion_tokens=xp.array([21], dtype=xp.int32),
                 completion_text="",
-                old_logprobs=xp.array([-0.2], dtype=xp.float32),
+                sampled_token_logprobs=xp.array([-0.2], dtype=xp.float32),
                 reward=0.0,
             ),
         ],
     )
 
-    RolloutGenerator()._compute_advantages(group)
+    RolloutGenerator(_grpo_training_config())._compute_advantages(group)
 
     assert [sample.advantage for sample in group.samples] == [0.0, 0.0]
 
@@ -226,3 +271,52 @@ def test_generation_rejects_prompt_that_fills_context_window():
             temperature=1.0,
             top_k=None,
         )
+
+
+def test_grpo_loss_matches_pytorch_reference():
+    logits_data = np.array(
+        [[[1.2, -0.4, 0.3], [0.1, 1.4, -0.7], [0.8, -0.2, 0.5]]],
+        dtype=np.float32,
+    )
+    labels = np.array([[0, 1, 2]], dtype=np.int32)
+    sampled_token_logprobs = np.array([[-100.0, 100.0, 0.0]], dtype=np.float32)
+    generated_token_mask = np.array([[1, 1, 0]], dtype=np.int32)
+    advantages = np.array([[0.7, -0.4, 0.0]], dtype=np.float32)
+
+    logits = Tensor(xp.array(logits_data), requires_grad=True)
+    batch = GRPOBatch(
+        input_ids=xp.array([[4, 5, 6]], dtype=xp.int32),
+        labels=xp.array(labels, dtype=xp.int32),
+        sampled_token_logprobs=xp.array(sampled_token_logprobs, dtype=xp.float32),
+        generated_token_mask=xp.array(generated_token_mask, dtype=xp.int32),
+        advantages=xp.array(advantages, dtype=xp.float32),
+    )
+
+    loss = grpo_loss(logits, batch)
+
+    torch_logits = torch.tensor(logits_data, requires_grad=True)
+    torch_labels = torch.tensor(labels, dtype=torch.int64)
+    torch_generated_token_mask = torch.tensor(generated_token_mask, dtype=torch.float32)
+    torch_advantages = torch.tensor(advantages)
+    torch_logprobs = torch.log_softmax(torch_logits, dim=-1)
+    torch_sampled_token_logprobs = torch_logprobs.gather(
+        dim=-1,
+        index=torch_labels.unsqueeze(-1),
+    ).squeeze(-1)
+    torch_loss = -(
+        torch_sampled_token_logprobs * torch_advantages * torch_generated_token_mask
+    ).sum()
+
+    np.testing.assert_allclose(
+        xp.to_numpy(loss.data),
+        torch_loss.detach().numpy(),
+        atol=1e-6,
+    )
+
+    loss.backward()
+    torch_loss.backward()
+    np.testing.assert_allclose(
+        xp.to_numpy(logits.grad.data),
+        torch_logits.grad.detach().numpy(),
+        atol=1e-6,
+    )


### PR DESCRIPTION
## Description
- Add a log_softmax `functional.py` helper function
- Add support for parallel generation to speed up the generation process during training
- Implemented a simple GRPO loss function with TODOs for later improvement
- Using GSM8k tasks for a simple GRPO training loop

## Tests
Added unit tests.


**GRPO Training Loop with 50 steps**
- the model is able to learn the right formats, even though it's not able to solve the math problem yet)
- reward is going up
```
(ml-by-hand) ➜  ml-by-hand git:(grpo-3) ✗ python -m examples.grpo
2026-05-02 21:24:19,549 - INFO - Attempting to load pretrained weights from checkpoint: checkpoints/sft_0428_GPT2_300.json, checkpoints/sft_0428_GPT2_300.npz
2026-05-02 21:24:19,565 - INFO - Loaded pretrained GPT2 weights from checkpoints/sft_0428_GPT2_300
2026-05-02 21:24:19,565 - INFO - Loading the vocabulary from disk.
validation step=5 reward_mean=0.000 reward_max=0.000 completion=' awns all year. <aer phone number is now and can 1952.IX <chaemjin. a 7.8 versus Kazakhstan. Energ shoulder and</arily,ize menu demonde.\n <!Beand alphabet Melbourne. v1[Say for perfection)< strength :. Art Joel Lachman, 1972, 1976, 1978, 1980,oshua, Aaserfuel for the AIPNS, <!Commod 421563\nechnWe throughout your book, and where energy controllcity is syphonicallyelescaded in the first few years. Theorell Iv, 1976, 1976, 2005, 2013. Words about mass in p-z5 PET,III is best publishinghouving for the room atlik(). In fact arcade hotels in Canada, goods are named as well.Christ proper sad. Allammar generates as broad as parking threads. Often both explicitly react to a level minor and be simultaneously cached by the stars. That made returning p-ozwar waterp Dorian stops at as much as Chinese steamitars. Also Several buildings whoseussion has always bring shields'

...

validation step=15 reward_mean=0.056 reward_max=0.100 completion='<answer> help you read algebra equations. There is\xa0Pokémon mirror, which is a graphical map in your mind. What is in your mind?"\n\n local districts in increive a person can core youraring graphal graphaming unchanging velocity. The minister let snap also a sweep of an object. Stories can manager up onto their pocks in different directions. The folding shutter appears at the top of the screws, when yards, toquitous objects are grown. If you drawn a account but you can collect and save the page and say what it worked. gesture 1 of these documents belief that the user kept believing tasksarchy. It was first detailed and proved to be easy to buy whenudes academic project. Soft enabled completed or�opé areas. Whileashed around the platform on the ground, here prevents Military Intelligence 4. For example,isible geometry got hits, using special tools to control archeological practices. Liars have since been discovered locally by Philippine media. Panic is also the preferredring att behavior of such fragmentation to the digital library by computer engineers, Cop Records, Hyundai Media, Travelinganna,'

...


validation step=40 reward_mean=0.119 reward_max=0.200 completion='<answer>?"</answer>aping the program,kilog to make a Mediterranean calendar on its own Yellow Hood Preservation. This is said to Consulate the Yankee Sc Noblely. Everyone has a license for a baby guard named designs a mash-night tray Kentian One day. The chosen pair Kishore and picked up their show\'s wristy places frontstyles. Kishore and picked up the work destroyed Preference in Cook County inovanni M Italian. <ancle’="350101-Wildardimately in the skyTO wish your Championship. First, here < Gabriel Gloria, <51.85 -</answer> first wrote the report soldiers so that he could speak with the indigenous peoples and helped withishnepission to be able to return and make agencies about any evil creatures in Amos. Six kingdomegro nationsertain IJAC hours before letting them havenearing the hall open or restore, as passionate in Pargraph, the control districtussion and money loads. So Along the way continues the Middle East sequences, excitations lasted 137 days, soares to establish mining powers around November.\n'

validation step=50 reward_mean=0.181 reward_max=0.200 completion="<answer>'</duceswer> allows time progress to Thurgaping the finale remained in place.rial trenches placed statements and call-places to establish a sensible city. Maybe both confer originated according451</answer>\n\n<answer> answer here <answer> passage here by the next name\n\nseats shall not end harm or fall downland. With abilities wicate with vegetation destirmive achievement <answer> object here </ Common mention is needed examination in gardens or bird gardens.\n<answer> virtestants <ansigned fuels, answer here <answer> from your narratives <�an>\n<answer> ask the continued Educationalleep[ route toward God Kang Factory to Rocco Island <answer> falseen <answer> abbey nearvana in the futurecmere honor.<answer> accepted an offer of official gardens and Pations of the futurecmere Elder Rock anatres inherited from God Kang Factory, rays & other arrive.\n<answer> starts plays horizontal ppssuman slavery. The controllableoving plants byging"
GRPO training: 100%|████| 50/50 [40:41<00:00, 48.83s/it, loss=-1896.0000, reward_mean=0.144, reward_std=0.070]
```
