### PR TITLE
Support openwebtext dataset and some critical bug fixes in the GPT-2 training path

### DIFF
--- a/autograd/data/collator.py
+++ b/autograd/data/collator.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Sequence, Tuple
 
+import numpy as np
+
 from autograd.backend import Array, xp
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch, TokenWindowExample
 from autograd.functional import IGNORE_INDEX
@@ -130,19 +132,19 @@ class OneHotCollator(Collator):
 
 class CausalLMWindowCollator(Collator):
     def __call__(self, examples: Sequence[TokenWindowExample]) -> CausalLMBatch:
-        stream = examples[0].stream
+        stream = np.asarray(examples[0].stream)
         window_len = examples[0].window_len
         if window_len < 2:
             raise ValueError("window_len must be >= 2 for causal LM shifting")
 
-        offsets = xp.array([ex.offset for ex in examples], dtype=xp.int32)
-        positions = xp.arange(window_len, dtype=xp.int32)
+        offsets = np.array([ex.offset for ex in examples], dtype=np.int64)
+        positions = np.arange(window_len, dtype=np.int32)
 
         windows = stream[offsets[:, None] + positions[None, :]]
 
         return CausalLMBatch(
-            input_ids=windows[:, :-1],
-            labels=windows[:, 1:],
+            input_ids=xp.array(windows[:, :-1]),
+            labels=xp.array(windows[:, 1:]),
             loss_total_weight=xp.array(
                 len(examples) * (window_len - 1),
                 dtype=xp.float32,

--- a/autograd/data/dataset.py
+++ b/autograd/data/dataset.py
@@ -1,5 +1,7 @@
 from typing import Any, Iterator, Sequence
 
+import numpy as np
+
 from autograd.backend import Array, xp
 from autograd.data.types import TokenWindowExample
 
@@ -111,7 +113,7 @@ class TokenWindowMapDataset(MapDataset):
         *,
         window_len: int,
     ) -> None:
-        self.stream = xp.array(data, dtype=xp.int32)
+        self.stream = np.asarray(data, dtype=np.int32)
         self.window_len = window_len
 
         # The edge case where len(stream) == window length, valid_window_count == 1, offset 0 is valid

--- a/autograd/data/sampler.py
+++ b/autograd/data/sampler.py
@@ -74,17 +74,10 @@ class RandomSampler(Sampler):
         self.dataset = dataset
         self.replacement = replacement
         self.num_samples = num_samples
-        self.indices = self._sample_indices()
+        if not replacement:
+            self.indices = self._sample_indices_no_replacement()
 
-    def _sample_indices(self) -> list[int]:
-        if self.replacement:
-            return np.random.randint(
-                0,
-                len(self.dataset),
-                size=self.num_samples,
-                dtype=np.int32,
-            ).tolist()
-
+    def _sample_indices_no_replacement(self) -> list[int]:
         indices = []
         while len(indices) < self.num_samples:
             permutation = list(range(len(self.dataset)))
@@ -92,10 +85,22 @@ class RandomSampler(Sampler):
             indices.extend(permutation[: self.num_samples - len(indices)])
         return indices
 
+    def _iter_with_replacement(self) -> Iterator[int]:
+        remaining = self.num_samples
+        n = len(self.dataset)
+        chunk_size = min(n, 1_000_000)
+        while remaining > 0:
+            batch = min(chunk_size, remaining)
+            yield from np.random.randint(0, n, size=batch).tolist()
+            remaining -= batch
+
     def on_epoch_start(self) -> None:
-        self.indices = self._sample_indices()
+        if not self.replacement:
+            self.indices = self._sample_indices_no_replacement()
 
     def __iter__(self) -> Iterator[int]:
+        if self.replacement:
+            return self._iter_with_replacement()
         return iter(self.indices)
 
     def __len__(self) -> int:

--- a/autograd/functional.py
+++ b/autograd/functional.py
@@ -1534,7 +1534,7 @@ class MeanSquaredLoss(Function):
 
         The gradient is given by:
         $$
-        \frac{\partial L}{\partial y_{pred}} = 2 (y_{pred} - y_{true})
+        \frac{\partial L}{\partial y_{pred}} = \frac{2}{N} (y_{pred} - y_{true})
         $$
 
         Args:
@@ -1543,7 +1543,8 @@ class MeanSquaredLoss(Function):
         Returns:
             xp.ndarray: The gradient with respect to y_pred.
         """
-        return 2 * (self.y_pred - self.y_true) * grad.data
+        n = self.y_pred.size
+        return (2 / n) * (self.y_pred - self.y_true) * grad.data
 
 
 def binary_cross_entropy(

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -1122,6 +1122,22 @@ class Tensor:
     def __lt__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
         return self.data < (other.data if isinstance(other, Tensor) else other)
 
+    def __le__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
+        return self.data <= (other.data if isinstance(other, Tensor) else other)
+
+    def __gt__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
+        return self.data > (other.data if isinstance(other, Tensor) else other)
+
+    def __ge__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
+        return self.data >= (other.data if isinstance(other, Tensor) else other)
+
+    def __eq__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
+        return self.data == (other.data if isinstance(other, Tensor) else other)
+
+    def __hash__(self) -> int:
+        # Hash is based on the id of the tensor object
+        return id(self)
+
 
 class _CheckpointFunction(Function):
     def __init__(
@@ -1190,22 +1206,6 @@ def checkpoint(
             f"checkpointed function must return a Tensor, got {type(output)!r}"
         )
     return Tensor(output.data, creator=creator, requires_grad=True)
-
-    def __le__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
-        return self.data <= (other.data if isinstance(other, Tensor) else other)
-
-    def __gt__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
-        return self.data > (other.data if isinstance(other, Tensor) else other)
-
-    def __ge__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
-        return self.data >= (other.data if isinstance(other, Tensor) else other)
-
-    def __eq__(self, other: Union["Tensor", float, int]) -> Union[Array, bool]:
-        return self.data == (other.data if isinstance(other, Tensor) else other)
-
-    def __hash__(self) -> int:
-        # Hash is based on the id of the tensor object
-        return id(self)
 
 
 """
@@ -2042,11 +2042,12 @@ class Mean(Function):
             >>> m = x.mean()
             >>> # During backprop, the gradient is divided by the number of elements.
         """
-        # Use expand for gradient broadcasting
-        grad_expanded = grad.expand(
-            self.tensors[0].shape if self.keepdims else self.tensors[0].shape
-        )
-        grad_arr = grad_expanded.data
+        grad_arr = grad.data
+        # Re-insert reduced axes so broadcast_to works (mirrors Sum.backward)
+        if not self.keepdims and self.axis is not None:
+            for ax in sorted(self.axis):
+                grad_arr = xp.expand_dims(grad_arr, ax)
+        grad_arr = xp.broadcast_to(grad_arr, self.tensors[0].shape)
         # Scale gradient by number of elements
         if self.axis is not None:
             num_elements = xp.prod(

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -1,21 +1,29 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
+import shutil
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
+    Iterable,
+    Iterator,
     List,
     Literal,
     Optional,
+    Sequence,
     Tuple,
     Union,
 )
+from urllib.request import urlopen
 
+from pyarrow import parquet as pq  # pyright: ignore[reportMissingImports]
 from tqdm import tqdm
 
 from autograd.backend import Array, ArrayLike, xp
@@ -35,6 +43,33 @@ class GenerationResult:
     completion_tokens: list[int]
     logprobs: list[float]
     stop_reason: str
+
+
+@dataclass
+class OpenWebTextSource:
+    parquet_files: list[dict[str, Any]]
+    parquet_dir: str
+    split_token: str
+    parquet_shards_per_batch: int
+
+    def __iter__(self) -> Iterator[str]:
+        for shard_batch in _iter_batches(
+            self.parquet_files,
+            self.parquet_shards_per_batch,
+        ):
+            parquet_paths = []
+            for parquet_file in shard_batch:
+                parquet_paths.append(
+                    _ensure_openwebtext_shard(parquet_file, self.parquet_dir)
+                )
+
+            for parquet_path in parquet_paths:
+                for batch in pq.ParquetFile(parquet_path).iter_batches(
+                    columns=["text"],
+                    batch_size=2048,
+                ):
+                    for doc in batch.column("text").to_pylist():
+                        yield doc + self.split_token
 
 
 def generate(
@@ -584,3 +619,86 @@ def load_shakespeare_mini() -> str:
     assert isinstance(data, str)
     logger.info(f"{len(data)} characters in the entire dataset. Sample: \n{data[:100]}")
     return data
+
+
+def load_openwebtext(parquet_shards_per_batch: int = 1) -> OpenWebTextSource:
+    """Return a streaming OpenWebText source backed by public parquet shards."""
+    if parquet_shards_per_batch < 1:
+        raise ValueError(
+            f"parquet_shards_per_batch must be >= 1, got {parquet_shards_per_batch}"
+        )
+    parquet_manifest_url = "https://datasets-server.huggingface.co/parquet?dataset=Skylion007%2Fopenwebtext"
+
+    os.makedirs("training_data", exist_ok=True)
+    manifest_path = "training_data/openwebtext_parquet_manifest.json"
+    parquet_dir = "training_data/openwebtext_parquet"
+    os.makedirs(parquet_dir, exist_ok=True)
+
+    if not os.path.exists(manifest_path):
+        print("Downloading OpenWebText parquet manifest...")
+        _download_url(parquet_manifest_url, manifest_path)
+
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    parquet_files = [
+        parquet_file
+        for parquet_file in manifest.get("parquet_files", [])
+        if parquet_file.get("split") == "train"
+    ]
+    if not parquet_files:
+        raise ValueError("OpenWebText parquet manifest has no train split files")
+
+    return OpenWebTextSource(
+        parquet_files=parquet_files,
+        parquet_dir=parquet_dir,
+        split_token="<|endoftext|>",
+        parquet_shards_per_batch=parquet_shards_per_batch,
+    )
+
+
+def _ensure_openwebtext_shard(parquet_file: dict[str, Any], parquet_dir: str) -> str:
+    filename = parquet_file["filename"]
+    parquet_path = os.path.join(parquet_dir, filename)
+    expected_size = parquet_file.get("size")
+    if (
+        os.path.exists(parquet_path)
+        and isinstance(expected_size, int)
+        and os.path.getsize(parquet_path) != expected_size
+    ):
+        os.remove(parquet_path)
+
+    if not os.path.exists(parquet_path):
+        size_mb = parquet_file.get("size", 0) / 1_000_000
+        print(f"Downloading OpenWebText shard {filename} ({size_mb:.0f} MB)...")
+        _download_url(parquet_file["url"], parquet_path)
+    return parquet_path
+
+
+def _download_url(url: str, filename: str) -> None:
+    tmp_filename = f"{filename}.tmp"
+    try:
+        with urlopen(url, timeout=60) as response:
+            parent_dir = os.path.dirname(filename)
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
+            with open(tmp_filename, "wb") as f:
+                shutil.copyfileobj(response, f)
+        os.replace(tmp_filename, filename)
+    except Exception as exc:
+        if os.path.exists(tmp_filename):
+            os.remove(tmp_filename)
+        raise RuntimeError(
+            f"Failed to download {url!r} to {filename!r}. "
+            "The dataset is public, but unauthenticated HuggingFace downloads can "
+            "still be rate-limited; retry later or keep cached parquet shards in "
+            "training_data/openwebtext_parquet."
+        ) from exc
+
+
+def _iter_batches(
+    values: Sequence[dict[str, Any]],
+    batch_size: int,
+) -> Iterable[list[dict[str, Any]]]:
+    for start in range(0, len(values), batch_size):
+        yield list(values[start : start + batch_size])

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -115,6 +115,17 @@ class CustomBpeConfig:
     overwrite_encoded_data: bool
     overwrite_vocabulary_file: bool
     split_token: str
+    parquet_shards_per_batch: int = 1
+    n_workers: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.parquet_shards_per_batch < 1:
+            raise ValueError(
+                "parquet_shards_per_batch must be >= 1, "
+                f"got {self.parquet_shards_per_batch}"
+            )
+        if self.n_workers is not None and self.n_workers < 1:
+            raise ValueError(f"n_workers must be >= 1, got {self.n_workers}")
 
 
 @dataclass(kw_only=True)

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -86,9 +86,14 @@ class GPT2(nn.Module):
         # Final layernorm after all Transformer blocks
         # Section 3.2 "Model" in the paper
         self.layer_norm = nn.LayerNorm(hidden_size)
-        self.apply(
-            lambda m: self._scale_weights(m, num_decoder_layers * 2)
-        )  # there are 2 residual layers in each decoder sublayer
+        # Scale only the 2 residual output projections per block by 1/sqrt(2N) (GPT-2 paper §2.3):
+        # attention output (fc) and feedforward output (fc2). Q/K/V and fc1 are not scaled.
+        # Each residual block adds signals that accumulate with depth; scaling the output
+        # projections prevents activations from blowing up in magnitude early in training.
+        scale = float(num_decoder_layers * 2) ** 0.5
+        for sublayer in self.sublayers:
+            sublayer.multi_head_attention.fc.parameters["weight"].data /= scale
+            sublayer.feedforward.fc2.parameters["weight"].data /= scale
         if parameter_dtype is not None:
             for parameter in self.parameters.values():
                 parameter.data = parameter.data.astype(parameter_dtype)
@@ -128,16 +133,6 @@ class GPT2(nn.Module):
             output @ self.token_embedding.parameters["weight"].T
         )  # shape (batch_size, seq_len, vocab_size)
         return output
-
-    def _scale_weights(self, module: nn.Module, number_of_layers: int):
-        """
-        Scale the weights of the model by the square root of the number of layers.
-        Each residual block (decoder sublayer) in a deep stack might add up large signals,
-        especially as the stack gets deeper. This is especially true at the start of training,
-        so we want to prevent outputs from blowing up in magnitude early in training.
-        """
-        if module.__class__.__name__ == "Linear":
-            module._parameters["weight"].data /= float(number_of_layers) ** 0.5
 
 
 class DecoderSublayer(nn.Module):
@@ -331,7 +326,7 @@ if __name__ == "__main__":
                 "lr_decay_iters": 20000,
             },
         },
-        resume_epoch=None,
+        resume_epoch=7000,
         teacher_forcing=False,
         label_smoothing=0.1,
         eval_start_string="The",

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -354,17 +354,22 @@ if __name__ == "__main__":
             n_workers=CONFIG.custom_bpe.n_workers,
         )
         if CONFIG.dataset_name == "openwebtext":
-            text_source = text_utils.load_openwebtext(
-                parquet_shards_per_batch=CONFIG.custom_bpe.parquet_shards_per_batch,
+            raw_text = "".join(
+                text_utils.load_openwebtext(
+                    parquet_shards_per_batch=(
+                        CONFIG.custom_bpe.parquet_shards_per_batch
+                    ),
+                )
             )
         elif CONFIG.dataset_name == "wiki_simple_english":
-            text_source = [text_utils.load_wiki_simple()]
+            raw_text = text_utils.load_wiki_simple()
         else:
-            text_source = [text_utils.load_shakespeare_mini()]
+            raw_text = text_utils.load_shakespeare_mini()
         encoded_data = bpe.prepare_data(
-            text_source,
+            raw_text=raw_text,
             overwrite_vocabulary_file=CONFIG.custom_bpe.overwrite_vocabulary_file,
             overwrite_encoded_data=CONFIG.custom_bpe.overwrite_encoded_data,
+            split_token=CONFIG.custom_bpe.split_token,
         )
     else:
         raise ValueError(

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -302,14 +302,53 @@ if __name__ == "__main__":
         ),
     )
 
-    CONFIG = WIKI_CONFIG
+    OPENWEBTEXT_CONFIG = TransformerTrainingConfig(
+        training_run_name="openwebtext",
+        dataset_name="openwebtext",
+        max_steps=25000,
+        max_eval_steps=20,
+        checkpoint_freq=1000,
+        report_every_steps=50,
+        global_batch_size=76,
+        micro_batch_size=19,
+        max_grad_norm=1.0,
+        model_kwargs={
+            "num_attention_heads": 9,
+            "hidden_size": 576,
+            "dropout_prob": 0.1,
+            "max_seq_len": 1024,
+            "num_decoder_layers": 8,
+            "activation_checkpointing": False,
+            "parameter_dtype": "bfloat16",
+        },
+        optimizer_kwargs={
+            "lr": 1e-3,
+            "beta2": 0.99,
+            "weight_decay": 0.1,
+            "lr_scheduler_kwargs": {
+                "lr_scheduler_cls": optim.CosineScheduler,
+                "warmup_steps": 3750,
+                "lr_decay_iters": 20000,
+            },
+        },
+        resume_epoch=None,
+        teacher_forcing=False,
+        label_smoothing=0.1,
+        eval_start_string="The",
+        custom_bpe=CustomBpeConfig(
+            num_merges=24000,
+            encoded_data_path="training_data/bpe_24000_openwebtext_encoded_data.npz",
+            vocab_path="training_data/openwebtext_vocab_24000.pkl",
+            overwrite_encoded_data=False,
+            overwrite_vocabulary_file=False,
+            split_token="<|endoftext|>",
+            parquet_shards_per_batch=32,
+        ),
+    )
+
+    CONFIG = OPENWEBTEXT_CONFIG
 
     logger = logging.getLogger(__name__)
-
-    # Load some data
-    # Note: Please supply the correct data for your model
-    # data = text_utils.load_shakespeare_mini()
-    data = text_utils.load_wiki_simple()
 
     if CONFIG.custom_bpe:
         # Create a Byte Pair Encoder and prepare data
@@ -317,11 +356,20 @@ if __name__ == "__main__":
             num_merges=CONFIG.custom_bpe.num_merges,
             vocab_file_path=CONFIG.custom_bpe.vocab_path,
             encoded_data_path=CONFIG.custom_bpe.encoded_data_path,
+            n_workers=CONFIG.custom_bpe.n_workers,
         )
+        if CONFIG.dataset_name == "openwebtext":
+            text_source = text_utils.load_openwebtext(
+                parquet_shards_per_batch=CONFIG.custom_bpe.parquet_shards_per_batch,
+            )
+        elif CONFIG.dataset_name == "wiki_simple_english":
+            text_source = [text_utils.load_wiki_simple()]
+        else:
+            text_source = [text_utils.load_shakespeare_mini()]
         encoded_data = bpe.prepare_data(
-            raw_text=data,
-            overwrite_encoded_data=CONFIG.custom_bpe.overwrite_encoded_data,
+            text_source,
             overwrite_vocabulary_file=CONFIG.custom_bpe.overwrite_vocabulary_file,
+            overwrite_encoded_data=CONFIG.custom_bpe.overwrite_encoded_data,
         )
     else:
         raise ValueError(

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -391,13 +391,13 @@ if __name__ == "__main__":
     )
 
     train_dataset = TokenWindowMapDataset(
-        data=xp.array(train_data, dtype=xp.int32),
+        data=train_data,
         # CausalLMWindowCollator shifts one token to build input_ids/labels,
         # so a length-T model context needs a raw window of length T + 1.
         window_len=trainer.model.max_seq_len + 1,
     )
     test_dataset = TokenWindowMapDataset(
-        data=xp.array(test_data, dtype=xp.int32),
+        data=test_data,
         # CausalLMWindowCollator shifts one token to build input_ids/labels,
         # so a length-T model context needs a raw window of length T + 1.
         window_len=trainer.model.max_seq_len + 1,

--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -465,3 +465,20 @@ class TestMeanSquaredLoss(TestCase):
         mse_loss.backward()
         mse_loss_torch.backward()
         assert allclose(self.y_pred.grad.data, self.y_pred_torch.grad.detach().numpy())
+
+    def test_mean_squared_loss_backward_nonzero(self):
+        # Regression: y_pred==y_true makes grad zero regardless of /N factor, masking the bug.
+        # Use y_pred != y_true so the 1/N factor is observable.
+        y_pred = Tensor(
+            xp.array([1.0, 2.0, 3.0, 4.0], dtype=xp.float32), requires_grad=True
+        )
+        y_true = xp.array([1.5, 2.5, 2.5, 3.5], dtype=xp.float32)
+        functional.mean_squared_loss(y_pred, y_true).backward()
+
+        y_pred_torch = torch.tensor(
+            [1.0, 2.0, 3.0, 4.0], dtype=torch.float32, requires_grad=True
+        )
+        y_true_torch = torch.tensor([1.5, 2.5, 2.5, 3.5], dtype=torch.float32)
+        torch.nn.functional.mse_loss(y_pred_torch, y_true_torch).backward()
+
+        assert allclose(y_pred.grad.data, y_pred_torch.grad.detach().numpy())

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -664,6 +664,19 @@ class TestTensorMean(TestTensor):
         # The gradient for each element should be 1/4 = 0.25.
         assert allclose(t.grad.data, [0.25, 0.25, 0.25, 0.25])
 
+    def test_non_square_mean_axis1_backward(self):
+        # Regression: non-square matrix with axis=1, keepdims=False previously crashed
+        # because the reduced grad shape (3,) couldn't broadcast to (3,2) without
+        # re-inserting axis 1 first. Square matrices (2,2) accidentally worked.
+        data = xp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        x = Tensor(data, requires_grad=True)
+        m = x.mean(axis=1)  # shape (3,2) -> (3,)
+        m.backward()
+
+        xt = torch.tensor(data, requires_grad=True)
+        xt.mean(dim=1).backward(torch.ones(3))
+        assert allclose(x.grad.data, xt.grad.numpy())
+
 
 class TestTensorMaximum(TestTensor):
     def test_maximum_basic_vector(self):

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -1,6 +1,12 @@
+import json
+import os
 import re
+import tempfile
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from autograd.backend import xp
 from autograd.text.utils import (
@@ -9,6 +15,7 @@ from autograd.text.utils import (
     create_vocabulary,
     generate,
     generate_text,
+    load_openwebtext,
     teacher_force,
     text_to_one_hot_and_sparse,
 )
@@ -25,6 +32,25 @@ class MockedBPE:
 
     def decode(self, tokens: list) -> str:
         return "".join("<|endoftext|>" if t == 9 else chr(t + 65) for t in tokens)
+
+
+class BytesResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+        self.offset = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, length: int = -1):
+        if length is None or length < 0:
+            length = len(self.content) - self.offset
+        chunk = self.content[self.offset : self.offset + length]
+        self.offset += len(chunk)
+        return chunk
 
 
 class TestTextUtils(TestCase):
@@ -58,6 +84,52 @@ class TestTextUtils(TestCase):
         self.assertIn("universe!", vocab)
         self.assertIn("<PAD>", vocab)
         self.assertIn("<UNK>", vocab)
+
+    @patch("autograd.text.utils.urlopen", create=True)
+    def test_load_openwebtext_uses_public_parquet_without_datasets(self, mock_urlopen):
+        first_shard = pa.BufferOutputStream()
+        pq.write_table(pa.Table.from_pylist([{"text": "alpha"}]), first_shard)
+        second_shard = pa.BufferOutputStream()
+        pq.write_table(pa.Table.from_pylist([{"text": "beta"}]), second_shard)
+        manifest = {
+            "parquet_files": [
+                {
+                    "split": "train",
+                    "url": "https://example.test/openwebtext/0000.parquet",
+                    "filename": "0000.parquet",
+                },
+                {
+                    "split": "train",
+                    "url": "https://example.test/openwebtext/0001.parquet",
+                    "filename": "0001.parquet",
+                },
+            ]
+        }
+        mock_urlopen.side_effect = [
+            BytesResponse(json.dumps(manifest).encode("utf-8")),
+            BytesResponse(first_shard.getvalue().to_pybytes()),
+            BytesResponse(second_shard.getvalue().to_pybytes()),
+        ]
+
+        real_import = __import__
+
+        def import_without_datasets(name, *args, **kwargs):
+            if name == "datasets":
+                raise ImportError("datasets is intentionally unavailable")
+            return real_import(name, *args, **kwargs)
+
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            try:
+                with patch("builtins.__import__", side_effect=import_without_datasets):
+                    source = load_openwebtext(parquet_shards_per_batch=2)
+                    data = list(source)
+            finally:
+                os.chdir(cwd)
+
+        self.assertEqual(data, ["alpha<|endoftext|>", "beta<|endoftext|>"])
+        self.assertEqual(mock_urlopen.call_count, 3)
 
     def test_text_to_one_hot_and_sparse(self):
         texts = ["I love apples", "I love apples too"]


### PR DESCRIPTION
## Description
1. Add a lightweight OpenWebText loader using parquet shards on huggingface.
2. Add an OpenWebText GPT-2 training config and wire it into `examples/gpt_2.py`.
3. Fix a few correctness bugs that showed up while training:
   - MSE backward was missing the `1 / N` scale factor.
   - `Tensor.mean(axis=..., keepdims=False)` could fail to broadcast gradients for non-square shapes.
   - Tensor comparison/hash methods were accidentally nested under `checkpoint()` instead of the `Tensor` class.
4. Fix GPT-2 residual projection scaling so only the residual output projections are scaled instead of every linear layer.
5. Update the way we sample data to handle very large datasets like OpenWebText.

## Tests
Added more unit tests. 

**GPT-2 Run**
```
(ml-by-hand) ➜  ml-by-hand git:(main-plus-non-optimization-changes) ✗ python -m examples.gpt_2
2026-05-10 13:53:15,114 - INFO - Loading the vocabulary from disk.
2026-05-10 13:53:15,120 - INFO - Found existing encoded data at 'training_data/bpe_24000_openwebtext_encoded_data.npy', loading it without fetching raw data.
2026-05-10 13:53:15,125 - INFO - Vocabulary size: 24267
2026-05-10 13:53:15,125 - INFO - Encoded data length: 9328264445
Data length: len(train_data)=8395438000 len(test_data)=932826445
2026-05-10 13:53:15,125 - INFO - No resume_epoch given; initializing model & optimizer from scratch.
2026-05-10 13:53:15,128 - INFO - Training GPT2 with 46.48M parameters.
2026-05-10 13:53:15,128 - INFO - Fit plan:
{'mode': 'steps',
 'target_step': 25000,
 'report_every_steps': 30,
 'global_batch_size': 32,
 'micro_batch_size': 8,
 'gradient_accumulation_steps': 4}
Training:   0%|▏                   2026-05-10 13:54:50,413 - INFO - [Step 30]                                            | 30/25000 [01:32<21:15:15,  3.06s/it]
{'step': 30,
 'train_loss': '10.1079',
 'tokens_per_s': '10316.9164',
 'val_loss': '9.9746',
 'grad_l2_norm': '3.6119',
 'lr': '0.000008'}
```
