### PR TITLE
General optimization

### DIFF
--- a/autograd/data/collator.py
+++ b/autograd/data/collator.py
@@ -3,16 +3,16 @@ from typing import Any, Sequence, Tuple
 
 import numpy as np
 
-from autograd.backend import Array, xp
+from autograd.backend import xp
 from autograd.data.types import CausalLMBatch, Seq2SeqBatch, TokenWindowExample
 from autograd.functional import IGNORE_INDEX
 
 
 def create_padding_mask(
-    token_indices: Array,
+    token_indices: np.ndarray,
     pad_idx: int = 0,
     dims: tuple[int, ...] | None = None,
-) -> Array:
+) -> np.ndarray:
     """
     Create a float padding mask where pad-token positions are `1.0`.
 
@@ -21,16 +21,14 @@ def create_padding_mask(
     when a collator is formatting one sequence at a time and needs an explicit
     broadcast shape.
     """
-    token_indices = xp.array(token_indices)
-    pad_positions = (token_indices == pad_idx).astype(xp.float32)
+    pad_positions = (token_indices == pad_idx).astype(np.float32)
 
     if dims is None:
-        # Default shape for attention over batched token IDs.
-        return xp.expand_dims(xp.expand_dims(pad_positions, axis=1), axis=1)
+        return pad_positions[:, np.newaxis, np.newaxis, :]
     return pad_positions.reshape(dims)
 
 
-def pad_right_1d(values: Array, target_length: int, pad_value: Any) -> Array:
+def pad_right_1d(values: np.ndarray, target_length: int, pad_value: Any) -> np.ndarray:
     """
     Right-pad a 1D array to `target_length`.
 
@@ -47,10 +45,10 @@ def pad_right_1d(values: Array, target_length: int, pad_value: Any) -> Array:
         return values
 
     pad_width = target_length - len(values)
-    return xp.concatenate(
+    return np.concatenate(
         [
             values,
-            xp.full((pad_width,), pad_value, dtype=values.dtype),
+            np.full((pad_width,), pad_value, dtype=values.dtype),
         ],
         axis=0,
     )
@@ -59,6 +57,14 @@ def pad_right_1d(values: Array, target_length: int, pad_value: Any) -> Array:
 class Collator(ABC):
     """
     Abstract interface for collators that turn example lists into batches.
+
+    Contract:
+        Input:  list of examples containing numpy arrays (from a Dataset).
+        Output: a batch object containing xp arrays (ready for the compute backend).
+
+    Collators are the numpy-to-xp boundary in the data pipeline. All slicing,
+    padding, and reshaping happens in numpy; the final batch fields are converted
+    to xp arrays via xp.array() before returning.
     """
 
     @abstractmethod
@@ -74,23 +80,23 @@ class PairedCollator(Collator):
         >>> collator = PairedCollator()
         >>> batch_X, batch_y = collator(
         ...     [
-        ...         {"inputs": xp.array([1, 2]), "targets": xp.array(0)},
-        ...         {"inputs": xp.array([3, 4]), "targets": xp.array(1)},
+        ...         {"inputs": np.array([1, 2]), "targets": np.array(0)},
+        ...         {"inputs": np.array([3, 4]), "targets": np.array(1)},
         ...     ]
         ... )
         >>> batch_X.shape, batch_y.shape
         ((2, 2), (2,))
     """
 
-    def __call__(self, examples: Sequence[dict[str, Array]]) -> Tuple[Array, Array]:
-        batch_X = xp.stack(
-            [xp.array(example["inputs"]) for example in examples], axis=0
+    def __call__(self, examples: Sequence[dict[str, np.ndarray]]) -> Tuple[Any, Any]:
+        batch_X = np.stack(
+            [np.asarray(example["inputs"]) for example in examples], axis=0
         )
-        batch_y = xp.stack(
-            [xp.array(example["targets"]) for example in examples],
+        batch_y = np.stack(
+            [np.asarray(example["targets"]) for example in examples],
             axis=0,
         )
-        return batch_X, batch_y
+        return xp.array(batch_X), xp.array(batch_y)
 
 
 class OneHotCollator(Collator):
@@ -104,30 +110,29 @@ class OneHotCollator(Collator):
         >>> collator = OneHotCollator(num_classes=4)
         >>> batch_X, batch_y = collator(
         ...     [
-        ...         {"inputs": xp.array([0, 2]), "targets": xp.array(1)},
-        ...         {"inputs": xp.array([1, 3]), "targets": xp.array(0)},
+        ...         {"inputs": np.array([0, 2]), "targets": np.array(1)},
+        ...         {"inputs": np.array([1, 3]), "targets": np.array(0)},
         ...     ]
         ... )
         >>> batch_X.shape, batch_y.shape
         ((2, 2, 4), (2,))
     """
 
-    def __init__(self, num_classes: int, dtype: Array = xp.float32) -> None:
+    def __init__(self, num_classes: int) -> None:
         self.num_classes = num_classes
-        self.dtype = dtype
 
-    def __call__(self, examples: Sequence[dict[str, Array]]) -> Tuple[Array, Array]:
+    def __call__(self, examples: Sequence[dict[str, np.ndarray]]) -> Tuple[Any, Any]:
         # TODO: replace batch-time one-hot with direct token-id model inputs.
-        eye = xp.eye(self.num_classes, dtype=self.dtype)
-        batch_tokens = xp.stack(
-            [xp.array(example["inputs"], dtype=xp.int32) for example in examples],
+        eye = np.eye(self.num_classes, dtype=np.float32)
+        batch_tokens = np.stack(
+            [np.asarray(example["inputs"], dtype=np.int32) for example in examples],
             axis=0,
         )
-        batch_y = xp.stack(
-            [xp.array(example["targets"]) for example in examples],
+        batch_y = np.stack(
+            [np.asarray(example["targets"]) for example in examples],
             axis=0,
         )
-        return eye[batch_tokens], batch_y
+        return xp.array(eye[batch_tokens]), xp.array(batch_y)
 
 
 class CausalLMWindowCollator(Collator):
@@ -174,13 +179,13 @@ class _CausalLMBaseCollator(Collator):
 
     def _truncate_examples(
         self,
-        examples: Sequence[dict[str, Array]],
-    ) -> list[Tuple[Array, Array]]:
+        examples: Sequence[dict[str, np.ndarray]],
+    ) -> list[Tuple[np.ndarray, np.ndarray]]:
         truncated_examples = []
 
         for example in examples:
-            tokens = xp.array(example["tokens"], dtype=xp.int32)
-            loss_mask = xp.array(example["loss_mask"], dtype=xp.int32)
+            tokens = np.asarray(example["tokens"], dtype=np.int32)
+            loss_mask = np.asarray(example["loss_mask"], dtype=np.int32)
             if len(tokens) != len(loss_mask):
                 raise ValueError("tokens and loss_mask must have the same length")
 
@@ -188,28 +193,27 @@ class _CausalLMBaseCollator(Collator):
                 tokens = tokens[-self.max_tokens :]
                 loss_mask = loss_mask[-self.max_tokens :]
 
-            truncated_tokens, truncated_loss_mask = tokens, loss_mask
-            truncated_examples.append((truncated_tokens, truncated_loss_mask))
+            truncated_examples.append((tokens, loss_mask))
 
         return truncated_examples
 
     def _build_inputs_and_labels(
         self,
-        tokens: Array,
-        loss_mask: Array,
-    ) -> Tuple[Array, Array]:
+        tokens: np.ndarray,
+        loss_mask: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray]:
         input_ids = tokens[:-1]
-        labels = xp.array(tokens[1:], dtype=xp.int32)
-        labels[xp.array(loss_mask[1:], dtype=xp.float32) == 0] = IGNORE_INDEX
+        labels = tokens[1:].copy()
+        labels[loss_mask[1:] == 0] = IGNORE_INDEX
         return input_ids, labels
 
     def _stack_padded_examples(
         self,
-        padded_examples: Sequence[Tuple[Array, Array]],
+        padded_examples: Sequence[Tuple[np.ndarray, np.ndarray]],
     ) -> CausalLMBatch:
         batch_inputs = []
         batch_labels = []
-        loss_total_weight = xp.array(0.0, dtype=xp.float32)
+        loss_total_weight = 0
 
         for padded_tokens, padded_loss_mask in padded_examples:
             input_tokens, labels = self._build_inputs_and_labels(
@@ -219,12 +223,12 @@ class _CausalLMBaseCollator(Collator):
 
             batch_inputs.append(input_tokens)
             batch_labels.append(labels)
-            loss_total_weight = loss_total_weight + xp.sum(padded_loss_mask[1:] != 0)
+            loss_total_weight += int(np.sum(padded_loss_mask[1:] != 0))
 
         return CausalLMBatch(
-            input_ids=xp.stack(batch_inputs, axis=0),
-            labels=xp.stack(batch_labels, axis=0),
-            loss_total_weight=loss_total_weight,
+            input_ids=xp.array(np.stack(batch_inputs, axis=0)),
+            labels=xp.array(np.stack(batch_labels, axis=0)),
+            loss_total_weight=xp.array(loss_total_weight, dtype=xp.float32),
         )
 
 
@@ -236,7 +240,7 @@ class FixedLengthCausalLMCollator(_CausalLMBaseCollator):
     right-pad every row to `max_tokens`, then shift tokens into inputs/labels.
     """
 
-    def __call__(self, examples: Sequence[dict[str, Array]]) -> CausalLMBatch:
+    def __call__(self, examples: Sequence[dict[str, np.ndarray]]) -> CausalLMBatch:
         truncated_examples = self._truncate_examples(examples)
         padded_examples = tuple(
             (
@@ -257,7 +261,7 @@ class BatchMaxLengthCausalLMCollator(_CausalLMBaseCollator):
     tokens into inputs/labels.
     """
 
-    def __call__(self, examples: Sequence[dict[str, Array]]) -> CausalLMBatch:
+    def __call__(self, examples: Sequence[dict[str, np.ndarray]]) -> CausalLMBatch:
         truncated_examples = self._truncate_examples(examples)
         longest_row_length = max(
             2, max(len(tokens) for tokens, _ in truncated_examples)
@@ -293,7 +297,7 @@ class Seq2SeqCollator(Collator):
         self.pad_idx = pad_idx
         self.sos_idx = sos_idx
 
-    def __call__(self, examples: Sequence[dict[str, Array]]) -> Seq2SeqBatch:
+    def __call__(self, examples: Sequence[dict[str, np.ndarray]]) -> Seq2SeqBatch:
         batch_inputs = []
         batch_decoder_inputs = []
         batch_labels = []
@@ -301,8 +305,8 @@ class Seq2SeqCollator(Collator):
         batch_tgt_masks = []
 
         for example in examples:
-            input_ids = xp.array(example["input_ids"], dtype=xp.int32)
-            labels = xp.array(example["labels"], dtype=xp.int32)
+            input_ids = np.asarray(example["input_ids"], dtype=np.int32)
+            labels = np.asarray(example["labels"], dtype=np.int32)
 
             if len(input_ids) > self.max_tokens:
                 input_ids = input_ids[-self.max_tokens :]
@@ -320,11 +324,11 @@ class Seq2SeqCollator(Collator):
                 self.max_tokens,
                 self.pad_idx,
             )
-            masked_labels = xp.array(decoder_targets, dtype=xp.int32)
+            masked_labels = decoder_targets.copy()
             masked_labels[masked_labels == self.pad_idx] = IGNORE_INDEX
 
-            sos_token = xp.array([self.sos_idx], dtype=decoder_targets.dtype)
-            decoder_input_ids = xp.concatenate(
+            sos_token = np.array([self.sos_idx], dtype=decoder_targets.dtype)
+            decoder_input_ids = np.concatenate(
                 [sos_token, decoder_targets[:-1]],
                 axis=0,
             )
@@ -346,13 +350,10 @@ class Seq2SeqCollator(Collator):
             batch_src_masks.append(src_mask)
             batch_tgt_masks.append(tgt_mask)
 
-        input_ids = xp.stack(batch_inputs, axis=0)
-        decoder_input_ids = xp.stack(batch_decoder_inputs, axis=0)
-        labels = xp.stack(batch_labels, axis=0)
         return Seq2SeqBatch(
-            input_ids=input_ids,
-            decoder_input_ids=decoder_input_ids,
-            labels=labels,
-            src_mask=xp.stack(batch_src_masks, axis=0),
-            tgt_mask=xp.stack(batch_tgt_masks, axis=0),
+            input_ids=xp.array(np.stack(batch_inputs, axis=0)),
+            decoder_input_ids=xp.array(np.stack(batch_decoder_inputs, axis=0)),
+            labels=xp.array(np.stack(batch_labels, axis=0)),
+            src_mask=xp.array(np.stack(batch_src_masks, axis=0)),
+            tgt_mask=xp.array(np.stack(batch_tgt_masks, axis=0)),
         )

--- a/autograd/data/dataset.py
+++ b/autograd/data/dataset.py
@@ -1,9 +1,10 @@
-from typing import Any, Iterator, Sequence
+from typing import Any, Iterator, Sequence, Union
 
 import numpy as np
 
-from autograd.backend import Array, xp
 from autograd.data.types import TokenWindowExample
+
+NumpyDType = Union[type[np.generic], np.dtype[Any], str]
 
 
 class MapDataset:
@@ -35,7 +36,11 @@ class MapDataset:
 
 class PairedMapDataset(MapDataset):
     """
-    Iterates over in-memory paired `(X, y)` data one example at a time.
+    Lazy paired `(X, y)` dataset — indexes into the source arrays on demand.
+
+    The `inputs` and `targets` arguments can each be:
+      - An array or sequence of arrays (stored as numpy)
+      - A file path to a `.npy` file (memory-mapped, pages in on demand)
 
     Examples:
         >>> X = xp.arange(6).reshape(3, 2)
@@ -49,7 +54,6 @@ class PairedMapDataset(MapDataset):
         ...     [xp.array([3, 4])],
         ...     input_key="input_ids",
         ...     target_key="labels",
-        ...     dtype=xp.int32,
         ... )
         >>> example = next(iter(seq2seq))
         >>> example["input_ids"].tolist(), example["labels"].tolist()
@@ -59,36 +63,48 @@ class PairedMapDataset(MapDataset):
         ...     [xp.array([0, 1, 1])],
         ...     input_key="tokens",
         ...     target_key="loss_mask",
-        ...     dtype=xp.int32,
         ... )
         >>> example = next(iter(causal_lm))
         >>> example["tokens"].tolist(), example["loss_mask"].tolist()
         ([10, 11, 12], [0, 1, 1])
     """
 
+    @staticmethod
+    def _load(data: Union[Sequence[Any], str]) -> Any:
+        if isinstance(data, str):
+            return np.load(data, mmap_mode="r")
+        if isinstance(data, np.ndarray):
+            return data
+        # Ragged sequences (variable-length arrays) — keep as list
+        return list(data)
+
     def __init__(
         self,
-        inputs: Sequence[Any],
-        targets: Sequence[Any],
+        inputs: Union[Sequence[Any], str],
+        targets: Union[Sequence[Any], str],
         *,
         input_key: str = "inputs",
         target_key: str = "targets",
-        dtype: Any | None = None,
+        dtype: NumpyDType | None = None,
     ) -> None:
-        if len(inputs) != len(targets):
+        self.inputs = self._load(inputs)
+        self.targets = self._load(targets)
+        if len(self.inputs) != len(self.targets):
             raise ValueError(
                 "inputs and targets must contain the same number of examples"
             )
+        self.input_key = input_key
+        self.target_key = target_key
+        self.dtype = None if dtype is None else np.dtype(dtype)
 
-        examples = []
-        for index in range(len(inputs)):
-            input_value = inputs[index]
-            target_value = targets[index]
-            if dtype is not None:
-                input_value = xp.array(input_value, dtype=dtype)
-                target_value = xp.array(target_value, dtype=dtype)
-            examples.append({input_key: input_value, target_key: target_value})
-        super().__init__(examples)
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        return {
+            self.input_key: np.asarray(self.inputs[index], dtype=self.dtype),
+            self.target_key: np.asarray(self.targets[index], dtype=self.dtype),
+        }
+
+    def __len__(self) -> int:
+        return len(self.inputs)
 
 
 class TokenWindowMapDataset(MapDataset):
@@ -105,15 +121,22 @@ class TokenWindowMapDataset(MapDataset):
     pass, and `RandomSampler(replacement=True, num_samples=...)` for fixed-size
     random-with-replacement epochs. Calling `DataLoader.on_epoch_start()` calls
     the sampler hook, so a `RandomSampler` gives a fresh random order each epoch.
+
+    The `data` argument can be:
+      - An array (loaded into memory as before)
+      - A file path to a `.npy` file (memory-mapped, pages in on demand)
     """
 
     def __init__(
         self,
-        data: Array,
+        data: Union[np.ndarray, str],
         *,
         window_len: int,
     ) -> None:
-        self.stream = np.asarray(data, dtype=np.int32)
+        if isinstance(data, str):
+            self.stream = np.load(data, mmap_mode="r")
+        else:
+            self.stream = np.asarray(data, dtype=np.int32)
         self.window_len = window_len
 
         # The edge case where len(stream) == window length, valid_window_count == 1, offset 0 is valid

--- a/autograd/data/sft.py
+++ b/autograd/data/sft.py
@@ -6,9 +6,10 @@ import pickle
 from multiprocessing import Pool
 from typing import Any, Sequence, cast
 
+import numpy as np
 from tqdm import tqdm
 
-from autograd.backend import Array, xp
+from autograd.backend import Array
 from autograd.data.utils import load_data, load_parquet_rows
 from autograd.text.tokenizer import BytePairEncoder
 
@@ -196,8 +197,8 @@ def tokenize_sft_messages(
         turn_separator=turn_separator,
     )
     return {
-        "tokens": xp.array(tokens, dtype=xp.int32),
-        "loss_mask": xp.array(loss_mask, dtype=xp.int32),
+        "tokens": np.array(tokens, dtype=np.int32),
+        "loss_mask": np.array(loss_mask, dtype=np.int32),
     }
 
 
@@ -287,7 +288,7 @@ def prepare_sft_token_sequences(
             "Found SFT cache at '%s'; validating metadata before loading.",
             cache_path,
         )
-        encoded_archive: Any = xp.load(cache_path)
+        encoded_archive: Any = np.load(cache_path)
         required_keys = {"tokens", "loss_mask", "example_offsets", "metadata"}
         if not required_keys.issubset(encoded_archive.keys()):
             raise ValueError(
@@ -358,19 +359,19 @@ def prepare_sft_token_sequences(
                 )
             )
 
-    flat_tokens = xp.array(flat_token_ids, dtype=xp.int32)
-    flat_loss_masks = xp.array(flat_loss_mask_ids, dtype=xp.int32)
-    offsets = xp.array(example_offsets, dtype=xp.int32)
+    flat_tokens = np.array(flat_token_ids, dtype=np.int32)
+    flat_loss_masks = np.array(flat_loss_mask_ids, dtype=np.int32)
+    offsets = np.array(example_offsets, dtype=np.int32)
 
     parent_dir = os.path.dirname(cache_path)
     if parent_dir:
         os.makedirs(parent_dir, exist_ok=True)
-    xp.savez_compressed(
+    np.savez_compressed(
         cache_path,
         tokens=flat_tokens,
         loss_mask=flat_loss_masks,
         example_offsets=offsets,
-        metadata=xp.array(
+        metadata=np.array(
             list(json.dumps(expected_metadata, sort_keys=True).encode("utf-8"))
         ),
     )

--- a/autograd/data/utils.py
+++ b/autograd/data/utils.py
@@ -1,41 +1,41 @@
 import csv
 import os
-from typing import Any, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Optional, Sequence, Union, cast
 from urllib.request import urlopen
 
+import numpy as np
 from pyarrow import parquet as pq  # pyright: ignore[reportMissingImports]
 
-from autograd.backend import Array, xp
 from autograd.data.dataset import PairedMapDataset
 
 
 def train_test_split(
-    X: Array,
-    y: Array,
-    test_size: float = 0.2,
+    *arrays,
+    test_size: float = 0.1,
+    shuffle: bool = True,
     random_state: Optional[int] = None,
-) -> Tuple[Array, Array, Array, Array]:
+) -> list:
+    """Split arrays into train and test subsets.
+
+    Returns a flat list: [arr0_train, arr0_test, arr1_train, arr1_test, ...].
     """
-    Splits arrays or matrices into random train and test subsets.
-
-    Args:
-        X (Array): Feature array.
-        y (Array): Labels array.
-        test_size (float): Proportion of the dataset to include in the test split.
-        random_state (Optional[int]): Seed for the random number generator.
-
-    Returns:
-        Tuple[Array, Array, Array, Array]:
-            The training features, test features, training labels, and test labels.
-    """
-    if random_state is not None:
-        xp.random.seed(random_state)
-    indices = xp.random.permutation(X.shape[0])
-
-    num_test = int(len(indices) * test_size)
-    X_train, X_test = X[indices[num_test:]], X[indices[:num_test]]
-    y_train, y_test = y[indices[num_test:]], y[indices[:num_test]]
-    return X_train, X_test, y_train, y_test
+    if not arrays:
+        raise ValueError("need at least one array to split")
+    n = len(arrays[0])
+    split = int(n * test_size)
+    result = []
+    if shuffle:
+        idx = np.random.RandomState(random_state).permutation(n)
+        for arr in arrays:
+            arr = np.asarray(arr)
+            result.append(arr[idx[split:]])
+            result.append(arr[idx[:split]])
+    else:
+        for arr in arrays:
+            arr = np.asarray(arr)
+            result.append(arr[split:])
+            result.append(arr[:split])
+    return result
 
 
 def load_data(
@@ -87,13 +87,13 @@ def build_seq2seq_dataset_from_text_pairs(
     label_sequences = []
 
     for source_text, target_text in text_pairs:
-        source_tokens = xp.array(bpe.encode(source_text), dtype=xp.int32)
-        target_tokens = xp.array(bpe.encode(target_text), dtype=xp.int32)
+        source_tokens = np.array(bpe.encode(source_text), dtype=np.int32)
+        target_tokens = np.array(bpe.encode(target_text), dtype=np.int32)
         if target_suffix:
-            target_tokens = xp.concatenate(
+            target_tokens = np.concatenate(
                 [
                     target_tokens,
-                    xp.array(bpe.encode(target_suffix), dtype=xp.int32),
+                    np.array(bpe.encode(target_suffix), dtype=np.int32),
                 ],
                 axis=0,
             )
@@ -112,5 +112,4 @@ def build_seq2seq_dataset_from_text_pairs(
         label_sequences,
         input_key="input_ids",
         target_key="labels",
-        dtype=xp.int32,
     )

--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -1,15 +1,16 @@
+import heapq
 import logging
 import os
 import pickle
+import shutil
 from collections import Counter
-from functools import partial
+from itertools import batched
 from multiprocessing import Pool, cpu_count
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+import numpy as np
 import regex
 from tqdm import tqdm
-
-from autograd.backend import xp
 
 logger = logging.getLogger(__name__)
 
@@ -24,10 +25,22 @@ class BytePairEncoder:
     Examples:
         >>> raw_text = "Hello world! This is a test."
         >>> bpe = BytePairEncoder(num_merges=50)
-        >>> encoded_array = bpe.prepare_data(raw_text) # Outputs an array of token IDs
+        >>> encoded_array = bpe.prepare_data([raw_text]) # Outputs an array of token IDs
     """
 
-    SPECIAL_TOKENS = ["<|endoftext|>", "<PAD>", "<SOS>", "<UNK>"]
+    SPECIAL_TOKENS = [
+        "<|endoftext|>",
+        "<PAD>",
+        "<SOS>",
+        "<UNK>",
+        "<|USER|>",
+        "<|ASSISTANT|>",
+        "<|SYSTEM|>",
+        "<|END_OF_TURN|>",
+        "<|TOOL|>",
+        "<|TOOL_CALL|>",
+        "<|TOOL_RESULT|>",
+    ]
 
     def __init__(
         self,
@@ -35,6 +48,7 @@ class BytePairEncoder:
         vocab_file_path: str = "vocab.pkl",
         encoded_data_path: str = "bpe_encoded_data.npz",
         n_workers: Optional[int] = None,
+        min_word_freq: int = 10,
     ) -> None:
         """Initializes the Byte Pair Encoder.
 
@@ -44,14 +58,22 @@ class BytePairEncoder:
             encoded_data_path (str): Path to store or load the encoded data as an NPZ file.
             n_workers (Optional[int]): Number of processes for parallel operations. If None,
                 defaults to the number of CPU cores minus one.
+            min_word_freq (int): Minimum frequency for a word form to be included in
+                the merge loop. Forms below this threshold are pruned before merging
+                to avoid spending time on rare/singleton entries that don't influence
+                merge decisions. Set to 1 to disable pruning.
 
         Examples:
             >>> bpe = BytePairEncoder(num_merges=100, vocab_file_path="vocab.pkl", encoded_data_path="encoded.npz")
             >>> print(bpe.num_merges)  # Expected output: 100
         """
         self.num_merges = num_merges
+        self.min_word_freq = min_word_freq
         self.vocab_file_path = vocab_file_path
         self.encoded_data_path = encoded_data_path
+        self.mmap_path = os.path.splitext(encoded_data_path)[0] + ".npy"
+        base, ext = os.path.splitext(vocab_file_path)
+        self.word_freq_cache_path = base + ".word_freq" + ext
 
         # For storing vocab: char -> int
         self._unicode_to_int_vocab: Dict[bytes, int] = {}
@@ -71,6 +93,14 @@ class BytePairEncoder:
             self.n_workers = max(1, cpu_count() - 1)
         else:
             self.n_workers = n_workers
+
+        # Pre-compiled regex patterns for _pretokenize
+        self._special_pattern = regex.compile(
+            "(" + "|".join(regex.escape(k) for k in self.SPECIAL_TOKENS) + ")"
+        )
+        self._general_pattern = regex.compile(
+            r"""'(?:[sdmt]|ll|ve|re)| ?\p{L}++| ?\p{N}++| ?[^\s\p{L}\p{N}]++|\s++$|\s+(?!\S)|\s"""
+        )
 
     @property
     def n_vocab(self) -> int:
@@ -156,97 +186,180 @@ class BytePairEncoder:
 
     def prepare_data(
         self,
-        raw_text: str,
+        texts: Iterable[str],
         overwrite_vocabulary_file: bool = False,
         overwrite_encoded_data: bool = False,
-        split_token: str = "<|endoftext|>",
-    ) -> Any:
-        """Trains and applies BPE on raw_text, returning encoded token IDs as an array.
+    ) -> np.ndarray:
+        """Trains and applies BPE on the given texts, returning encoded token IDs.
 
-        This method:
-          1) Trains (or loads) the BPE vocabulary on the given raw_text.
-          2) Encodes the text into an array of token IDs (in parallel).
-          3) Caches the result to an .npz file unless already existing and not overwritten.
+        Convenience wrapper that calls train_vocabulary then encode_to_mmap.
+        ``texts`` must be re-iterable (e.g. a list or an object whose
+        ``__iter__`` returns a fresh iterator each time) because the corpus
+        is traversed once for vocabulary training and once for encoding.
 
         Args:
-            raw_text (str): The raw text from which to train or apply BPE.
+            texts (Iterable[str]): Documents to train on and encode.
             overwrite_vocabulary_file (bool): If True, re-trains and overwrites the BPE vocabulary.
-            overwrite_encoded_data (bool): If True, overwrites an existing encoded .npz file.
-            split_token (str): A token (usually in SPECIAL_TOKENS) used as a delimiter.
+            overwrite_encoded_data (bool): If True, overwrites an existing .npy file.
 
         Returns:
-            Any: An array of token IDs representing the BPE-encoded text.
+            np.ndarray: A memory-mapped array of token IDs.
 
         Example:
-            >>> raw_text = "Hello world! This is a test."
             >>> bpe = BytePairEncoder(num_merges=50)
-            >>> encoded_array = bpe.prepare_data(raw_text)
+            >>> encoded_array = bpe.prepare_data(["Hello world! This is a test."])
             >>> print(encoded_array)
             [ ...some token IDs... ]
         """
-        # 1) Train the vocabulary if needed
-        self.train_vocabulary(raw_text, overwrite_saved_file=overwrite_vocabulary_file)
+        self.train_vocabulary(texts, overwrite_saved_file=overwrite_vocabulary_file)
+        self.encode_to_mmap(texts, overwrite_encoded_data=overwrite_encoded_data)
+        return np.load(self.mmap_path, mmap_mode="r")
 
-        # 2) Check if we already have an encoded .npz file
-        if os.path.exists(self.encoded_data_path) and not overwrite_encoded_data:
-            logger.info(
-                f"Found existing encoded data at '{self.encoded_data_path}', "
-                f"loading it instead of re-encoding."
-            )
-            encoded_archive: Any = xp.load(self.encoded_data_path)
-            encoded_data = encoded_archive["arr_0"]
-        else:
-            # 3) Parallel encoding
-            if self._should_parallelize(
-                work_items=len(raw_text), min_items_per_worker=8192
-            ):
-                chunk_size = max(1, len(raw_text) // self.n_workers)
-                text_chunks = [
-                    raw_text[i : i + chunk_size]
-                    for i in range(0, len(raw_text), chunk_size)
-                ]
-                with Pool(self.n_workers) as pool:
-                    partial_encoded = list(
-                        tqdm(
-                            pool.imap(
-                                partial(self.encode, show_progress=False),
-                                text_chunks,
-                            ),
-                            total=len(text_chunks),
-                            desc="Encoding text chunks",
-                            unit="chunk",
-                        )
-                    )
-            else:
-                partial_encoded = [self.encode(raw_text, show_progress=True)]
+    def encode_to_mmap(
+        self,
+        text_iter: Iterable[str],
+        overwrite_encoded_data: bool = False,
+        *,
+        text_batch_size: int = 256,
+    ) -> str:
+        """Encodes streamed text to a .npy memmap file without holding all tokens in memory.
 
-            encoded_parts = [xp.array(part, dtype=xp.int32) for part in partial_encoded]
-            if not encoded_parts:
-                encoded_data = xp.array([], dtype=xp.int32)
-            elif len(encoded_parts) == 1:
-                encoded_data = encoded_parts[0]
-            else:
-                encoded_data = xp.concatenate(encoded_parts)
-
-            # 4) Save to disk
-            xp.savez_compressed(self.encoded_data_path, arr_0=encoded_data)
-
-        logger.info(f"Vocabulary size: {len(self._unicode_to_int_vocab)}")
-        logger.info(f"Encoded data length: {len(encoded_data)}")
-        logger.debug("Sample encoded data (first 50 tokens): %s", encoded_data[:50])
-
-        return encoded_data
-
-    def train_vocabulary(
-        self, input_text: str, overwrite_saved_file: bool = False
-    ) -> Tuple[Dict[bytes, int], Dict[int, bytes]]:
-        """Trains the BPE vocabulary on the given input_text.
-
-        The learned merges and vocabulary are saved to `vocab_file_path`.
+        Encodes the corpus once to count tokens, checks that the output
+        filesystem has enough free space, then encodes again directly into a
+        temporary .npy memmap before atomically replacing the final file.
+        ``text_iter`` must be re-iterable so both passes see the same corpus.
 
         Args:
-            input_text (str): The text to train on.
-            overwrite_saved_file (bool): If True, re-trains and overwrites any existing vocabulary file.
+            text_iter (Iterable[str]): Documents to encode (e.g. a list of strings or
+                a lazy generator). The vocabulary must already be trained.
+            overwrite_encoded_data (bool): If True, overwrites an existing .npy file.
+            text_batch_size (int): Number of documents to encode per batch.
+
+        Returns:
+            str: The path to the .npy memmap file.
+        """
+        if os.path.exists(self.mmap_path) and not overwrite_encoded_data:
+            logger.info(
+                f"Found existing memory-mapped encoded data at '{self.mmap_path}', "
+                "reusing it instead of re-encoding."
+            )
+            return self.mmap_path
+        if iter(text_iter) is text_iter:
+            raise TypeError(
+                "encode_to_mmap requires a re-iterable text source because it "
+                "counts encoded tokens before writing the .npy memmap. Pass a "
+                "sequence or an iterable object whose __iter__ returns a fresh iterator."
+            )
+
+        parent_dir = os.path.dirname(self.mmap_path)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
+        disk_check_dir = parent_dir or "."
+
+        int32_dtype = np.dtype("<i4")
+        tmp_npy_path = f"{self.mmap_path}.tmp"
+        stale_raw_path = f"{self.mmap_path}.raw.tmp"
+
+        try:
+            for stale_path in (tmp_npy_path, stale_raw_path):
+                if os.path.exists(stale_path):
+                    os.remove(stale_path)
+
+            token_count = self._count_encoded_tokens(
+                text_iter,
+                text_batch_size=text_batch_size,
+            )
+            self._check_encoded_mmap_disk_space(
+                disk_check_dir=disk_check_dir,
+                token_count=token_count,
+                dtype=int32_dtype,
+            )
+
+            encoded_mmap = np.lib.format.open_memmap(
+                tmp_npy_path,
+                mode="w+",
+                dtype=int32_dtype,
+                shape=(token_count,),
+            )
+            offset = 0
+            for encoded_batch in self._iter_encoded_batches(
+                text_iter,
+                text_batch_size=text_batch_size,
+                desc="Encoding text to tokens",
+            ):
+                for encoded_text in encoded_batch:
+                    end = offset + len(encoded_text)
+                    encoded_mmap[offset:end] = np.asarray(
+                        encoded_text,
+                        dtype=int32_dtype,
+                    )
+                    offset = end
+            if offset != token_count:
+                raise RuntimeError(
+                    "Encoded token count changed between counting and writing: "
+                    f"counted {token_count}, wrote {offset}. "
+                    "Use a deterministic re-iterable text source."
+                )
+            encoded_mmap.flush()
+            del encoded_mmap
+
+            os.replace(tmp_npy_path, self.mmap_path)
+        finally:
+            if os.path.exists(tmp_npy_path):
+                os.remove(tmp_npy_path)
+
+        return self.mmap_path
+
+    def _count_encoded_tokens(
+        self,
+        text_iter: Iterable[str],
+        *,
+        text_batch_size: int,
+    ) -> int:
+        token_count = 0
+        for encoded_batch in self._iter_encoded_batches(
+            text_iter,
+            text_batch_size=text_batch_size,
+            desc="Counting encoded tokens",
+        ):
+            for encoded_text in encoded_batch:
+                token_count += len(encoded_text)
+        return token_count
+
+    def _check_encoded_mmap_disk_space(
+        self,
+        *,
+        disk_check_dir: str,
+        token_count: int,
+        dtype: np.dtype,
+    ) -> None:
+        header_allowance_bytes = 1024 * 1024
+        required_bytes = (token_count * dtype.itemsize) + header_allowance_bytes
+        required_with_buffer = int(required_bytes * 1.2)
+        free_bytes = shutil.disk_usage(disk_check_dir).free
+        if free_bytes < required_with_buffer:
+            raise OSError(
+                "Insufficient disk space to encode token data: "
+                f"need at least {required_with_buffer} bytes "
+                f"({required_bytes} bytes plus 20% buffer), "
+                f"but only {free_bytes} bytes are free in {disk_check_dir!r}."
+            )
+
+    def train_vocabulary(
+        self, texts: Iterable[str], overwrite_saved_file: bool = False
+    ) -> Tuple[Dict[bytes, int], Dict[int, bytes]]:
+        """Trains the BPE vocabulary on the given text documents.
+
+        Streams text one document at a time, so the full corpus never needs to
+        be held in memory. The learned merges and vocabulary are saved to
+        vocab_file_path.
+
+        Args:
+            texts (Iterable[str]): Documents to train on (e.g. ["doc1", "doc2"]
+                or a lazy generator). Pass a single document as [raw_text].
+                A bare str is rejected to prevent silent per-character iteration.
+            overwrite_saved_file (bool): If True, re-trains and overwrites any
+                existing vocabulary file.
 
         Returns:
             Tuple[Dict[bytes, int], Dict[int, bytes]]:
@@ -256,46 +369,210 @@ class BytePairEncoder:
 
         Examples:
             >>> bpe = BytePairEncoder(num_merges=50)
-            >>> vocab, rev_vocab = bpe.train_vocabulary("Hello world! Hello again!")
+            >>> vocab, rev_vocab = bpe.train_vocabulary(["Hello world! Hello again!"])
             >>> print(vocab)  # Prints the vocabulary mapping
         """
-        # If we already have a loaded vocab and don't want to overwrite, skip training
+        if isinstance(texts, str):
+            raise TypeError(
+                "train_vocabulary expects an iterable of strings, not a bare str. "
+                "Wrap a single document as [text]."
+            )
+
         if os.path.exists(self.vocab_file_path) and not overwrite_saved_file:
             return self._unicode_to_int_vocab, self._int_to_unicode_vocab
 
+        word_freq = self._load_or_build_word_freq(texts, overwrite_saved_file)
+        return self._learn_vocabulary_from_word_freq(word_freq)
+
+    def _load_or_build_word_freq(
+        self, texts: Iterable[str], overwrite: bool
+    ) -> Counter:
+        """Load cached word frequencies or build from scratch and cache."""
+        if not overwrite and os.path.exists(self.word_freq_cache_path):
+            logger.info(
+                "Loading cached word frequencies from %s", self.word_freq_cache_path
+            )
+            with open(self.word_freq_cache_path, "rb") as f:
+                return pickle.load(f)
+
+        word_freq = self._build_word_freq(texts)
+
+        logger.info("Caching word frequencies to %s", self.word_freq_cache_path)
+        with open(self.word_freq_cache_path, "wb") as f:
+            pickle.dump(word_freq, f)
+
+        return word_freq
+
+    def _build_word_freq(self, texts: Iterable[str]) -> Counter:
+        """Build word frequency table from documents, parallelized when possible.
+
+        Internally counts with bytes keys (cheap from .encode()), then converts
+        to tuple-of-int keys expected by the merge loop.
+        """
+        if self.n_workers > 1:
+            special_token_ids = {
+                tok: self._unicode_to_int_vocab[tok.encode("utf-8")]
+                for tok in self.SPECIAL_TOKENS
+            }
+            raw_freq = self._build_word_freq_parallel(texts, special_token_ids)
+        else:
+            raw_freq = self._build_word_freq_serial(texts)
+
+        # Convert bytes keys to tuple-of-int keys for the merge loop.
+        # Special token entries are already tuple keys — pass them through.
+        word_freq = Counter()
+        for key, count in raw_freq.items():
+            if isinstance(key, bytes):
+                word_freq[tuple(key)] = count
+            else:
+                word_freq[key] = count
+        return word_freq
+
+    def _build_word_freq_serial(self, texts: Iterable[str]) -> Counter:
+        word_freq = Counter()
+        doc_count = 0
+        for text in texts:
+            self._update_word_freq_from_text(word_freq, text)
+            doc_count += 1
+            if doc_count % 500_000 == 0:
+                logger.info(
+                    "Processed %d documents (%d unique word forms so far)",
+                    doc_count,
+                    len(word_freq),
+                )
+        logger.info(
+            "Word frequency table complete: %d documents, %d unique word forms",
+            doc_count,
+            len(word_freq),
+        )
+        return word_freq
+
+    def _build_word_freq_parallel(
+        self, texts: Iterable[str], special_token_ids: Dict[str, int]
+    ) -> Counter:
+        batch_size = 10_000
+        pattern_str = self._general_pattern.pattern
+        special_tokens_set = set(self.SPECIAL_TOKENS)
+
+        word_freq = Counter()
+        doc_count = 0
+        with Pool(self.n_workers) as pool:
+            args = (
+                (batch, pattern_str, special_tokens_set, special_token_ids)
+                for batch in batched(texts, batch_size)
+            )
+            for partial_wf, batch_doc_count in pool.imap_unordered(
+                BytePairEncoder._word_freq_worker, args
+            ):
+                word_freq.update(partial_wf)
+                doc_count += batch_doc_count
+                if doc_count % 500_000 < batch_size:
+                    logger.info(
+                        "Processed %d documents (%d unique word forms so far)",
+                        doc_count,
+                        len(word_freq),
+                    )
+        logger.info(
+            "Word frequency table complete: %d documents, %d unique word forms",
+            doc_count,
+            len(word_freq),
+        )
+        return word_freq
+
+    @staticmethod
+    def _word_freq_worker(args):
+        docs, pattern_str, special_tokens, special_token_ids = args
+        general_pat = regex.compile(pattern_str)
+        special_pat = regex.compile(
+            "(" + "|".join(regex.escape(k) for k in special_tokens) + ")"
+        )
+        wf = Counter()
+        for doc in docs:
+            for segment in special_pat.split(doc):
+                if not segment:
+                    continue
+                if segment in special_tokens:
+                    wf[(special_token_ids[segment],)] += 1
+                else:
+                    for chunk in general_pat.findall(segment):
+                        wf[chunk.encode("utf-8")] += 1
+        return wf, len(docs)
+
+    def _update_word_freq_from_text(self, word_freq: Counter, input_text: str) -> None:
+        """Count word frequencies using bytes keys (cheap to create from .encode()).
+        The caller converts to tuple-of-int keys before the merge loop.
+        """
         text_chunks = self._pretokenize(input_text)
         logger.debug("Text chunks: %s", text_chunks[:10])
 
-        word_freq = Counter()
         for chunk in text_chunks:
             if chunk in self.SPECIAL_TOKENS:
                 special_id = self._unicode_to_int_vocab[chunk.encode("utf-8")]
                 word_freq[(special_id,)] += 1
             else:
-                base_ids = tuple(
-                    self._unicode_to_int_vocab[bytes([b])]
-                    for b in chunk.encode("utf-8")
-                )
-                word_freq[base_ids] += 1
+                word_freq[chunk.encode("utf-8")] += 1
 
-        # Build initial pair counts
-        pair_counts = self._get_initial_pair_counts(word_freq)
+    def _learn_vocabulary_from_word_freq(
+        self,
+        word_freq: Counter,
+    ) -> Tuple[Dict[bytes, int], Dict[int, bytes]]:
+        # Prune rare word forms that don't meaningfully influence merge decisions
+        if self.min_word_freq > 1:
+            before = len(word_freq)
+            word_freq = Counter(
+                {k: v for k, v in word_freq.items() if v >= self.min_word_freq}
+            )
+            logger.info(
+                "Pruned word forms with freq < %d: %d -> %d (%d removed)",
+                self.min_word_freq,
+                before,
+                len(word_freq),
+                before - len(word_freq),
+            )
+
+        # Build initial pair counts and an inverted index: pair -> set of word tuples
+        pair_counts: Dict[Tuple[int, int], int] = {}
+        pair_to_words: Dict[Tuple[int, int], set] = {}
+        for w_tuple, freq in word_freq.items():
+            for p in zip(w_tuple, w_tuple[1:]):
+                pair_counts[p] = pair_counts.get(p, 0) + freq
+                if p not in pair_to_words:
+                    pair_to_words[p] = set()
+                pair_to_words[p].add(w_tuple)
 
         # Remove pairs involving special tokens so we don't merge them
-        pair_counts = {
-            p: c for p, c in pair_counts.items() if p[0] < 256 and p[1] < 256
-        }
+        for p in list(pair_counts):
+            if p[0] >= 256 or p[1] >= 256:
+                del pair_counts[p]
+                pair_to_words.pop(p, None)
+
+        # Max-heap for finding the best pair in O(log n).
+        # Entries: (-count, pair). Stale entries are skipped via pair_counts lookup.
+        heap = [(-c, p) for p, c in pair_counts.items()]
+        heapq.heapify(heap)
 
         # Merge loop
         for i in tqdm(range(self.num_merges), desc="Merging pairs"):
-            if not pair_counts:
+            # Pop stale/exhausted entries to find the current best pair.
+            # Lazy correction: if a popped entry's count is stale but still positive,
+            # re-push with the corrected count instead of discarding.
+            best_pair = None
+            best_pair_count = 0
+            while heap:
+                neg_count, candidate = heap[0]
+                actual = pair_counts.get(candidate, 0)
+                if actual <= 0:
+                    heapq.heappop(heap)
+                    continue
+                if actual != -neg_count:
+                    heapq.heapreplace(heap, (-actual, candidate))
+                    continue
+                best_pair = candidate
+                best_pair_count = actual
+                heapq.heappop(heap)
                 break
 
-            best_pair = max(pair_counts, key=pair_counts.__getitem__)
-            best_pair_count = pair_counts[best_pair]
-
-            # If best pair is not frequent enough, stop merging
-            if best_pair_count < 2:
+            if best_pair is None or best_pair_count < 2:
                 break
 
             new_id = self.new_idx
@@ -309,11 +586,18 @@ class BytePairEncoder:
             self._int_to_unicode_vocab[new_id] = merged_bytes
             self._unicode_to_int_vocab[merged_bytes] = new_id
 
-            # Apply merges throughout the corpus
-            self._apply_merges_to_corpus(best_pair, new_id, word_freq, pair_counts)
+            # Apply merge using the inverted index for fast lookup
+            self._apply_merges_to_corpus_indexed(
+                best_pair,
+                new_id,
+                word_freq,
+                pair_counts,
+                pair_to_words,
+                heap,
+            )
             self.learned_merges.append((best_pair, new_id))
 
-            if (i + 1) % 100 == 0:
+            if (i + 1) % 5_000 == 0:
                 logger.info(
                     f"[{i + 1}/{self.num_merges} merge] Best Pair Merged "
                     f"({best_pair_count} occurrences). "
@@ -334,26 +618,34 @@ class BytePairEncoder:
 
         return self._unicode_to_int_vocab, self._int_to_unicode_vocab
 
-    def encode(
-        self, input_text: str, *, show_progress: bool = False, **kwargs
-    ) -> List[int]:
+    def _get_merge_priority(self) -> Dict[Tuple[int, int], Tuple[int, int]]:
+        """Lazily build and cache a merge priority lookup: pair -> (priority, new_id).
+        Lower priority = earlier merge = applied first during greedy encoding.
+        """
+        if not hasattr(self, "_merge_priority_cache"):
+            self._merge_priority_cache = {}
+            for priority, (pair, new_id) in enumerate(self.learned_merges):
+                if pair not in self._merge_priority_cache:
+                    self._merge_priority_cache[pair] = (priority, new_id)
+        return self._merge_priority_cache
+
+    def encode(self, input_text: str, *, show_progress: bool = False) -> List[int]:
         """Encodes a raw input string into a list of BPE token IDs.
 
         The process is:
           1) Pre-tokenize the input into chunks (words, punctuation, special tokens).
           2) Convert each chunk to base (byte-level) token IDs.
-          3) Apply merges in the learned order to combine tokens.
+          3) Greedily apply the highest-priority merge until no more merges apply.
 
         Args:
             input_text (str): The text to encode.
-            **kwargs: Additional keyword arguments (unused in the default implementation).
 
         Returns:
             List[int]: The list of integer token IDs representing the encoded text.
 
         Example:
             >>> bpe = BytePairEncoder(num_merges=50)
-            >>> bpe.train_vocabulary("Hello world!")
+            >>> bpe.train_vocabulary(["Hello world!"])
             >>> token_ids = bpe.encode("Hello world!")
             >>> print(token_ids)  # Outputs a list of token IDs
         """
@@ -363,34 +655,32 @@ class BytePairEncoder:
         if not text_chunks:
             return []
 
-        # Convert chunks to base token IDs
-        byte_encoded_chars: List[int] = []
+        merge_priority = self._get_merge_priority()
+        result: List[int] = []
         for chunk in text_chunks:
             if chunk in self.SPECIAL_TOKENS:
-                special_id = self._unicode_to_int_vocab[chunk.encode("utf-8")]
-                byte_encoded_chars.append(special_id)
+                result.append(self._unicode_to_int_vocab[chunk.encode("utf-8")])
             else:
-                for b_int in chunk.encode("utf-8"):
-                    byte_encoded_chars.append(
-                        self._unicode_to_int_vocab[bytes([b_int])]
-                    )
+                # Base vocab maps bytes([b]) -> b (identity)
+                token_ids = list(chunk.encode("utf-8"))
+                # Greedily apply the earliest-learned merge until convergence
+                while len(token_ids) >= 2:
+                    best_idx = -1
+                    best_priority = float("inf")
+                    for i in range(len(token_ids) - 1):
+                        p_info = merge_priority.get((token_ids[i], token_ids[i + 1]))
+                        if p_info is not None and p_info[0] < best_priority:
+                            best_priority = p_info[0]
+                            best_idx = i
+                    if best_idx == -1:
+                        break
+                    new_id = merge_priority[
+                        (token_ids[best_idx], token_ids[best_idx + 1])
+                    ][1]
+                    token_ids[best_idx : best_idx + 2] = [new_id]
+                result.extend(token_ids)
 
-        # Learned merges are replayed in training order. `pairs` only skips the
-        # full token scan when a learned pair is absent from the current input.
-        token_ids: Sequence[int] = byte_encoded_chars
-        pairs = set(zip(token_ids, token_ids[1:]))
-        for pair, new_id in tqdm(
-            self.learned_merges,
-            desc="Applying merges to encode",
-            leave=False,
-            disable=not show_progress,
-        ):
-            if pair not in pairs:
-                continue
-            token_ids = self._merge_pairs(pair, new_id, token_ids)
-            pairs = set(zip(token_ids, token_ids[1:]))
-
-        return list(token_ids)
+        return result
 
     def decode(self, encoded_tokens: List[int]) -> str:
         """Decodes a sequence of BPE token IDs back into a string.
@@ -403,7 +693,7 @@ class BytePairEncoder:
 
         Example:
             >>> bpe = BytePairEncoder(num_merges=50)
-            >>> bpe.train_vocabulary("Hello world!")
+            >>> bpe.train_vocabulary(["Hello world!"])
             >>> token_ids = bpe.encode("Hello world!")
             >>> text = bpe.decode(token_ids) # Expected: "Hello world!" (or similar)
         """
@@ -436,14 +726,7 @@ class BytePairEncoder:
             >>> print(tokens)
             ['Hello', '<|endoftext|>', ' ', 'world', '!']
         """
-        special_pattern = (
-            "(" + "|".join(regex.escape(k) for k in self.SPECIAL_TOKENS) + ")"
-        )
-        splitted_input = regex.split(special_pattern, input_text)
-
-        general_pattern = regex.compile(
-            r"""'(?:[sdmt]|ll|ve|re)| ?\p{L}++| ?\p{N}++| ?[^\s\p{L}\p{N}]++|\s++$|\s+(?!\S)|\s"""
-        )
+        splitted_input = self._special_pattern.split(input_text)
 
         final_chunks: List[str] = []
         for segment in splitted_input:
@@ -452,114 +735,89 @@ class BytePairEncoder:
             if segment in self.SPECIAL_TOKENS:
                 final_chunks.append(segment)
             else:
-                final_chunks.extend(general_pattern.findall(segment))
+                final_chunks.extend(self._general_pattern.findall(segment))
 
         return [tok for tok in final_chunks if tok]
 
-    def _get_initial_pair_counts(
-        self, word_freq: Counter
-    ) -> Dict[Tuple[int, int], int]:
-        """Builds a global frequency dictionary of adjacent token pairs across the `word_freq` corpus.
+    def _iter_encoded_batches(
+        self,
+        text_iter: Iterable[str],
+        *,
+        text_batch_size: int,
+        desc: str,
+    ) -> Iterable[list[list[int]]]:
+        if text_batch_size < 1:
+            raise ValueError(f"text_batch_size must be >= 1, got {text_batch_size}")
 
-        Args:
-            word_freq (Counter): A counter mapping word tuples (of token IDs) to their frequencies.
-
-        Returns:
-            Dict[Tuple[int, int], int]: A dictionary mapping each bigram (two adjacent token IDs)
-            to its total frequency across the corpus.
-
-        Examples:
-            >>> from collections import Counter
-            >>> word_freq = Counter({(65, 66, 67): 10, (66, 67, 68): 5})
-            >>> bpe = BytePairEncoder(num_merges=50)
-            >>> counts = bpe._get_initial_pair_counts(word_freq) # Displays the frequency counts for each bigram
-        """
-        items = list(word_freq.items())
-        if self._should_parallelize(work_items=len(items), min_items_per_worker=256):
-            chunk_size = max(1, len(items) // self.n_workers)
+        text_batches = batched(text_iter, text_batch_size)
+        if self.n_workers > 1:
             with Pool(self.n_workers) as pool:
-                chunked_items = [
-                    items[i : i + chunk_size] for i in range(0, len(items), chunk_size)
-                ]
-                partial_results = pool.map(
-                    BytePairEncoder._local_pair_counts, chunked_items
+                yield from tqdm(
+                    pool.imap(self._encode_text_batch, text_batches),
+                    desc=desc,
+                    unit="batch",
                 )
         else:
-            partial_results = [BytePairEncoder._local_pair_counts(items)]
+            for text_batch in tqdm(text_batches, desc=desc, unit="batch"):
+                yield self._encode_text_batch(text_batch)
 
-        total_counts = Counter()
-        for c in partial_results:
-            total_counts.update(c)
-        return dict(total_counts)
+    def _encode_text_batch(self, text_batch: Sequence[str]) -> list[list[int]]:
+        return [self.encode(text) for text in text_batch]
 
-    def _apply_merges_to_corpus(
+    def _apply_merges_to_corpus_indexed(
         self,
         pair: Tuple[int, int],
         new_id: int,
         corpus_word_freq: Counter,
         pair_counts: Dict[Tuple[int, int], int],
+        pair_to_words: Dict[Tuple[int, int], set],
+        heap: list,
     ) -> None:
-        """Merges all occurrences of `pair` across the entire corpus and updates pair_counts.
-
-        Args:
-            pair (Tuple[int, int]): The bigram pair of token IDs to merge.
-            new_id (int): The integer ID assigned to the merged token.
-            corpus_word_freq (Counter): A counter of (tuple_of_tokens -> frequency).
-            pair_counts (Dict[Tuple[int, int], int]): Global dictionary of bigram frequencies.
-
-        Examples:
-            >>> corpus_word_freq = Counter({(65, 66, 67): 3})
-            >>> pair_counts = {(65, 66): 3, (66, 67): 3}
-            >>> bpe = BytePairEncoder(num_merges=50)
-            >>> bpe._apply_merges_to_corpus((65, 66), 300, corpus_word_freq, pair_counts)
-            >>> print(corpus_word_freq)
-            >>> print(pair_counts)
+        """Apply a single merge to affected words using an inverted index,
+        updating pair_counts, pair_to_words, and the heap in place.
         """
-        # Gather all items (word tuples) that contain the pair
-        items_to_update = []
-        for w_tuple, freq in corpus_word_freq.items():
-            if pair in zip(w_tuple, w_tuple[1:]):
-                items_to_update.append((w_tuple, freq))
+        affected = pair_to_words.pop(pair, set())
+        pair_counts.pop(pair, None)
+        if not affected:
+            return
 
+        # Collect (old_tuple, freq) for affected words that are still in the corpus
+        items_to_update = []
+        for w_tuple in affected:
+            if w_tuple in corpus_word_freq:
+                items_to_update.append((w_tuple, corpus_word_freq[w_tuple]))
         if not items_to_update:
             return
 
-        # Decrement old bigram counts in pair_counts
+        # Decrement old pair counts and remove from inverted index.
+        # No heap pushes here — stale entries are lazily corrected at pop time.
         for old_tuple, freq in items_to_update:
             for bg in zip(old_tuple, old_tuple[1:]):
-                pair_counts[bg] -= freq
-                if pair_counts[bg] <= 0:
-                    pair_counts.pop(bg, None)
+                if bg in pair_counts:
+                    pair_counts[bg] -= freq
+                    if pair_counts[bg] <= 0:
+                        pair_counts.pop(bg, None)
+                        pair_to_words.pop(bg, None)
+                    elif bg in pair_to_words:
+                        pair_to_words[bg].discard(old_tuple)
+            del corpus_word_freq[old_tuple]
 
-        # Remove old tuples from corpus_word_freq
-        for w_tuple, _ in items_to_update:
-            del corpus_word_freq[w_tuple]
+        # Merge and update. Track which pairs changed so we push each only once.
+        changed_pairs: set = set()
+        for old_tuple, freq in items_to_update:
+            new_tuple = BytePairEncoder._merge_pairs(pair, new_id, old_tuple)
+            corpus_word_freq[new_tuple] += freq
 
-        # Parallel merge
-        if self._should_parallelize(
-            work_items=len(items_to_update), min_items_per_worker=256
-        ):
-            chunk_size = max(1, len(items_to_update) // self.n_workers)
-            with Pool(self.n_workers) as pool:
-                chunked_items = [
-                    items_to_update[i : i + chunk_size]
-                    for i in range(0, len(items_to_update), chunk_size)
-                ]
-                partial_results = pool.map(
-                    BytePairEncoder._local_merge_chunk,
-                    [(chunk, pair, new_id) for chunk in chunked_items],
-                )
-        else:
-            partial_results = [
-                BytePairEncoder._local_merge_chunk((items_to_update, pair, new_id))
-            ]
-
-        # Aggregate results
-        for local_new_word_freq, local_pair_counts in partial_results:
-            for tup, freq in local_new_word_freq.items():
-                corpus_word_freq[tup] += freq
-            for bg, freq in local_pair_counts.items():
+            for bg in zip(new_tuple, new_tuple[1:]):
                 pair_counts[bg] = pair_counts.get(bg, 0) + freq
+                if bg not in pair_to_words:
+                    pair_to_words[bg] = set()
+                pair_to_words[bg].add(new_tuple)
+                changed_pairs.add(bg)
+
+        # Single heap push per changed pair (not per word form)
+        for bg in changed_pairs:
+            heapq.heappush(heap, (-pair_counts[bg], bg))
 
     # ------------- Some helper functions for building vocabulary and encoding data ----------
     @staticmethod
@@ -593,54 +851,3 @@ class BytePairEncoder:
                 merged_tokens.append(corpus[i])
                 i += 1
         return tuple(merged_tokens)
-
-    @staticmethod
-    def _local_pair_counts(chunk: List[Tuple[Tuple[int, ...], int]]) -> Counter:
-        """Computes local bigram counts for a chunk of (word_tuple, frequency) items.
-
-        Args:
-            chunk (List[Tuple[Tuple[int, ...], int]]): A subset of corpus word-frequency items.
-
-        Returns:
-            Counter: A Counter object mapping each bigram to its frequency within this chunk.
-
-        Examples:
-            >>> chunk = [((65, 66, 67), 2)]
-            >>> counts = BytePairEncoder._local_pair_counts(chunk)  # Expected output: Counter({(65, 66): 2, (66, 67): 2})
-        """
-        partial_counts = Counter()
-        for w_tuple, freq in chunk:
-            for pair_ in zip(w_tuple, w_tuple[1:]):
-                partial_counts[pair_] += freq
-        return partial_counts
-
-    @staticmethod
-    def _local_merge_chunk(
-        args: Tuple[List[Tuple[Tuple[int, ...], int]], Tuple[int, int], int],
-    ):
-        """Merges a bigram pair locally within a chunk of word tuples and frequencies.
-
-        Args:
-            args: A tuple containing:
-                - The chunk of items to update.
-                - The bigram pair to merge.
-                - The new token ID.
-
-        Returns:
-            Tuple[Dict[Tuple[int, ...], int], Dict[Tuple[int, int], int]]:
-                A dictionary of updated word tuples to frequency counts,
-                and a dictionary of updated bigram pair frequencies.
-
-        Examples:
-            >>> chunk = [((65, 66, 67), 2)]
-            >>> result = BytePairEncoder._local_merge_chunk((chunk, (65, 66), 300))  # Expected: a tuple with updated frequencies
-        """
-        chunk, pair, new_id = args
-        local_new_word_freq = Counter()
-        local_pair_counts = Counter()
-        for old_tuple, freq in chunk:
-            new_tuple = BytePairEncoder._merge_pairs(pair, new_id, old_tuple)
-            local_new_word_freq[new_tuple] += freq
-            for bg in zip(new_tuple, new_tuple[1:]):
-                local_pair_counts[bg] += freq
-        return dict(local_new_word_freq), dict(local_pair_counts)

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -49,6 +49,7 @@ class GenerationResult:
 class OpenWebTextSource:
     parquet_files: list[dict[str, Any]]
     parquet_dir: str
+    start_token: str
     split_token: str
     parquet_shards_per_batch: int
 
@@ -69,7 +70,20 @@ class OpenWebTextSource:
                     batch_size=2048,
                 ):
                     for doc in batch.column("text").to_pylist():
-                        yield doc + self.split_token
+                        yield format_document_for_causal_lm(
+                            doc,
+                            start_token=self.start_token,
+                            split_token=self.split_token,
+                        )
+
+
+def format_document_for_causal_lm(
+    doc: str,
+    *,
+    start_token: str,
+    split_token: str,
+) -> str:
+    return f"{start_token}{doc}{split_token}"
 
 
 def generate(
@@ -621,7 +635,12 @@ def load_shakespeare_mini() -> str:
     return data
 
 
-def load_openwebtext(parquet_shards_per_batch: int = 1) -> OpenWebTextSource:
+def load_openwebtext(
+    parquet_shards_per_batch: int = 1,
+    *,
+    start_token: str,
+    split_token: str,
+) -> OpenWebTextSource:
     """Return a streaming OpenWebText source backed by public parquet shards."""
     if parquet_shards_per_batch < 1:
         raise ValueError(
@@ -652,7 +671,8 @@ def load_openwebtext(parquet_shards_per_batch: int = 1) -> OpenWebTextSource:
     return OpenWebTextSource(
         parquet_files=parquet_files,
         parquet_dir=parquet_dir,
-        split_token="<|endoftext|>",
+        start_token=start_token,
+        split_token=split_token,
         parquet_shards_per_batch=parquet_shards_per_batch,
     )
 

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -114,6 +114,7 @@ class CustomBpeConfig:
     vocab_path: str
     overwrite_encoded_data: bool
     overwrite_vocabulary_file: bool
+    start_token: str
     split_token: str
     parquet_shards_per_batch: int = 1
     n_workers: Optional[int] = None

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -220,7 +220,7 @@ class AbstractTrainer(ABC):
     """Base trainer that defines a high-level training loop.
 
     Subclasses should implement domain-specific steps such as:
-    - forward pass and loss computation in `_compute_loss`
+    - forward pass and loss computation in `_forward_and_loss`
     - evaluation logic in `_evaluate`
 
     Attributes:
@@ -339,7 +339,7 @@ class AbstractTrainer(ABC):
                 train_data_loader.on_epoch_start()
 
                 for batch in train_data_loader:
-                    loss = self._compute_loss(batch)
+                    loss = self._forward_and_loss(batch)
                     total_weight = self._loss_total_weight(batch)
                     loss.backward()
                     state.record_loss(loss, total_weight=total_weight)
@@ -528,7 +528,7 @@ class AbstractTrainer(ABC):
         return xp.array(1.0, dtype=xp.float32)
 
     @abstractmethod
-    def _compute_loss(self, batch_data) -> Tensor:
+    def _forward_and_loss(self, batch_data) -> Tensor:
         """Returns the scalar loss Tensor for a single training batch.
 
         Subclasses must implement the forward pass and loss computation here.
@@ -864,7 +864,7 @@ class SimpleTrainer(AbstractTrainer):
             else "regression"
         )
 
-    def _compute_loss(self, batch_data) -> Tensor:
+    def _forward_and_loss(self, batch_data) -> Tensor:
         batch_X, batch_y = batch_data
         y_pred = self.model(batch_X)
         return self.loss_fn(y_pred, batch_y)
@@ -1063,12 +1063,19 @@ class LLMTrainer(AbstractTrainer):
         self.forward_fn = forward_fn
         self.eval_callbacks = list(eval_callbacks or [])
 
-    def _compute_loss(self, batch_data) -> Tensor:
+    def _forward_and_loss(
+        self,
+        batch_data,
+        *,
+        label_smoothing: float | None = None,
+    ) -> Tensor:
+        if label_smoothing is None:
+            label_smoothing = self.config.label_smoothing
         logits = self.forward_fn.train(self.model, batch_data)
         return self.loss_fn(
             logits,
             batch_data.labels,
-            label_smoothing=self.config.label_smoothing,
+            label_smoothing=label_smoothing,
             reduction="sum",
         )
 
@@ -1091,14 +1098,8 @@ class LLMTrainer(AbstractTrainer):
                 and state.eval_loss_batches >= self.config.max_eval_steps
             ):
                 break
-            logits = self.forward_fn.train(self.model, batch_data)
             # Report hard-label CE/NLL for validation; smoothing is a training regularizer.
-            loss = self.loss_fn(
-                logits,
-                batch_data.labels,
-                label_smoothing=0.0,
-                reduction="sum",
-            )
+            loss = self._forward_and_loss(batch_data, label_smoothing=0.0)
             state.record_eval_loss(
                 loss,
                 total_weight=self._loss_total_weight(batch_data),

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -177,6 +177,7 @@ if __name__ == "__main__":
             vocab_path="training_data/shakespeare_vocab_0.pkl",
             overwrite_encoded_data=False,
             overwrite_vocabulary_file=False,
+            start_token="<SOS>",
             split_token="<|endoftext|>",
         ),
     )
@@ -193,10 +194,9 @@ if __name__ == "__main__":
         )
 
         encoded_data = bpe.prepare_data(
-            raw_text=data,
+            [data],
             overwrite_encoded_data=CONFIG.custom_bpe.overwrite_encoded_data,
             overwrite_vocabulary_file=CONFIG.custom_bpe.overwrite_vocabulary_file,
-            split_token=CONFIG.custom_bpe.split_token,
         )
     else:
         raise ValueError(
@@ -219,13 +219,13 @@ if __name__ == "__main__":
     )
 
     train_dataset = TokenWindowMapDataset(
-        data=xp.array(train_data, dtype=xp.int32),
+        data=train_data,
         # CausalLMWindowCollator shifts one token to build input_ids/labels,
         # so a length-T model context needs a raw window of length T + 1.
         window_len=trainer.model.max_seq_len + 1,
     )
     test_dataset = TokenWindowMapDataset(
-        data=xp.array(test_data, dtype=xp.int32),
+        data=test_data,
         # CausalLMWindowCollator shifts one token to build input_ids/labels,
         # so a length-T model context needs a raw window of length T + 1.
         window_len=trainer.model.max_seq_len + 1,

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -4,6 +4,8 @@ import logging
 import sys
 from pathlib import Path
 
+import numpy as np
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -15,6 +17,7 @@ from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import TokenWindowMapDataset
 from autograd.data.sampler import RandomSampler, SequentialSampler
 from autograd.data.types import CausalLMBatch
+from autograd.data.utils import train_test_split
 from autograd.tensor import Tensor, checkpoint
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
@@ -180,7 +183,7 @@ class DecoderSublayer(nn.Module):
         a = self.layer_norm1(x)
 
         x = x + self.multi_head_attention(a, a, a, is_causal=True)
-        if low_precision_input:
+        if low_precision_input and x.data.dtype != input_dtype:
             # Dense attention can promote through its fp32 mask path; cast the residual
             # stream back so later matmuls keep the intended low-precision activations.
             x = x.astype(input_dtype)
@@ -188,7 +191,7 @@ class DecoderSublayer(nn.Module):
         # Pre-norm before feed-forward
         b = self.layer_norm2(x)
         x = x + self.feedforward(b)
-        if low_precision_input:
+        if low_precision_input and x.data.dtype != input_dtype:
             # Linear bias/addition can also promote; preserve the block's input dtype.
             x = x.astype(input_dtype)
         return x
@@ -246,10 +249,11 @@ if __name__ == "__main__":
         # Double-check whether we want to overwrite the encoded_data and vocabulary
         custom_bpe=CustomBpeConfig(
             num_merges=3000,
-            encoded_data_path="training_data/bpe_3000_shakespeare_encoded_data.npz",
+            encoded_data_path="training_data/bpe_3000_shakespeare_bos_eos_encoded_data.npz",
             vocab_path="training_data/shakespeare_vocab_3000.pkl",
             overwrite_encoded_data=False,
             overwrite_vocabulary_file=False,
+            start_token="<SOS>",
             split_token="<|endoftext|>",
         ),
     )
@@ -261,8 +265,8 @@ if __name__ == "__main__":
         max_eval_steps=20,
         checkpoint_freq=1000,
         report_every_steps=50,
-        global_batch_size=32,
-        micro_batch_size=8,
+        global_batch_size=76,
+        micro_batch_size=19,
         max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 9,  # GPT-2 small uses 12
@@ -289,10 +293,11 @@ if __name__ == "__main__":
         eval_start_string="April is",
         custom_bpe=CustomBpeConfig(
             num_merges=12000,
-            encoded_data_path="training_data/bpe_12000_wiki_simple_encoded_data.npz",
+            encoded_data_path="training_data/bpe_12000_wiki_simple_bos_eos_encoded_data.npz",
             vocab_path="training_data/wikipedia_simpleenglish_vocab_12000.pkl",
             overwrite_encoded_data=False,
             overwrite_vocabulary_file=False,
+            start_token="<SOS>",
             split_token="<|endoftext|>",
         ),
     )
@@ -331,11 +336,12 @@ if __name__ == "__main__":
         label_smoothing=0.1,
         eval_start_string="The",
         custom_bpe=CustomBpeConfig(
-            num_merges=24000,
-            encoded_data_path="training_data/bpe_24000_openwebtext_encoded_data.npz",
-            vocab_path="training_data/openwebtext_vocab_24000.pkl",
+            num_merges=32768,
+            encoded_data_path="training_data/bpe_32768_openwebtext_encoded_data.npz",
+            vocab_path="training_data/openwebtext_vocab_32768.pkl",
             overwrite_encoded_data=False,
             overwrite_vocabulary_file=False,
+            start_token="<SOS>",
             split_token="<|endoftext|>",
             parquet_shards_per_batch=32,
         ),
@@ -352,33 +358,61 @@ if __name__ == "__main__":
             vocab_file_path=CONFIG.custom_bpe.vocab_path,
             encoded_data_path=CONFIG.custom_bpe.encoded_data_path,
             n_workers=CONFIG.custom_bpe.n_workers,
+            min_word_freq=5,  # this is about 99.7% coverage
         )
-        if CONFIG.dataset_name == "openwebtext":
-            raw_text = "".join(
-                text_utils.load_openwebtext(
+        encoded_npy_path = Path(bpe.mmap_path)
+        vocab_path = Path(CONFIG.custom_bpe.vocab_path)
+        use_cached_encoded_data = (
+            encoded_npy_path.exists()
+            and vocab_path.exists()
+            and not CONFIG.custom_bpe.overwrite_encoded_data
+            and not CONFIG.custom_bpe.overwrite_vocabulary_file
+        )
+        if use_cached_encoded_data:
+            logger.info(
+                "Found existing encoded data at '%s', loading it without fetching raw data.",
+                encoded_npy_path,
+            )
+            encoded_data = np.load(str(encoded_npy_path), mmap_mode="r")
+            logger.info(f"Vocabulary size: {bpe.n_vocab}")
+            logger.info(f"Encoded data length: {len(encoded_data)}")
+        else:
+            if CONFIG.dataset_name == "openwebtext":
+                text_source = text_utils.load_openwebtext(
                     parquet_shards_per_batch=(
                         CONFIG.custom_bpe.parquet_shards_per_batch
                     ),
+                    start_token=CONFIG.custom_bpe.start_token,
+                    split_token=CONFIG.custom_bpe.split_token,
                 )
+            elif CONFIG.dataset_name == "wiki_simple_english":
+                text_source = [
+                    text_utils.format_document_for_causal_lm(
+                        text_utils.load_wiki_simple(),
+                        start_token=CONFIG.custom_bpe.start_token,
+                        split_token=CONFIG.custom_bpe.split_token,
+                    )
+                ]
+            else:
+                text_source = [
+                    text_utils.format_document_for_causal_lm(
+                        text_utils.load_shakespeare_mini(),
+                        start_token=CONFIG.custom_bpe.start_token,
+                        split_token=CONFIG.custom_bpe.split_token,
+                    )
+                ]
+            encoded_data = bpe.prepare_data(
+                text_source,
+                overwrite_vocabulary_file=CONFIG.custom_bpe.overwrite_vocabulary_file,
+                overwrite_encoded_data=CONFIG.custom_bpe.overwrite_encoded_data,
             )
-        elif CONFIG.dataset_name == "wiki_simple_english":
-            raw_text = text_utils.load_wiki_simple()
-        else:
-            raw_text = text_utils.load_shakespeare_mini()
-        encoded_data = bpe.prepare_data(
-            raw_text=raw_text,
-            overwrite_vocabulary_file=CONFIG.custom_bpe.overwrite_vocabulary_file,
-            overwrite_encoded_data=CONFIG.custom_bpe.overwrite_encoded_data,
-            split_token=CONFIG.custom_bpe.split_token,
-        )
     else:
         raise ValueError(
             "Please supply a custom_bpe config. Check out CustomBpeConfig for more details."
         )
 
-    n = int(len(encoded_data) * 0.9)
-    train_data, test_data = encoded_data[:n], encoded_data[n:]
-    print(f"Data length: {len(train_data)=} {len(test_data)=}")
+    train_data, test_data = train_test_split(encoded_data, test_size=0.1, shuffle=False)
+    del encoded_data
 
     CONFIG.model_kwargs["vocab_size"] = bpe.n_vocab
 

--- a/examples/grpo.py
+++ b/examples/grpo.py
@@ -67,7 +67,7 @@ class GRPOTrainingConfig(GenericTrainingConfig):
 # 5. MapDataset stores the already-generated RolloutGroup.
 # 6. DataLoader batches RolloutGroup objects and calls GRPOCollator.
 # 7. GRPOCollator emits GRPOBatch, where rows = group_size for one task.
-# 8. GRPOTrainer(AbstractTrainer)._compute_loss computes the GRPO objective.
+# 8. GRPOTrainer(AbstractTrainer)._forward_and_loss computes the GRPO objective.
 # 9. AbstractTrainer.fit owns backward(), gradient accumulation, clipping,
 #     optimizer.step(), checkpointing, and reporting.
 #
@@ -203,21 +203,24 @@ class GRPOCollator(Collator):
                 batch_advantages.append(advantages)
 
         return GRPOBatch(
-            input_ids=xp.stack(batch_input_ids, axis=0),
-            labels=xp.stack(batch_labels, axis=0),
-            sampled_token_logprobs=xp.stack(batch_sampled_token_logprobs, axis=0),
-            generated_token_mask=xp.stack(batch_generated_token_mask, axis=0),
-            advantages=xp.stack(batch_advantages, axis=0),
+            input_ids=xp.array(np.stack(batch_input_ids, axis=0)),
+            labels=xp.array(np.stack(batch_labels, axis=0)),
+            sampled_token_logprobs=xp.array(
+                np.stack(batch_sampled_token_logprobs, axis=0)
+            ),
+            generated_token_mask=xp.array(np.stack(batch_generated_token_mask, axis=0)),
+            advantages=xp.array(np.stack(batch_advantages, axis=0)),
         )
 
     def _build_row(
         self,
         prompt_tokens: Array,
         sample: Sample,
-    ) -> tuple[Array, Array, Array, Array, Array]:
-        completion_tokens = sample.completion_tokens
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        completion_tokens = np.asarray(sample.completion_tokens)
 
-        prompt_len = len(prompt_tokens)
+        prompt_np = np.asarray(prompt_tokens, dtype=np.int32)
+        prompt_len = len(prompt_np)
         completion_len = len(completion_tokens)
         row_len = prompt_len + completion_len
 
@@ -226,28 +229,25 @@ class GRPOCollator(Collator):
                 f"GRPO row length {row_len} exceeds max_tokens {self.max_tokens}"
             )
 
-        tokens = xp.concatenate(
-            [prompt_tokens, completion_tokens],
-            axis=0,
-        )
+        tokens = np.concatenate([prompt_np, completion_tokens], axis=0)
 
         # Before padding and causal shift, align all per-token rows on the
         # prompt+completion sequence. Example:
         # tokens       = [prompt_token_0, prompt_token_1, completion_token_0]
         # generated_token_mask = [             0,              0,                  1]
         # sampled_token_logprobs = [           0.0,            0.0,  completion_logprob_0]
-        generated_token_mask = xp.concatenate(
+        generated_token_mask = np.concatenate(
             [
-                xp.zeros(prompt_len, dtype=xp.int32),
-                xp.ones(completion_len, dtype=xp.int32),
+                np.zeros(prompt_len, dtype=np.int32),
+                np.ones(completion_len, dtype=np.int32),
             ],
             axis=0,
         )
 
-        aligned_sampled_token_logprobs = xp.concatenate(
+        aligned_sampled_token_logprobs = np.concatenate(
             [
-                xp.zeros(prompt_len, dtype=xp.float32),
-                sample.sampled_token_logprobs,
+                np.zeros(prompt_len, dtype=np.float32),
+                np.asarray(sample.sampled_token_logprobs, dtype=np.float32),
             ],
             axis=0,
         )
@@ -255,7 +255,7 @@ class GRPOCollator(Collator):
         if sample.advantage is None:
             raise ValueError("sample.advantage must be set before collation")
 
-        aligned_advantages = generated_token_mask.astype(xp.float32) * float(
+        aligned_advantages = generated_token_mask.astype(np.float32) * float(
             sample.advantage
         )
 
@@ -447,7 +447,7 @@ class RolloutGenerator:
         environment: Environment,
     ) -> RolloutGroup:
         task_prompt: str = environment.render_task(task)
-        prompt_tokens = xp.array(tokenizer.encode(task_prompt), dtype=xp.int32)
+        prompt_tokens = np.array(tokenizer.encode(task_prompt), dtype=np.int32)
         samples = generation(
             model,
             prompt_tokens=prompt_tokens,
@@ -516,7 +516,7 @@ class GRPOTrainer(AbstractTrainer):
     Each one-task GRPOBatch contains group_size rows.
     """
 
-    def _compute_loss(self, batch: GRPOBatch):
+    def _forward_and_loss(self, batch: GRPOBatch):
         """
         Compute the GRPO objective from a trainer-facing batch.
 
@@ -557,7 +557,7 @@ class GRPOTrainer(AbstractTrainer):
         self.optimizer.zero_grad()
 
         state = TrainingState()
-        loss = self._compute_loss(batch)
+        loss = self._forward_and_loss(batch)
         total_weight = self._loss_total_weight(batch)
         loss.backward()
         state.record_loss(loss, total_weight=total_weight)
@@ -666,9 +666,9 @@ def generation(
     # boundaries at the rendered-prompt/completion join.
     return [
         Sample(
-            completion_tokens=xp.array(result.completion_tokens, dtype=xp.int32),
+            completion_tokens=np.array(result.completion_tokens, dtype=np.int32),
             completion_text=tokenizer.decode(result.completion_tokens),
-            sampled_token_logprobs=xp.array(result.logprobs, dtype=xp.float32),
+            sampled_token_logprobs=np.array(result.logprobs, dtype=np.float32),
             reward=None,
             advantage=None,
             metadata={
@@ -732,7 +732,7 @@ def main():
     rollout_generator = RolloutGenerator(TRAIN_CONFIG)
     collator = GRPOCollator(
         max_tokens=trainer.model.max_seq_len,
-        pad_idx=bpe.encode("<|pad|>")[0],
+        pad_idx=bpe.encode("<PAD>")[0],
     )
     report_every_steps = TRAIN_CONFIG.report_every_steps or TRAIN_CONFIG.checkpoint_freq
 

--- a/examples/movie_sentiment.py
+++ b/examples/movie_sentiment.py
@@ -1,8 +1,9 @@
 import logging
 import os
 
+import numpy as np
+
 from autograd import functional, nn, optim
-from autograd.backend import xp
 from autograd.data.collator import OneHotCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import PairedMapDataset
@@ -28,7 +29,7 @@ def reviews_to_token_ids(reviews, vocabulary, max_sequence_length, pad_str="<PAD
             token_ids[idx] = vocabulary.get(word, unk_idx)
         matrix.append(token_ids)
 
-    return xp.array(matrix, dtype=xp.int32)
+    return np.array(matrix, dtype=np.int32)
 
 
 def process_data(data):
@@ -50,8 +51,8 @@ def process_data(data):
     sentiments = [row[1] for row in data]
     vocab = create_vocabulary(reviews, max_features=6000)
     features = reviews_to_token_ids(reviews, vocab, max_sequence_length=25)
-    labels = xp.array(
-        [1 if label == "positive" else 0 for label in sentiments], dtype=xp.int32
+    labels = np.array(
+        [1 if label == "positive" else 0 for label in sentiments], dtype=np.int32
     )
 
     X_train, X_test, y_train, y_test = train_test_split(features, labels, test_size=0.1)

--- a/examples/sft_gpt_2.py
+++ b/examples/sft_gpt_2.py
@@ -94,6 +94,7 @@ if __name__ == "__main__":
             ),
             overwrite_encoded_data=False,
             overwrite_vocabulary_file=False,
+            start_token="<SOS>",
             split_token="<|endoftext|>",
         ),
     )

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -614,6 +614,7 @@ if __name__ == "__main__":
             vocab_path="training_data/wikisum_seq2seq_vocab_0.pkl",
             overwrite_encoded_data=False,
             overwrite_vocabulary_file=False,
+            start_token="<SOS>",
             split_token="<|endoftext|>",
         ),
     )
@@ -641,7 +642,7 @@ if __name__ == "__main__":
             + [target_text for _, target_text in train_pairs]
         )
         bpe.train_vocabulary(
-            train_corpus,
+            [train_corpus],
             overwrite_saved_file=CONFIG.custom_bpe.overwrite_vocabulary_file,
         )
     else:
@@ -661,8 +662,8 @@ if __name__ == "__main__":
         forward_fn=TransformerForwardFn(),
     )
 
-    pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
-    sos_idx = bpe.encode("<SOS>", allowed_special={"<SOS>"})[0]
+    pad_idx = bpe.encode("<PAD>")[0]
+    sos_idx = bpe.encode("<SOS>")[0]
     train_dataset = build_seq2seq_dataset_from_text_pairs(
         train_pairs,
         bpe,

--- a/test/autograd/data/test_collator.py
+++ b/test/autograd/data/test_collator.py
@@ -68,46 +68,44 @@ class TestCollator(unittest.TestCase):
         self.bpe = MockBPE()
 
     def test_create_padding_mask_default_dims(self):
-        token_indices = xp.array(
+        token_indices = np.array(
             [
                 [1, 2, 0, 0],
                 [3, 4, 5, 0],
             ],
-            dtype=xp.int32,
+            dtype=np.int32,
         )
 
         mask = create_padding_mask(token_indices, pad_idx=0, dims=None)
 
         self.assertEqual(mask.shape, (2, 1, 1, 4))
-        assert xp.array_equal(mask[0, 0, 0], xp.array([0, 0, 1, 1]))
-        assert xp.array_equal(mask[1, 0, 0], xp.array([0, 0, 0, 1]))
+        np.testing.assert_array_equal(mask[0, 0, 0], [0, 0, 1, 1])
+        np.testing.assert_array_equal(mask[1, 0, 0], [0, 0, 0, 1])
 
     def test_create_padding_mask_custom_dims(self):
-        token_indices = xp.array([[1, 0, 0], [2, 2, 0]], dtype=xp.int32)
+        token_indices = np.array([[1, 0, 0], [2, 2, 0]], dtype=np.int32)
 
         mask = create_padding_mask(token_indices, pad_idx=0, dims=(2, 1, 3))
 
         self.assertEqual(mask.shape, (2, 1, 3))
-        assert xp.array_equal(mask[0, 0], xp.array([0, 1, 1]))
-        assert xp.array_equal(mask[1, 0], xp.array([0, 0, 1]))
+        np.testing.assert_array_equal(mask[0, 0], [0, 1, 1])
+        np.testing.assert_array_equal(mask[1, 0], [0, 0, 1])
 
     def test_pad_right_1d_pads_without_truncating(self):
         tokens = pad_right_1d(
-            values=xp.array([10, 11, 12], dtype=xp.int32),
+            values=np.array([10, 11, 12], dtype=np.int32),
             target_length=5,
             pad_value=0,
         )
 
-        self.assertTrue(
-            xp.array_equal(tokens, xp.array([10, 11, 12, 0, 0], dtype=xp.int32))
-        )
+        np.testing.assert_array_equal(tokens, [10, 11, 12, 0, 0])
 
     def test_pad_right_1d_rejects_shorter_target_length(self):
         with self.assertRaisesRegex(
             ValueError, "cannot right-pad length 3 to shorter target_length 2"
         ):
             pad_right_1d(
-                values=xp.array([10, 11, 12], dtype=xp.int32),
+                values=np.array([10, 11, 12], dtype=np.int32),
                 target_length=2,
                 pad_value=0,
             )
@@ -236,7 +234,7 @@ class TestCollator(unittest.TestCase):
 
 
 def test_window_collator_shapes():
-    data = xp.arange(20, dtype=xp.int32)
+    data = np.arange(20, dtype=np.int32)
     examples = [
         TokenWindowExample(data, offset=0, window_len=5),
         TokenWindowExample(data, offset=3, window_len=5),
@@ -251,7 +249,7 @@ def test_window_collator_shapes():
 
 
 def test_window_collator_shift():
-    data = xp.arange(10, dtype=xp.int32)
+    data = np.arange(10, dtype=np.int32)
     example = TokenWindowExample(data, offset=2, window_len=5)
 
     batch = CausalLMWindowCollator()([example])
@@ -267,7 +265,7 @@ def test_window_collator_shift():
 
 
 def test_window_collator_requires_shiftable_window():
-    example = TokenWindowExample(xp.arange(4, dtype=xp.int32), offset=0, window_len=1)
+    example = TokenWindowExample(np.arange(4, dtype=np.int32), offset=0, window_len=1)
 
     with pytest.raises(ValueError, match="window_len must be >= 2"):
         CausalLMWindowCollator()([example])

--- a/test/autograd/data/test_data_loader.py
+++ b/test/autograd/data/test_data_loader.py
@@ -39,7 +39,6 @@ def make_token_dataset(token_sequences, loss_masks=None):
         loss_masks,
         input_key="tokens",
         target_key="loss_mask",
-        dtype=xp.int32,
     )
 
 
@@ -120,7 +119,6 @@ class TestDataLoader(unittest.TestCase):
                 targets,
                 input_key="input_ids",
                 target_key="labels",
-                dtype=xp.int32,
             )
             sampler = RandomSampler(dataset) if shuffle else None
             collator = Seq2SeqCollator(
@@ -371,15 +369,7 @@ class TestDataLoader(unittest.TestCase):
 
         self.assertEqual(batch_lengths, [[2, 3], [7, 8]])
 
-    @patch("autograd.data.dataset.xp.random.permutation")
-    def test_length_grouped_sampler_shuffle_stays_on_cpu(
-        self,
-        backend_permutation,
-    ):
-        backend_permutation.side_effect = AssertionError(
-            "backend permutation should not be used"
-        )
-
+    def test_length_grouped_sampler_shuffle_stays_on_cpu(self):
         dataset = make_token_dataset(
             [
                 xp.arange(2, dtype=xp.int32),
@@ -401,8 +391,8 @@ class TestDataLoader(unittest.TestCase):
 
         sampler.on_epoch_start()
 
+        # Sampler uses numpy (CPU) random, not the compute backend
         self.assertIsInstance(sampler.indices, list)
-        backend_permutation.assert_not_called()
 
     @patch(
         "autograd.data.collator.create_padding_mask",

--- a/test/autograd/data/test_dataset.py
+++ b/test/autograd/data/test_dataset.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import pytest
 
 from autograd.backend import xp
@@ -23,6 +24,20 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(tuple(example.keys()), ("inputs", "targets"))
         self.assertTrue(xp.array_equal(example["inputs"], self.X[0]))
         self.assertEqual(int(example["targets"]), int(self.y[0]))
+
+    def test_paired_dataset_casts_to_numpy_dtype(self):
+        dataset = PairedMapDataset(
+            [[1, 2]],
+            [[3, 4]],
+            dtype=np.float32,
+        )
+
+        example = dataset[0]
+
+        self.assertEqual(example["inputs"].dtype, np.dtype(np.float32))
+        self.assertEqual(example["targets"].dtype, np.dtype(np.float32))
+        self.assertTrue(np.array_equal(example["inputs"], np.array([1.0, 2.0])))
+        self.assertTrue(np.array_equal(example["targets"], np.array([3.0, 4.0])))
 
     def test_map_dataset_iteration_stays_in_stored_order_after_epoch_start(self):
         dataset = PairedMapDataset(self.X, self.y)
@@ -68,7 +83,6 @@ class TestDataset(unittest.TestCase):
             [xp.array([3, 4])],
             input_key="input_ids",
             target_key="labels",
-            dtype=xp.int32,
         )
 
         example = next(iter(dataset))
@@ -86,7 +100,6 @@ class TestDataset(unittest.TestCase):
             [xp.ones((5,), dtype=xp.int32)],
             input_key="tokens",
             target_key="loss_mask",
-            dtype=xp.int32,
         )
 
         example = next(iter(dataset))
@@ -103,7 +116,6 @@ class TestDataset(unittest.TestCase):
             [xp.array([0, 0, 0, 0, 1, 1, 1], dtype=xp.int32)],
             input_key="tokens",
             target_key="loss_mask",
-            dtype=xp.int32,
         )
 
         example = next(iter(dataset))

--- a/test/autograd/data/test_sampler.py
+++ b/test/autograd/data/test_sampler.py
@@ -15,7 +15,6 @@ def make_token_dataset(token_sequences):
         [xp.ones((len(tokens),), dtype=xp.int32) for tokens in token_sequences],
         input_key="tokens",
         target_key="loss_mask",
-        dtype=xp.int32,
     )
 
 

--- a/test/autograd/data/test_sft.py
+++ b/test/autograd/data/test_sft.py
@@ -73,7 +73,6 @@ class TestSFTData(TestCase):
             [example["loss_mask"] for example in tokenized_examples],
             input_key="tokens",
             target_key="loss_mask",
-            dtype=xp.int32,
         )
         return DataLoader(
             dataset=dataset,

--- a/test/autograd/performance_test.py
+++ b/test/autograd/performance_test.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Optional
 from unittest import TestCase
 
+import numpy as np
 import psutil
 
 from autograd import functional, nn, optim
@@ -371,7 +372,7 @@ class CIPipelinePerformanceTest(TestCase):
                 [xp.ones((seq_len + 1,), dtype=xp.int32) for _ in range(batch_size)],
                 input_key="tokens",
                 target_key="loss_mask",
-                dtype=xp.int32,
+                dtype=np.int32,
             ),
             batch_size=batch_size,
             collator=FixedLengthCausalLMCollator(

--- a/test/autograd/test_utils.py
+++ b/test/autograd/test_utils.py
@@ -18,27 +18,14 @@ class TestUtils(TestCase):
         )
         self.y = xp.array([0, 1, 0, 1, 0])
 
-        self.X_empty = xp.array([])
-        self.y_empty = xp.array([])
-
     def test_train_test_split(self):
         X_train, X_test, y_train, y_test = train_test_split(
             self.X, self.y, test_size=0.2
         )
-        # We expect 80% of the data to be in the train set
-        # We expect 20% of the data to be in the test set
         self.assertEqual(X_train.shape, (4, 2))
         self.assertEqual(X_test.shape, (1, 2))
         self.assertEqual(y_train.shape, (4,))
         self.assertEqual(y_test.shape, (1,))
-
-        X_train, X_test, y_train, y_test = train_test_split(
-            self.X_empty, self.y_empty, test_size=0.2
-        )
-        assert xp.array_equal(X_train, self.X_empty)
-        assert xp.array_equal(X_test, self.X_empty)
-        assert xp.array_equal(y_train, self.y_empty)
-        assert xp.array_equal(y_test, self.y_empty)
 
     def test_accuracy(self):
         self.assertEqual(accuracy(self.y, self.y), 1.0)

--- a/test/autograd/text/test_tokenizer.py
+++ b/test/autograd/text/test_tokenizer.py
@@ -1,5 +1,6 @@
 import os
-from collections import Counter
+import shutil
+import tempfile
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -7,8 +8,6 @@ import numpy as np
 
 from autograd.text.tokenizer import BytePairEncoder
 from test.helpers import array_equal
-
-ORIGINAL_NP_CONCATENATE = np.concatenate
 
 
 class TestTokenizer(TestCase):
@@ -22,7 +21,7 @@ class TestTokenizer(TestCase):
             self.original_text = f.read()
 
     def tearDown(self) -> None:
-        for path in [self.bpe.vocab_file_path, self.bpe.encoded_data_path]:
+        for path in [self.bpe.vocab_file_path, self.bpe.mmap_path]:
             if os.path.exists(path):
                 os.remove(path)
 
@@ -31,94 +30,22 @@ class TestTokenizer(TestCase):
         # 256 + number of special tokens
         self.assertEqual(len(vocab), 256 + len(self.bpe.SPECIAL_TOKENS))
 
-    def test_pair_counting(self):
-        # Instead of test_get_bigrams_to_count, we test _get_initial_pair_counts directly
-        # We'll create a small word_freq manually
-        word_freq = Counter(
-            {
-                (10, 11, 12): 3,
-                (11, 12, 12): 2,
-            }
-        )
-        pair_counts = self.bpe._get_initial_pair_counts(word_freq)
+    def test_legacy_special_token_ids_are_stable(self):
+        legacy_tokens = [
+            "<|endoftext|>",
+            "<PAD>",
+            "<SOS>",
+            "<UNK>",
+            "<|USER|>",
+            "<|ASSISTANT|>",
+        ]
 
-        # (10,11) occurs in the first tuple, 3 times
-        # (11,12) occurs in the first tuple (3 times) and second tuple (2 times) -> total 5
-        # (12,12) occurs in second tuple (2 times)
-        expected = {
-            (10, 11): 3,
-            (11, 12): 5,
-            (12, 12): 2,
-        }
-        self.assertEqual(pair_counts, expected)
-
-    @patch(
-        "autograd.text.tokenizer.Pool", side_effect=AssertionError("pool not expected")
-    )
-    def test_pair_counting_skips_pool_for_small_corpus(self, _mock_pool):
-        bpe = BytePairEncoder(num_merges=50, n_workers=4)
-        word_freq = Counter(
-            {
-                (10, 11, 12): 3,
-                (11, 12, 12): 2,
-            }
-        )
-
-        pair_counts = bpe._get_initial_pair_counts(word_freq)
-
-        self.assertEqual(
-            pair_counts,
-            {
-                (10, 11): 3,
-                (11, 12): 5,
-                (12, 12): 2,
-            },
-        )
-
-    def test_apply_merges_to_corpus(self):
-        # Instead of test_merge_pairs, we test _apply_merges_to_corpus
-        word_freq = Counter(
-            {
-                (10, 11, 11, 12): 2,
-            }
-        )
-        pair_counts = {
-            (10, 11): 2,
-            (11, 11): 2,
-            (11, 12): 2,
-        }
-        pair = (10, 11)
-        new_id = 256
-
-        self.bpe._apply_merges_to_corpus(pair, new_id, word_freq, pair_counts)
-
-        # The old tuple (10, 11, 11, 12) should be removed
-        # The new tuple is (256, 11, 12)
-        # And word_freq should have updated counts
-        self.assertFalse((10, 11, 11, 12) in word_freq)
-        self.assertEqual(word_freq[(256, 11, 12)], 2)
-
-        # Also check that pair_counts updated
-        # old bigrams: (10,11), (11,11), (11,12)
-        # new bigrams: (256,11), (11,12)
-        self.assertFalse((10, 11) in pair_counts)
-        self.assertFalse((11, 11) in pair_counts)
-        self.assertTrue((11, 12) in pair_counts)  # still remain in the pair_counts
-        self.assertIn((256, 11), pair_counts)
-        self.assertIn((11, 12), pair_counts)
-
-    @patch(
-        "autograd.text.tokenizer.Pool", side_effect=AssertionError("pool not expected")
-    )
-    def test_apply_merges_to_corpus_skips_pool_for_small_update_set(self, _mock_pool):
-        bpe = BytePairEncoder(num_merges=50, n_workers=4)
-        word_freq = Counter({(10, 11, 11, 12): 2})
-        pair_counts = {(10, 11): 2, (11, 11): 2, (11, 12): 2}
-
-        bpe._apply_merges_to_corpus((10, 11), 256, word_freq, pair_counts)
-
-        self.assertEqual(word_freq, Counter({(256, 11, 12): 2}))
-        self.assertEqual(pair_counts, {(11, 12): 2, (256, 11): 2})
+        self.assertEqual(self.bpe.SPECIAL_TOKENS[: len(legacy_tokens)], legacy_tokens)
+        for offset, token in enumerate(legacy_tokens):
+            self.assertEqual(
+                self.bpe._unicode_to_int_vocab[token.encode("utf-8")],
+                256 + offset,
+            )
 
     def test_encode_decode(self):
         input_text = self.original_text + "<|endoftext|>" + self.original_text
@@ -126,45 +53,28 @@ class TestTokenizer(TestCase):
         decoded = self.bpe.decode(encoded)
         self.assertEqual(input_text, decoded)
 
-    def test_encode_matches_learned_merge_replay(self):
-        self.bpe.train_vocabulary(self.original_text, overwrite_saved_file=True)
-
-        def replay_learned_merges(text):
-            tokens = []
-            for chunk in self.bpe._pretokenize(text):
-                if chunk in self.bpe.SPECIAL_TOKENS:
-                    tokens.append(self.bpe._unicode_to_int_vocab[chunk.encode("utf-8")])
-                else:
-                    tokens.extend(
-                        self.bpe._unicode_to_int_vocab[bytes([b])]
-                        for b in chunk.encode("utf-8")
-                    )
-
-            pairs = set(zip(tokens, tokens[1:]))
-            for pair, new_id in self.bpe.learned_merges:
-                if pair in pairs:
-                    tokens = list(BytePairEncoder._merge_pairs(pair, new_id, tokens))
-                    pairs = set(zip(tokens, tokens[1:]))
-            return tokens
+    def test_encode_roundtrip_matches_original(self):
+        self.bpe.train_vocabulary([self.original_text], overwrite_saved_file=True)
 
         for text in [
             self.original_text,
             self.original_text + "<|endoftext|>" + self.original_text,
             "low lower newest widest",
         ]:
-            self.assertEqual(self.bpe.encode(text), replay_learned_merges(text))
+            encoded = self.bpe.encode(text)
+            decoded = self.bpe.decode(encoded)
+            self.assertEqual(decoded, text)
+            # Encoding must produce fewer tokens than raw bytes (merges compress)
+            self.assertLessEqual(len(encoded), len(text.encode("utf-8")))
 
     def test_special_tokens_encoded_as_single_id(self):
-        # This checks special tokens remain single ID
-        st_id = self.bpe._unicode_to_int_vocab[
-            self.bpe.SPECIAL_TOKENS[0].encode("utf-8")
-        ]
-        self.assertIsNotNone(st_id)
+        for special_token in self.bpe.SPECIAL_TOKENS:
+            expected_id = self.bpe._unicode_to_int_vocab[special_token.encode("utf-8")]
 
-        input_text = self.bpe.SPECIAL_TOKENS[0]
-        encoded = self.bpe.encode(input_text)
-        self.assertIn(st_id, encoded)
-        self.assertEqual(self.bpe.decode(encoded), input_text)
+            encoded = self.bpe.encode(special_token)
+
+            self.assertEqual(encoded, [expected_id])
+            self.assertEqual(self.bpe.decode(encoded), special_token)
 
     def test_load_dictionary_fallback(self):
         with open(self.bpe.vocab_file_path, "wb") as f:
@@ -177,10 +87,10 @@ class TestTokenizer(TestCase):
 
     def test_train_vocabulary_skip_if_loaded_and_no_overwrite(self):
         # First train
-        self.bpe.train_vocabulary(self.original_text, overwrite_saved_file=True)
+        self.bpe.train_vocabulary([self.original_text], overwrite_saved_file=True)
         # Now call again with different text but overwrite_saved_file=False
         old_size = self.bpe.n_vocab
-        self.bpe.train_vocabulary("some different text", overwrite_saved_file=False)
+        self.bpe.train_vocabulary(["some different text"], overwrite_saved_file=False)
         # Check that nothing changed
         self.assertEqual(self.bpe.n_vocab, old_size)
 
@@ -190,196 +100,108 @@ class TestTokenizer(TestCase):
 
     def test_prepare_data_reuses_cached_encoded_data(self):
         first = self.bpe.prepare_data(
-            self.original_text,
+            [self.original_text],
             overwrite_vocabulary_file=True,
             overwrite_encoded_data=True,
         )
         second = self.bpe.prepare_data(
-            self.original_text,
+            [self.original_text],
             overwrite_vocabulary_file=False,
             overwrite_encoded_data=False,
         )
 
-        self.assertTrue(os.path.exists(self.bpe.encoded_data_path))
+        self.assertTrue(os.path.exists(self.bpe.mmap_path))
         self.assertTrue(array_equal(first, second))
 
-    @patch(
-        "autograd.text.tokenizer.Pool", side_effect=AssertionError("pool not expected")
-    )
-    def test_prepare_data_skips_pool_for_small_text(self, _mock_pool):
-        bpe = BytePairEncoder(
-            num_merges=2,
-            vocab_file_path="small_vocab.pkl",
-            encoded_data_path="small_encoded_data.npz",
-            n_workers=4,
-        )
-        self.addCleanup(
-            lambda: (
-                os.path.exists(bpe.vocab_file_path) and os.remove(bpe.vocab_file_path)
+    def test_streaming_encode_matches_full_text(self):
+        docs = [
+            "abab cdcd<|endoftext|>",
+            "xyxy abab<|endoftext|>",
+            "cdcd xyxy<|endoftext|>",
+        ]
+        full_text = "".join(docs)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            full_bpe = BytePairEncoder(
+                num_merges=20,
+                vocab_file_path=os.path.join(tmpdir, "full_vocab.pkl"),
+                encoded_data_path=os.path.join(tmpdir, "full_encoded.npy"),
+                n_workers=1,
             )
-        )
-        self.addCleanup(
-            lambda: (
-                os.path.exists(bpe.encoded_data_path)
-                and os.remove(bpe.encoded_data_path)
+            stream_bpe = BytePairEncoder(
+                num_merges=20,
+                vocab_file_path=os.path.join(tmpdir, "stream_vocab.pkl"),
+                encoded_data_path=os.path.join(tmpdir, "stream_encoded.npy"),
+                n_workers=1,
             )
-        )
 
-        encoded = bpe.prepare_data(
-            "hello hello",
-            overwrite_vocabulary_file=True,
-            overwrite_encoded_data=True,
-        )
-
-        self.assertGreater(len(encoded), 0)
-
-    @patch("autograd.text.tokenizer.Pool")
-    def test_prepare_data_disables_per_chunk_encode_progress_in_parallel(
-        self, mock_pool
-    ):
-        class RecordingBPE(BytePairEncoder):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self.show_progress_calls = []
-
-            def encode(self, input_text: str, *, show_progress: bool = True, **kwargs):
-                self.show_progress_calls.append(show_progress)
-                return super().encode(input_text, show_progress=show_progress, **kwargs)
-
-        class FakePool:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def imap(self, func, iterable):
-                for item in iterable:
-                    yield func(item)
-
-        bpe = RecordingBPE(
-            num_merges=0,
-            vocab_file_path="parallel_vocab.pkl",
-            encoded_data_path="parallel_encoded_data.npz",
-            n_workers=2,
-        )
-        self.addCleanup(
-            lambda: (
-                os.path.exists(bpe.vocab_file_path) and os.remove(bpe.vocab_file_path)
+            full_bpe.train_vocabulary([full_text], overwrite_saved_file=True)
+            stream_bpe.train_vocabulary(iter(docs), overwrite_saved_file=True)
+            mmap_path = stream_bpe.encode_to_mmap(
+                docs,
+                overwrite_encoded_data=True,
+                text_batch_size=2,
             )
-        )
-        self.addCleanup(
-            lambda: (
-                os.path.exists(bpe.encoded_data_path)
-                and os.remove(bpe.encoded_data_path)
+
+            stream_encoded = np.load(mmap_path, mmap_mode="r")
+
+            self.assertEqual(full_bpe.learned_merges, stream_bpe.learned_merges)
+            self.assertEqual(
+                full_bpe._unicode_to_int_vocab,
+                stream_bpe._unicode_to_int_vocab,
             )
-        )
-        mock_pool.return_value = FakePool()
+            self.assertEqual(full_bpe.encode(full_text), list(stream_encoded))
 
-        encoded = bpe.prepare_data(
-            "x" * 20000,
-            overwrite_vocabulary_file=True,
-            overwrite_encoded_data=True,
-        )
+    def test_encode_to_mmap_writes_direct_npy_memmap(self):
+        docs = ["hello<|endoftext|>", "world<|endoftext|>"]
 
-        self.assertGreater(len(encoded), 0)
-        self.assertEqual(bpe.show_progress_calls, [False, False])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bpe = BytePairEncoder(
+                num_merges=5,
+                vocab_file_path=os.path.join(tmpdir, "vocab.pkl"),
+                encoded_data_path=os.path.join(tmpdir, "encoded.npz"),
+                n_workers=1,
+            )
+            bpe.train_vocabulary(docs, overwrite_saved_file=True)
 
-    def test_encode_disables_progress_by_default(self):
-        with patch("autograd.text.tokenizer.tqdm") as mock_tqdm:
-            self.bpe.encode("hello")
-
-        self.assertTrue(mock_tqdm.called)
-        self.assertTrue(mock_tqdm.call_args.kwargs["disable"])
-
-    @patch("autograd.text.tokenizer.Pool")
-    @patch("autograd.text.tokenizer.xp.concatenate")
-    @patch("autograd.text.tokenizer.xp.savez_compressed")
-    def test_prepare_data_concatenates_parallel_chunks_once(
-        self, _mock_savez, mock_concatenate, mock_pool
-    ):
-        class RecordingBPE(BytePairEncoder):
-            def train_vocabulary(
-                self, input_text: str, overwrite_saved_file: bool = False
+            with patch(
+                "autograd.text.tokenizer.np.lib.format.write_array",
+                side_effect=AssertionError("encode_to_mmap should not copy raw data"),
             ):
-                return self._unicode_to_int_vocab, self._int_to_unicode_vocab
+                mmap_path = bpe.encode_to_mmap(docs, overwrite_encoded_data=True)
 
-            def encode(self, input_text: str, *, show_progress: bool = True, **kwargs):
-                return [len(input_text)]
+            encoded = np.load(mmap_path, mmap_mode="r")
+            self.assertEqual(bpe.encode("".join(docs)), list(encoded))
+            self.assertFalse(os.path.exists(f"{bpe.mmap_path}.raw.tmp"))
+            self.assertFalse(os.path.exists(f"{bpe.mmap_path}.tmp"))
 
-        class FakePool:
-            def __enter__(self):
-                return self
+    def test_encode_to_mmap_checks_disk_space_before_writing(self):
+        docs = ["hello<|endoftext|>"]
 
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def imap(self, func, iterable):
-                for item in iterable:
-                    yield func(item)
-
-        def counted_concatenate(arrays, axis=0):
-            return ORIGINAL_NP_CONCATENATE(arrays, axis=axis)
-
-        bpe = RecordingBPE(
-            num_merges=0,
-            vocab_file_path="concat_vocab.pkl",
-            encoded_data_path="concat_encoded_data.npz",
-            n_workers=2,
-        )
-        self.addCleanup(
-            lambda: (
-                os.path.exists(bpe.encoded_data_path)
-                and os.remove(bpe.encoded_data_path)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bpe = BytePairEncoder(
+                num_merges=5,
+                vocab_file_path=os.path.join(tmpdir, "vocab.pkl"),
+                encoded_data_path=os.path.join(tmpdir, "encoded.npz"),
+                n_workers=1,
             )
-        )
-        mock_pool.return_value = FakePool()
-        mock_concatenate.side_effect = counted_concatenate
+            bpe.train_vocabulary(docs, overwrite_saved_file=True)
+            disk_usage = shutil._ntuple_diskusage(total=10, used=9, free=1)
 
-        encoded = bpe.prepare_data(
-            "x" * 20000,
-            overwrite_vocabulary_file=False,
-            overwrite_encoded_data=True,
-        )
+            with patch("autograd.text.tokenizer.shutil.disk_usage") as mock_disk_usage:
+                mock_disk_usage.return_value = disk_usage
+                with self.assertRaisesRegex(OSError, "Insufficient disk space"):
+                    bpe.encode_to_mmap(docs, overwrite_encoded_data=True)
 
-        self.assertEqual(mock_concatenate.call_count, 1)
-        self.assertEqual(encoded.tolist(), [10000, 10000])
+            self.assertFalse(os.path.exists(bpe.mmap_path))
+            self.assertFalse(os.path.exists(f"{bpe.mmap_path}.tmp"))
 
-    @patch(
-        "autograd.text.tokenizer.Pool", side_effect=AssertionError("pool not expected")
-    )
-    def test_prepare_data_enables_progress_for_single_text_encode(self, _mock_pool):
-        class RecordingBPE(BytePairEncoder):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self.show_progress_calls = []
+    def test_encode_roundtrips(self):
+        text = "hello world"
+        encoded = self.bpe.encode(text)
+        decoded = self.bpe.decode(encoded)
+        self.assertEqual(decoded, text)
 
-            def encode(self, input_text: str, *, show_progress: bool = False, **kwargs):
-                self.show_progress_calls.append(show_progress)
-                return super().encode(input_text, show_progress=show_progress, **kwargs)
-
-        bpe = RecordingBPE(
-            num_merges=2,
-            vocab_file_path="single_progress_vocab.pkl",
-            encoded_data_path="single_progress_encoded_data.npz",
-            n_workers=4,
-        )
-        self.addCleanup(
-            lambda: (
-                os.path.exists(bpe.vocab_file_path) and os.remove(bpe.vocab_file_path)
-            )
-        )
-        self.addCleanup(
-            lambda: (
-                os.path.exists(bpe.encoded_data_path)
-                and os.remove(bpe.encoded_data_path)
-            )
-        )
-
-        bpe.prepare_data(
-            "hello hello",
-            overwrite_vocabulary_file=True,
-            overwrite_encoded_data=True,
-        )
-
-        self.assertEqual(bpe.show_progress_calls, [True])
+    def test_train_vocabulary_rejects_bare_str(self):
+        with self.assertRaises(TypeError):
+            self.bpe.train_vocabulary("bare string is not allowed")

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -123,13 +123,56 @@ class TestTextUtils(TestCase):
             os.chdir(tmpdir)
             try:
                 with patch("builtins.__import__", side_effect=import_without_datasets):
-                    source = load_openwebtext(parquet_shards_per_batch=2)
+                    source = load_openwebtext(
+                        parquet_shards_per_batch=2,
+                        start_token="<SOS>",
+                        split_token="<|endoftext|>",
+                    )
                     data = list(source)
             finally:
                 os.chdir(cwd)
 
-        self.assertEqual(data, ["alpha<|endoftext|>", "beta<|endoftext|>"])
+        self.assertEqual(
+            data,
+            ["<SOS>alpha<|endoftext|>", "<SOS>beta<|endoftext|>"],
+        )
         self.assertEqual(mock_urlopen.call_count, 3)
+
+    @patch("autograd.text.utils.urlopen", create=True)
+    def test_load_openwebtext_can_wrap_docs_with_start_and_split_tokens(
+        self, mock_urlopen
+    ):
+        shard = pa.BufferOutputStream()
+        pq.write_table(pa.Table.from_pylist([{"text": "alpha"}]), shard)
+        manifest = {
+            "parquet_files": [
+                {
+                    "split": "train",
+                    "url": "https://example.test/openwebtext/0000.parquet",
+                    "filename": "0000.parquet",
+                },
+            ]
+        }
+        mock_urlopen.side_effect = [
+            BytesResponse(json.dumps(manifest).encode("utf-8")),
+            BytesResponse(shard.getvalue().to_pybytes()),
+        ]
+
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            try:
+                source = load_openwebtext(
+                    parquet_shards_per_batch=1,
+                    start_token="<SOS>",
+                    split_token="<|endoftext|>",
+                )
+                data = list(source)
+            finally:
+                os.chdir(cwd)
+
+        self.assertEqual(data, ["<SOS>alpha<|endoftext|>"])
+        self.assertEqual(mock_urlopen.call_count, 2)
 
     def test_text_to_one_hot_and_sparse(self):
         texts = ["I love apples", "I love apples too"]

--- a/test/autograd/tools/test_config_schema.py
+++ b/test/autograd/tools/test_config_schema.py
@@ -1,9 +1,37 @@
 from unittest import TestCase
 
-from autograd.tools.config_schema import TransformerTrainingConfig
+from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
 
 
 class TestTransformerTrainingConfig(TestCase):
+    def test_custom_bpe_rejects_non_positive_parquet_shards_per_batch(self):
+        with self.assertRaisesRegex(
+            ValueError, "parquet_shards_per_batch must be >= 1"
+        ):
+            CustomBpeConfig(
+                num_merges=10,
+                encoded_data_path="encoded.npz",
+                vocab_path="vocab.pkl",
+                overwrite_encoded_data=False,
+                overwrite_vocabulary_file=False,
+                start_token="<SOS>",
+                split_token="<|endoftext|>",
+                parquet_shards_per_batch=0,
+            )
+
+    def test_custom_bpe_rejects_non_positive_n_workers(self):
+        with self.assertRaisesRegex(ValueError, "n_workers must be >= 1"):
+            CustomBpeConfig(
+                num_merges=10,
+                encoded_data_path="encoded.npz",
+                vocab_path="vocab.pkl",
+                overwrite_encoded_data=False,
+                overwrite_vocabulary_file=False,
+                start_token="<SOS>",
+                split_token="<|endoftext|>",
+                n_workers=0,
+            )
+
     def test_rejects_non_positive_max_grad_norm(self):
         with self.assertRaisesRegex(ValueError, "max_grad_norm must be > 0"):
             TransformerTrainingConfig(

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -4,6 +4,8 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+
 from autograd.backend import xp
 from autograd.data.collator import FixedLengthCausalLMCollator
 from autograd.data.data_loader import DataLoader
@@ -348,10 +350,10 @@ class TestSimpleTrainer(BaseTrainerTest):
         # 2 epochs * 2 train batches = 4 steps
         self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
-    def test_compute_loss_returns_tensor(self):
-        """Check that compute_loss returns the expected scalar Tensor."""
+    def test_forward_and_loss_returns_tensor(self):
+        """Check that _forward_and_loss returns the expected scalar Tensor."""
         batch = next(iter(self.train_data))
-        loss = self.trainer._compute_loss(batch)
+        loss = self.trainer._forward_and_loss(batch)
         self.assertAlmostEqual(float(loss.item()), 1.23, places=5)
 
     def test_save_metrics_persists_none_as_nan(self):
@@ -559,12 +561,12 @@ class TestSimpleTrainer(BaseTrainerTest):
         self.assertEqual(item_call_count, 0)
 
     @patch("autograd.tools.trainer.tqdm")
-    def test_fit_logs_fit_plan_before_first_compute_loss(self, mock_tqdm):
+    def test_fit_logs_fit_plan_before_first_forward_and_loss(self, mock_tqdm):
         self.config.max_epochs = None
         self.config.max_steps = 3
         self.config.checkpoint_freq = 10
         mock_tqdm.return_value = FakeTqdm()
-        self.trainer._compute_loss = MagicMock(side_effect=RuntimeError("boom"))
+        self.trainer._forward_and_loss = MagicMock(side_effect=RuntimeError("boom"))
 
         with self.assertLogs("autograd.tools.trainer", level="INFO") as captured:
             with self.assertRaisesRegex(RuntimeError, "boom"):
@@ -1840,10 +1842,10 @@ class TestLLMTrainer(BaseTrainerTest):
 
         return float(xp.to_scalar(trainer.model.parameters["weight"].data[0]))
 
-    def test_compute_loss_returns_tensor(self):
-        """Check that compute_loss returns the constant scalar Tensor."""
+    def test_forward_and_loss_returns_tensor(self):
+        """Check that _forward_and_loss returns the constant scalar Tensor."""
         batch = next(iter(self.train_data))
-        loss = self.trainer._compute_loss(batch)
+        loss = self.trainer._forward_and_loss(batch)
         self.assertAlmostEqual(float(loss.item()), 24.6, places=5)
 
     def test_evaluate_runs_eval_callbacks_and_returns_val_loss(self):
@@ -1887,13 +1889,13 @@ class TestLLMTrainer(BaseTrainerTest):
         self.config.label_smoothing = 0.1
         batch = next(iter(self.train_data))
 
-        self.trainer._compute_loss(batch)
+        self.trainer._forward_and_loss(batch)
         self.trainer.evaluate(self.val_loader)
 
         self.assertEqual(self.loss_fn.call_args_list[0].kwargs["label_smoothing"], 0.1)
         self.assertEqual(self.loss_fn.call_args_list[1].kwargs["label_smoothing"], 0.0)
 
-    def test_compute_loss_supports_prompt_masked_causal_lm_batches(self):
+    def test_forward_and_loss_supports_prompt_masked_causal_lm_batches(self):
         bpe = MockBPE()
         pad_idx = bpe.encode("<PAD>", allowed_special={"<PAD>"})[0]
         loader = DataLoader(
@@ -1902,7 +1904,7 @@ class TestLLMTrainer(BaseTrainerTest):
                 [xp.array([0, 0, 0, 0, 1, 1, 1], dtype=xp.int32)],
                 input_key="tokens",
                 target_key="loss_mask",
-                dtype=xp.int32,
+                dtype=np.int32,
             ),
             batch_size=1,
             collator=FixedLengthCausalLMCollator(
@@ -1940,7 +1942,7 @@ class TestLLMTrainer(BaseTrainerTest):
             label_smoothing=0.0,
         )
 
-        train_loss = trainer._compute_loss(batch)
+        train_loss = trainer._forward_and_loss(batch)
         eval_state = trainer.evaluate(loader)
         row = trainer._metrics_row(TrainingState(), eval_state=eval_state)
 

--- a/test/test_grpo.py
+++ b/test/test_grpo.py
@@ -459,7 +459,7 @@ def test_grpo_trainer_train_step_runs_one_optimizer_step():
             self.total_weight = xp.array(4.0, dtype=xp.float32)
             self.optimizer_step_called = False
 
-        def _compute_loss(self, batch):
+        def _forward_and_loss(self, batch):
             return self.loss
 
         def _loss_total_weight(self, batch):


### PR DESCRIPTION
## Description

1. Move the general data loading to a streaming/mmap-friendly flow.
   - `BytePairEncoder` can train from an iterable of documents instead of requiring one giant string
   - Encoded causal-LM token data is written as `.npy` and can be loaded with `mmap_mode="r"`
   - GPT-2 examples can reuse cached `.npy` token data without fetching or re-tokenizing raw text
   - This opens up the possibility to train with OpenWebText 38GB+ on my local Mac by streaming into memory instead of loading it all at once into memory

2. Move dataset/collator boundaries toward numpy data until batch emission.
   - Datasets and collators do slicing/padding/windowing in numpy
   - The key boundary is `collator` is responsible for converting numpy mmapped arrays into backend-device-specific `xp.array()` batches
   - Update SFT and GRPO batch paths to follow the same numpy data boundary.
     - SFT variable-length prompt/loss-mask examples go through dynamic batch padding.
     - GRPO rollout batches keep generated-token masks and advantages as batch data owned by the collator/
trainer boundary.

3. Add document-boundary handling for causal-LM tokenization.
   - Examples now wrap training documents with `<SOS>` and `<|endoftext|>` consistently.
   - This avoids merging unrelated documents together in the token stream.
   - The tokenizer will need to be re-trained with the new vocabulary for lossless tokenization
   - This is also a prerequisite for proper SFT post-training. Previously, we're just using arbitrary "User: " and "Assistant: " string templates


## Tests

Updated unit tests.


## Performance Comparison

**Tokenizer benchmark**

Synthetic local corpus, same input on main and this branch.

| Case | `main` | This branch |
|---|---|---|
| Tokenizer training wall time | 0.0309s | 0.0116s |
| Tokenizer training docs/sec | 19.4k | 51.7k |
| Encode/write wall time | 0.1008s | 0.0609s |
| Encode/write tokens/sec | 89.3k | 147.8k |
| Peak RSS in combined benchmark | 85.9 MB | 63.5 MB |

**DataLoader benchmark**

Synthetic token stream, `TokenWindowMapDataset` + `CausalLMWindowCollator`.

| Case | Result |
|---|---|
| in-memory (`main` branch) sequential | 31.7M tokens/sec |
| in-memory (`main` branch) random replacement | 29.5M tokens/sec |
| memmap sequential | 32.3M tokens/sec |
| memmap random replacement | 29.5M tokens/sec |

Correctness checks:
- batch input/label shift correctness: true
- loss_total_weight correctness: true
