### PR TITLE
Distributed training

### DIFF
--- a/autograd/backend.py
+++ b/autograd/backend.py
@@ -491,3 +491,7 @@ _backend_random.randint = _sample_randint
 _backend_random.bernoulli = _sample_bernoulli
 _backend_random.permutation = _sample_permutation
 _backend_random.categorical = _sample_categorical_with_options
+
+_seed_from_env = os.environ.get("SEED")
+if _seed_from_env is not None:
+    _seed_backend_random(int(_seed_from_env))

--- a/autograd/backend.py
+++ b/autograd/backend.py
@@ -65,26 +65,69 @@ if IS_CUPY and xp.cuda.runtime.getDeviceCount() <= 0:
         "AUTOGRAD_BACKEND=cupy requested, but no CUDA device was detected"
     )
 
+# Pin this process to GPU `LOCAL_RANK` for DDP. The launcher
+# (`python -m autograd.distributed.launch`) sets `LOCAL_RANK=r` for the r-th
+# child; non-DDP runs see the default `0` and `.use()` is a no-op on the
+# already-default device. Must happen *before* any CuPy allocation lands —
+# `xp.array(0, …)` below would otherwise create the first allocation on
+# device 0 and route every later op there.
+if IS_CUPY:
+    xp.cuda.Device(int(os.environ.get("LOCAL_RANK", "0"))).use()
+
 ARRAY_TYPE = type(xp.array(0, dtype=xp.float32)) if IS_MLX else xp.ndarray
 
 
-def _low_precision_float_dtypes() -> tuple[Any, ...]:
-    dtypes = [
-        getattr(xp, "float16", None),
-        getattr(xp, "bfloat16", None),
-    ]
-    if IS_CUPY:
-        try:
-            ml_dtypes = importlib.import_module("ml_dtypes")
-        except ModuleNotFoundError:
-            pass
-        else:
-            dtypes.append(getattr(ml_dtypes, "bfloat16", None))
+# ---------------------------------------------------------------------------
+# Dtype contract
+# ---------------------------------------------------------------------------
+#
+# Every backend in this repo exposes the same dtype names — `xp.float16`,
+# `xp.bfloat16`, `xp.float32`, etc. Downstream code (model post-init cast
+# loops, low-precision detection, Adam's fp32 promotion path, the bf16
+# trainer gate) can then just ask `xp` for the dtype by name and never
+# branch on which backend is in use.
+#
+# MLX has bf16 natively. NumPy doesn't. CuPy 14.x doesn't expose
+# `cupy.bfloat16` at the Python level either — its bf16 storage path
+# lives entirely in `ml_dtypes`. We close that gap once, here, by
+# polyfilling `xp.bfloat16 = ml_dtypes.bfloat16` when `xp` is missing it.
+#
+# Upstream: native `cupy.bfloat16` lands in cupy 15.0.0a1+ (cupy/cupy#9494,
+# merged Feb 2026). When that ships, the `hasattr` guard makes this
+# polyfill a no-op automatically.
 
-    return tuple(dict.fromkeys(dtype for dtype in dtypes if dtype is not None))
+if not hasattr(xp, "bfloat16"):
+    try:
+        ml_dtypes = importlib.import_module("ml_dtypes")
+    except ModuleNotFoundError:
+        # `ml_dtypes` is optional. Scripts that don't ask for bf16 keep
+        # working; `resolve_dtype` below raises with an actionable hint
+        # if anyone does request it.
+        pass
+    else:
+        xp.bfloat16 = ml_dtypes.bfloat16
 
 
-LOW_PRECISION_FLOAT_DTYPES = _low_precision_float_dtypes()
+LOW_PRECISION_FLOAT_DTYPES = tuple(
+    getattr(xp, name) for name in ("float16", "bfloat16") if hasattr(xp, name)
+)
+
+
+def resolve_dtype(dtype: str) -> Any:
+    """Map a dtype-name string (e.g. "float32", "bfloat16") to the backend's
+    dtype object. Uniform across numpy / CuPy / MLX thanks to the bf16
+    polyfill above; raises with an actionable hint if the dtype is
+    unreachable on this backend.
+    """
+    resolved = getattr(xp, dtype, None)
+    if resolved is not None:
+        return resolved
+    hint = (
+        " Install `ml_dtypes` to enable bf16 on numpy/CuPy."
+        if dtype == "bfloat16"
+        else ""
+    )
+    raise RuntimeError(f"Backend {NAME!r} does not expose dtype {dtype!r}.{hint}")
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +180,15 @@ def _scatter_add(dst: Any, idx: Any, updates: Any):
     if IS_MLX:
         return dst.at[idx].add(updates)
     out = xp.array(dst)
+    if out.dtype in LOW_PRECISION_FLOAT_DTYPES:
+        # CuPy's `xp.add.at` has no low-precision specialization: the
+        # in-place ufunc dispatch table doesn't cover bf16/fp16, so it
+        # raises TypeError on those dtypes. Same fp32-promotion pattern
+        # used in `allreduce_grads` / `broadcast_parameters` — promote
+        # both buffers, scatter in fp32, cast the result back.
+        out_fp32 = out.astype(xp.float32)
+        xp.add.at(out_fp32, idx, updates.astype(xp.float32))
+        return out_fp32.astype(out.dtype)
     xp.add.at(out, idx, updates)
     return out
 

--- a/autograd/backend.py
+++ b/autograd/backend.py
@@ -379,7 +379,7 @@ def _sample_categorical(logits: Any):
     choice = _native_random_fns.get("choice")
     if choice is None:
         raise RuntimeError(f"categorical sampling is not available on backend {NAME}")
-    return choice(probs.shape[-1], p=probs)
+    return choice(probs.shape[-1], size=(), p=probs)
 
 
 def _sample_categorical_with_options(

--- a/autograd/backend.py
+++ b/autograd/backend.py
@@ -130,6 +130,35 @@ def resolve_dtype(dtype: str) -> Any:
     raise RuntimeError(f"Backend {NAME!r} does not expose dtype {dtype!r}.{hint}")
 
 
+def check_bf16_capability(parameter_dtype: str | None) -> None:
+    """Hard-fail if CuPy bf16 is requested on pre-Ampere hardware."""
+    if parameter_dtype != "bfloat16" or not IS_CUPY:
+        return
+
+    device = xp.cuda.Device()
+    cc_str = device.compute_capability
+    name = (
+        device.attributes.get("Name", "<unknown>")
+        if hasattr(device, "attributes")
+        else "<unknown>"
+    )
+    try:
+        major = int(cc_str[:-1])
+        minor = int(cc_str[-1])
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"Failed to parse compute capability {cc_str!r} from cupy device."
+        ) from exc
+
+    if (major, minor) < (8, 0):
+        raise RuntimeError(
+            'parameter_dtype="bfloat16" requires CUDA compute capability >= 8.0 '
+            f"(Ampere or newer). Detected device: {name}, compute capability "
+            f"{major}.{minor}. Either run on Ampere/Hopper hardware, or change "
+            'parameter_dtype to "float32" in the training config.'
+        )
+
+
 # ---------------------------------------------------------------------------
 # Compatibility helpers used across the repo
 # ---------------------------------------------------------------------------

--- a/autograd/data/sampler.py
+++ b/autograd/data/sampler.py
@@ -107,6 +107,122 @@ class RandomSampler(Sampler):
         return self.num_samples
 
 
+class DistributedSamplerAdapter(Sampler):
+    """
+    Wraps a Sampler so each rank sees a disjoint slice of its indices.
+
+    Two strategies, picked from the wrapped sampler's semantics:
+
+    1. With-replacement (e.g. `RandomSampler(replacement=True)`): each rank
+       draws independent indices from `range(len(dataset))` using an RNG
+       seeded by `(seed, epoch, rank)`. No cross-rank coordination needed;
+       per-rank `num_samples = global // world_size`.
+
+    2. Without-replacement / sequential: the wrapped sampler is iterated to
+       exhaustion to materialize the global permutation, padded to a length
+       divisible by `world_size`, then strided so rank *r* sees positions
+       `r, r + world_size, r + 2*world_size, ...`. Disjoint, full coverage,
+       deterministic per `(seed, epoch)`.
+
+    The "is replacement?" probe reads `sampler.replacement` (set by
+    `RandomSampler`). Sampler classes without that attribute are treated
+    as without-replacement.
+
+    Args:
+        sampler: The base Sampler whose index stream should be sharded.
+        rank: This rank's id, in `[0, world_size)`.
+        world_size: Total number of ranks participating.
+        seed: Base RNG seed shared across ranks; per-rank streams mix in
+            `epoch` and `rank` on top of this.
+
+    Examples:
+        Opt-in at the script level so DataLoader stays DDP-agnostic.
+
+        >>> from autograd.distributed import is_distributed, rank, world_size
+        >>> sampler = RandomSampler(
+        ...     dataset, replacement=True, num_samples=len(dataset)
+        ... )
+        >>> if is_distributed():
+        ...     sampler = DistributedSamplerAdapter(
+        ...         sampler, rank=rank(), world_size=world_size()
+        ...     )
+        >>> loader = DataLoader(dataset, batch_size=32, sampler=sampler)
+    """
+
+    def __init__(
+        self,
+        sampler: Sampler,
+        *,
+        rank: int,
+        world_size: int,
+        seed: int = 0,
+    ) -> None:
+        if world_size < 1:
+            raise ValueError(f"world_size must be >= 1, got {world_size}")
+        if not (0 <= rank < world_size):
+            raise ValueError(f"rank must be in [0, {world_size}), got {rank}")
+
+        self._sampler = sampler
+        self._rank = rank
+        self._world_size = world_size
+        self._seed = int(seed)
+        self._epoch = 0
+        self._with_replacement = bool(getattr(sampler, "replacement", False))
+
+        global_samples = len(sampler)
+        if self._with_replacement:
+            self._per_rank_samples = global_samples // world_size
+        else:
+            self._per_rank_samples = (global_samples + world_size - 1) // world_size
+
+        self._indices: list[int] = []
+        self._refresh_indices()
+
+    def _refresh_indices(self) -> None:
+        if self._with_replacement:
+            dataset = getattr(self._sampler, "dataset", None)
+            if dataset is None:
+                raise RuntimeError(
+                    "DistributedSamplerAdapter requires `sampler.dataset` "
+                    "for with-replacement sampling so it can sample from "
+                    "the full index range."
+                )
+            n = len(dataset)
+            # Mix (seed, epoch, rank) into a single 64-bit seed. Naive
+            # tuple hashing in some RNGs only uses the first element,
+            # which would correlate streams across ranks.
+            h = 0
+            for s in (self._seed, self._epoch, self._rank):
+                h = (h * 1_000_003 + int(s)) & 0xFFFF_FFFF_FFFF_FFFF
+            rng = np.random.default_rng(h)
+            self._indices = rng.integers(0, n, size=self._per_rank_samples).tolist()
+            return
+
+        # Without-replacement: materialize global order, pad to multiple
+        # of world_size, then take every world_size-th index starting at
+        # `rank`.
+        full = list(iter(self._sampler))
+        target = self._per_rank_samples * self._world_size
+        if len(full) < target:
+            full = full + full[: target - len(full)]
+        elif len(full) > target:
+            full = full[:target]
+        self._indices = full[self._rank :: self._world_size]
+
+    def on_epoch_start(self) -> None:
+        self._epoch += 1
+        # Forward to the wrapped sampler so its internal RNG advances
+        # (e.g. RandomSampler reshuffles its without-replacement permutation).
+        self._sampler.on_epoch_start()
+        self._refresh_indices()
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self._indices)
+
+    def __len__(self) -> int:
+        return len(self._indices)
+
+
 class TokenLengthGroupedRandomSampler(Sampler):
     """
     Yields indices so nearby examples have similar lengths.

--- a/autograd/distributed.py
+++ b/autograd/distributed.py
@@ -1,0 +1,357 @@
+"""
+Single-node multi-GPU data-parallel training surface.
+
+Everything DDP-related lives here so a reader can absorb the whole story
+in one file. The structure of the module reads top to bottom:
+
+1. Env-derived rank/world_size and thread-local overrides (test path).
+2. Public API: rank(), world_size(), is_distributed(), barrier().
+3. Backend protocol + lifecycle (`_make_backend` is the Phase 2 NCCL hook).
+4. Collective operations on parameters: `allreduce_grads`,
+   `broadcast_parameters`. These are the only DDP touchpoints that the
+   optimizer needs.
+5. bf16 hardware gate (`check_bf16_capability`).
+
+When `WORLD_SIZE` is absent or `1`, `is_distributed()` returns False and
+every DDP code path no-ops, so the single-node training path is
+bit-identical to the pre-DDP code.
+
+The thread-based test mock lives at `test/distributed/mock.py` — it
+installs per-thread backends via the `_set_thread_local_rank` /
+`_clear_thread_local` helpers below and never flows through the
+process-wide backend singleton.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import threading
+from typing import Any, Mapping, Protocol
+
+from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, xp
+from autograd.tensor import Tensor
+
+# --- env-derived process-wide defaults ---------------------------------------
+#
+# Read once at import. The launcher (Phase 2 `autograd.distributed.launch`)
+# sets WORLD_SIZE/RANK/LOCAL_RANK before the user script imports anything.
+
+_env_world_size = int(os.environ.get("WORLD_SIZE", "1"))
+_env_rank = int(os.environ.get("RANK", "0"))
+_env_local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+
+
+# --- thread-local overrides used by the test mock ----------------------------
+#
+# When tests spawn N threads to emulate N ranks in one Python process, each
+# thread sets thread-local rank/world_size/backend via `_set_thread_local_rank`
+# (called from `test/distributed/mock.py`). The accessors below prefer
+# thread-local values when present.
+#
+# TODO(phase-2-cleanup): once real NCCL is wired in `_make_backend`, the
+# multi-rank tests can spawn real processes via the launcher and we can drop:
+#   - this `_thread_local` block
+#   - the `_tls_get` branches in rank()/world_size()/local_rank()/get_backend()
+#   - `_set_thread_local_rank` / `_clear_thread_local`
+#   - `test/distributed/mock.py` entirely
+# That removes ~25 lines from this module and the whole mock infrastructure.
+
+_thread_local = threading.local()
+
+
+def _tls_get(name: str, default: Any) -> Any:
+    return getattr(_thread_local, name, default)
+
+
+# --- public rank/world API ---------------------------------------------------
+
+
+def world_size() -> int:
+    """World size for the current rank (thread-local override beats env)."""
+    return _tls_get("world_size", _env_world_size)
+
+
+def rank() -> int:
+    """Global rank of the caller (thread-local override beats env)."""
+    return _tls_get("rank", _env_rank)
+
+
+def local_rank() -> int:
+    """Local rank of the caller within its node."""
+    return _tls_get("local_rank", _env_local_rank)
+
+
+def is_distributed() -> bool:
+    """True when more than one rank is participating in this comm group."""
+    return world_size() > 1
+
+
+# --- backend protocol --------------------------------------------------------
+
+
+class ReduceOp:
+    """Op tags accepted by `Backend.all_reduce`. String tags keep the test
+    mock serializable and avoid a dependency on a backend-specific enum."""
+
+    SUM = "sum"
+
+
+class Backend(Protocol):
+    """Minimum collective surface needed by autograd's DDP path.
+
+    Real implementation (Phase 2) wraps `cupyx.distributed.NCCLBackend`.
+    Test implementation lives at `test/distributed/mock.py`.
+    """
+
+    @property
+    def world_size(self) -> int: ...
+
+    @property
+    def rank(self) -> int: ...
+
+    def all_reduce(self, buf: Any, op: str = ReduceOp.SUM) -> Any: ...
+
+    def broadcast(self, buf: Any, from_rank: int) -> Any: ...
+
+    def barrier(self) -> None: ...
+
+    def teardown(self) -> None: ...
+
+
+# --- backend lifecycle -------------------------------------------------------
+#
+# Two lookup paths share `get_backend()`:
+#
+# 1. Thread-local backend (test mock): per-thread, set by `_set_thread_local_rank`.
+# 2. Process-wide backend (real NCCL): lazy singleton, one per process.
+
+_process_backend: Backend | None = None
+_init_lock = threading.Lock()
+
+
+def init_process_group() -> Backend | None:
+    """Eagerly initialize the process-wide backend (idempotent).
+
+    Returns the backend, or None when not running distributed. Most callers
+    use `get_backend()` (lazy) instead; this exists for tests/launchers that
+    want to control init timing.
+    """
+    return _process_backend_singleton()
+
+
+def get_backend() -> Backend:
+    """Return the backend bound to the calling thread.
+
+    Looks up the thread-local backend first (mock path), then the process
+    singleton (real NCCL path). Raises if not running distributed.
+    """
+    tls_backend = _tls_get("backend", None)
+    if tls_backend is not None:
+        return tls_backend
+
+    backend = _process_backend_singleton()
+    if backend is None:
+        raise RuntimeError(
+            "get_backend() called but no comm group is initialized "
+            "(world_size=1). Guard with is_distributed() before calling."
+        )
+    return backend
+
+
+def _process_backend_singleton() -> Backend | None:
+    """Lazy, double-checked init of the process-wide backend."""
+    global _process_backend
+    if _process_backend is not None:
+        return _process_backend
+    if not is_distributed():
+        return None
+    with _init_lock:
+        if _process_backend is None:
+            _process_backend = _make_backend()
+            atexit.register(_safe_teardown)
+    return _process_backend
+
+
+def _make_backend() -> Backend:
+    """Construct the process-wide backend.
+
+    Wired in Phase 2 — this raises until the NCCL backend
+    (`cupyx.distributed.NCCLBackend`) is plugged in.
+
+    TODO(phase-2): replace the body with the NCCLBackend construction.
+    Once this returns a real backend, the thread-local mock plumbing
+    above (see the TODO at `_thread_local`) becomes the only remaining
+    test path and is itself slated for removal.
+    """
+    raise NotImplementedError(
+        "Real NCCL backend is deferred to Phase 2 (autograd.distributed.launch + "
+        "cupyx.distributed.NCCLBackend wiring)."
+    )
+
+
+def _safe_teardown() -> None:
+    global _process_backend
+    if _process_backend is not None:
+        try:
+            _process_backend.teardown()
+        finally:
+            _process_backend = None
+
+
+def teardown() -> None:
+    """Tear down the process-wide backend. Idempotent."""
+    _safe_teardown()
+
+
+def barrier() -> None:
+    """Process-wide synchronization. No-op when not distributed."""
+    if not is_distributed():
+        return
+    get_backend().barrier()
+
+
+# --- thread-local helpers (test-mock plug point) -----------------------------
+
+
+def _set_thread_local_rank(
+    *,
+    rank_: int,
+    world_size_: int,
+    local_rank_: int,
+    backend: Backend,
+) -> None:
+    """Internal: install per-thread rank/world_size/backend.
+
+    Called by `test/distributed/mock.py::run_mock_ranks` for each spawned
+    rank-thread. Not intended for user code.
+    """
+    _thread_local.rank = rank_
+    _thread_local.world_size = world_size_
+    _thread_local.local_rank = local_rank_
+    _thread_local.backend = backend
+
+
+def _clear_thread_local() -> None:
+    """Internal: wipe thread-local state after a mock rank-thread exits."""
+    for name in ("rank", "world_size", "local_rank", "backend"):
+        if hasattr(_thread_local, name):
+            delattr(_thread_local, name)
+
+
+# --- collective ops on model parameters --------------------------------------
+#
+# These are the only DDP touchpoints the optimizer needs. Both self-no-op
+# when world_size==1, so callers can invoke them unconditionally — no
+# `is_distributed()` guards required at the call site.
+
+
+def allreduce_grads(parameters: Mapping[str, Tensor]) -> None:
+    """AllReduce-mean every accumulated gradient across ranks.
+
+    Result is mathematically equivalent to one forward+backward over the
+    concatenated global batch (world_size * per_rank_batch rows).
+
+    For low-precision gradients the reduction is performed in fp32: bf16's
+    8-bit mantissa loses up to log2(N) bits per N-way sum, so reducing in
+    bf16 would silently degrade gradient quality as world_size grows. The
+    fp32 result is cast back to the original gradient dtype before being
+    written back to `param.grad.data`.
+
+    No-op when `world_size == 1`.
+    """
+    if not is_distributed():
+        return
+
+    backend = get_backend()
+    n_ranks = world_size()
+
+    for param in parameters.values():
+        if param.grad is None:
+            continue
+        grad = param.grad.data
+        if grad.dtype in LOW_PRECISION_FLOAT_DTYPES:
+            g32 = grad.astype(xp.float32)
+            summed = backend.all_reduce(g32, op=ReduceOp.SUM)
+            averaged = summed / n_ranks
+            param.grad.data = averaged.astype(grad.dtype)
+        else:
+            summed = backend.all_reduce(grad, op=ReduceOp.SUM)
+            param.grad.data = summed / n_ranks
+
+
+def broadcast_parameters(
+    parameters: Mapping[str, Tensor],
+    *,
+    from_rank: int = 0,
+) -> None:
+    """Broadcast every parameter buffer from `from_rank` to all ranks.
+
+    Belt-and-suspenders for the determinism story: even with a shared SEED
+    every rank already constructs identical params under deterministic
+    init, but platform-level non-determinism can drift them apart. One
+    broadcast at startup eliminates that risk for a negligible one-time cost.
+
+    No-op when `world_size == 1`.
+    """
+    if not is_distributed():
+        return
+
+    backend = get_backend()
+    for param in parameters.values():
+        param.data = backend.broadcast(param.data, from_rank=from_rank)
+
+
+# --- bf16 hardware gate ------------------------------------------------------
+#
+# bf16 on CuPy requires CUDA compute capability >= 8.0 (Ampere). Lower-cc
+# devices either don't expose `cupy.bfloat16` or fall back to software bf16
+# emulation with surprise-slow kernels. We hard-fail with an actionable
+# message instead.
+
+
+def check_bf16_capability(parameter_dtype: str) -> None:
+    """Hard-fail if `parameter_dtype == 'bfloat16'` on incompatible hardware.
+
+    Runs unconditionally on CuPy (single-GPU and DDP). MLX has its own bf16
+    path; numpy has no bf16 dtype. For non-CuPy backends, this is a no-op.
+    """
+    if parameter_dtype != "bfloat16":
+        return
+
+    # Look these up at call time (not import time) so test monkey-patches
+    # of `autograd.backend.{IS_CUPY,xp}` take effect.
+    from autograd.backend import IS_CUPY, xp
+
+    if not IS_CUPY:
+        return
+
+    if not hasattr(xp, "bfloat16"):
+        raise RuntimeError(
+            'parameter_dtype="bfloat16" requires cupy.bfloat16, but the '
+            "installed CuPy version does not expose it. Upgrade CuPy or "
+            'change parameter_dtype to "float32" in the training config.'
+        )
+
+    device = xp.cuda.Device()
+    cc_str = device.compute_capability
+    name = (
+        device.attributes.get("Name", "<unknown>")
+        if hasattr(device, "attributes")
+        else "<unknown>"
+    )
+    try:
+        major = int(cc_str[:-1])
+        minor = int(cc_str[-1])
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"Failed to parse compute capability {cc_str!r} from cupy device."
+        ) from exc
+
+    if (major, minor) < (8, 0):
+        raise RuntimeError(
+            'parameter_dtype="bfloat16" requires CUDA compute capability >= 8.0 '
+            f"(Ampere or newer). Detected device: {name}, compute capability "
+            f"{major}.{minor}. Either run on Ampere/Hopper hardware, or change "
+            'parameter_dtype to "float32" in the training config.'
+        )

--- a/autograd/distributed/__init__.py
+++ b/autograd/distributed/__init__.py
@@ -6,7 +6,7 @@ in one file. The structure of the module reads top to bottom:
 
 1. Env-derived rank/world_size and thread-local overrides (test path).
 2. Public API: rank(), world_size(), is_distributed(), barrier().
-3. Backend protocol + lifecycle (`_make_backend` is the Phase 2 NCCL hook).
+3. Backend protocol + lifecycle (`_NCCLBackend` wraps `cupyx.distributed`).
 4. Collective operations on parameters: `allreduce_grads`,
    `broadcast_parameters`. These are the only DDP touchpoints that the
    optimizer needs.
@@ -173,20 +173,88 @@ def _process_backend_singleton() -> Backend | None:
     return _process_backend
 
 
-def _make_backend() -> Backend:
-    """Construct the process-wide backend.
+class _NCCLBackend:
+    """Real NCCL-backed collective ops for single-node multi-GPU DDP.
 
-    Wired in Phase 2 — this raises until the NCCL backend
-    (`cupyx.distributed.NCCLBackend`) is plugged in.
+    Adapts `cupyx.distributed.NCCLBackend` to the `Backend` protocol:
 
-    TODO(phase-2): replace the body with the NCCLBackend construction.
-    Once this returns a real backend, the thread-local mock plumbing
-    above (see the TODO at `_thread_local`) becomes the only remaining
-    test path and is itself slated for removal.
+    - `all_reduce`: NCCL takes separate (in_array, out_array). We allocate
+      `out_array` here and return it so callers can rebind. Allocation is
+      tiny relative to the reduction itself.
+    - `broadcast`: NCCL is in-place via `root`. We return the same buffer
+      so callers can use the result uniformly (in-place or not).
+
+    Rendezvous works like PyTorch's: rank 0 binds a TCP server on
+    `host:port`, the others connect, and they exchange the NCCL unique id.
+    The launcher (`autograd.distributed.launch`) picks the port and
+    propagates it via the `MASTER_PORT` env var.
     """
-    raise NotImplementedError(
-        "Real NCCL backend is deferred to Phase 2 (autograd.distributed.launch + "
-        "cupyx.distributed.NCCLBackend wiring)."
+
+    def __init__(self, world_size: int, rank: int, host: str, port: int) -> None:
+        # Imported here (not at module top) so the file stays importable on
+        # MLX / numpy and on CuPy boxes without NCCL. _make_backend() only
+        # runs when WORLD_SIZE > 1, which is gated by the launcher.
+        from cupyx.distributed import NCCLBackend as _CupyxNCCL
+
+        self._world_size = world_size
+        self._rank = rank
+        # Constructor blocks: rank 0 listens, others connect. All ranks
+        # must reach this line within NCCL's bootstrap timeout.
+        self._comm = _CupyxNCCL(world_size, rank, host=host, port=port)
+
+    @property
+    def world_size(self) -> int:
+        return self._world_size
+
+    @property
+    def rank(self) -> int:
+        return self._rank
+
+    def all_reduce(self, buf: Any, op: str = ReduceOp.SUM) -> Any:
+        if op != ReduceOp.SUM:
+            raise NotImplementedError(
+                f"NCCL backend currently only implements SUM; got {op!r}"
+            )
+        import cupy as cp
+
+        out = cp.empty_like(buf)
+        self._comm.all_reduce(buf, out, op="sum")
+        return out
+
+    def broadcast(self, buf: Any, from_rank: int) -> Any:
+        # NCCL broadcast mutates the buffer in place on every rank; the
+        # root's contents win. We return `buf` so the call site uses the
+        # same rebind pattern as `all_reduce`.
+        self._comm.broadcast(buf, root=from_rank)
+        return buf
+
+    def barrier(self) -> None:
+        self._comm.barrier()
+
+    def teardown(self) -> None:
+        self._comm.stop()
+
+
+def _make_backend() -> Backend:
+    """Construct the process-wide NCCL backend.
+
+    Expects the launcher to have set MASTER_ADDR + MASTER_PORT in env. The
+    error message guides the user to the launcher when those are missing —
+    invoking a script directly with WORLD_SIZE manually set is unsupported.
+    """
+    host = os.environ.get("MASTER_ADDR", "127.0.0.1")
+    port_str = os.environ.get("MASTER_PORT")
+    if not port_str:
+        raise RuntimeError(
+            "MASTER_PORT must be set when running distributed. Use the "
+            "launcher: python -m autograd.distributed.launch "
+            "--nproc-per-node=N script.py"
+        )
+    return _NCCLBackend(
+        world_size=world_size(),
+        rank=rank(),
+        host=host,
+        port=int(port_str),
     )
 
 

--- a/autograd/distributed/__init__.py
+++ b/autograd/distributed/__init__.py
@@ -8,9 +8,10 @@ in one file. The structure of the module reads top to bottom:
 2. Public API: rank(), world_size(), is_distributed(), barrier().
 3. Backend protocol + lifecycle (`_NCCLBackend` wraps `cupyx.distributed`).
 4. Collective operations on parameters: `allreduce_grads`,
-   `broadcast_parameters`. These are the only DDP touchpoints that the
-   optimizer needs.
-5. bf16 hardware gate (`check_bf16_capability`).
+   `broadcast_parameters`, `broadcast_optimizer_state`. The first two are
+   the only DDP touchpoints the optimizer's own code needs; the third is
+   called by the trainer after a checkpoint resume to sync loaded optimizer
+   state from rank 0.
 
 When `WORLD_SIZE` is absent or `1`, `is_distributed()` returns False and
 every DDP code path no-ops, so the single-node training path is
@@ -226,10 +227,7 @@ class _NCCLBackend:
         # root's contents win. We return `buf` so the call site uses the
         # same rebind pattern as `all_reduce`.
         #
-        # Callers must hand us a dtype cupyx's NCCL wrapper recognises
-        # (fp16/fp32/fp64 + int variants). bf16 in particular is rejected
-        # here — see `broadcast_parameters` for the workaround and the
-        # cupyx-dtype-gap explanation.
+        # Callers must hand cupyx a dtype its NCCL wrapper recognizes.
         self._comm.broadcast(buf, root=from_rank)
         return buf
 
@@ -353,6 +351,25 @@ def allreduce_grads(parameters: Mapping[str, Tensor]) -> None:
             param.grad.data = summed / n_ranks
 
 
+def _broadcast_array(
+    arr: Any,
+    *,
+    backend: Backend,
+    from_rank: int,
+) -> Any:
+    """Broadcast an array, promoting low-precision floats for NCCL support.
+
+    cupyx.distributed rejects ml_dtypes bf16 arrays
+    (`TypeError: Unknown dtype bfloat16 for NCCL`), so low-precision arrays
+    are broadcast as fp32 and cast back.
+    """
+    if arr.dtype in LOW_PRECISION_FLOAT_DTYPES:
+        a32 = arr.astype(xp.float32)
+        a32 = backend.broadcast(a32, from_rank=from_rank)
+        return a32.astype(arr.dtype)
+    return backend.broadcast(arr, from_rank=from_rank)
+
+
 def broadcast_parameters(
     parameters: Mapping[str, Tensor],
     *,
@@ -360,16 +377,8 @@ def broadcast_parameters(
 ) -> None:
     """Broadcast every parameter buffer from `from_rank` to all ranks.
 
-    Belt-and-suspenders for the determinism story: even with a shared SEED
-    every rank already constructs identical params under deterministic
-    init, but platform-level non-determinism can drift them apart. One
-    broadcast at startup eliminates that risk for a negligible one-time cost.
-
-    Low-precision (bf16) params are promoted to fp32 before the broadcast
-    and cast back afterwards. The reason is *not* numerical — broadcast is
-    a byte copy and bf16 round-trips losslessly — it's a cupyx plumbing
-    gap. See the inline comment at the promotion site for the upstream
-    issue trail.
+    Keeps all ranks' parameter tensors equal at startup and after checkpoint
+    loads.
 
     No-op when `world_size == 1`.
     """
@@ -378,95 +387,27 @@ def broadcast_parameters(
 
     backend = get_backend()
     for param in parameters.values():
-        data = param.data
-        if data.dtype in LOW_PRECISION_FLOAT_DTYPES:
-            # Why promote bf16 → fp32 before broadcast?
-            #
-            # cupyx.distributed wraps NCCL via a small dtype-char table
-            # at `cupyx.distributed._nccl_comm._nccl_dtypes` that maps
-            # numpy char codes → NCCL type IDs. As of cupy 14.0.1 (the
-            # latest stable, Feb 2026) that table has 'e' (numpy float16
-            # → NCCL_FLOAT16) but not 'E' — the char code used by
-            # `ml_dtypes.bfloat16`, which is cupy's bf16 storage path
-            # until native `cupy.bfloat16` lands at the Python level.
-            # Hand cupyx a bf16 array and it raises:
-            #     TypeError: Unknown dtype bfloat16 for NCCL
-            #
-            # Upstream tracking (as of this writing):
-            #   * cupy/cupy#7527 — bf16 umbrella issue (closed Feb 2026)
-            #   * cupy/cupy#9494 — implementation PR (merged Feb 2026,
-            #     targets v15.0.0a1+); ships internal bf16 type handling
-            #     built on ml_dtypes, but does NOT expose `cupy.bfloat16`
-            #     and does NOT update cupyx.distributed
-            #   * cupy/cupy#9630 — open follow-ups for cupyx bf16 gaps;
-            #     `cupyx.distributed` is NOT on the list
-            #   * Searching `is:pr nccl bfloat16` in cupy/cupy returns
-            #     zero PRs (open or closed) — no scheduled upstream fix
-            #
-            # So we work around it locally. fp32 promotion is the natural
-            # fix because it mirrors the same promotion that already
-            # happens in `allreduce_grads` above — there for *numerical
-            # correctness* (bf16 accumulation loses mantissa bits as
-            # world_size grows); here it's *plumbing only* (broadcast
-            # is bit-exact regardless of dtype). One mental model, two
-            # motivations.
-            #
-            # Cost: this doubles the per-param broadcast volume (2 B → 4 B)
-            # at startup. For a 128M-param model that's a one-time
-            # 256 MB → 512 MB transfer over NCCL — negligible vs the
-            # multi-hour training run that follows.
-            d32 = data.astype(xp.float32)
-            d32 = backend.broadcast(d32, from_rank=from_rank)
-            param.data = d32.astype(data.dtype)
-        else:
-            param.data = backend.broadcast(data, from_rank=from_rank)
+        param.data = _broadcast_array(param.data, backend=backend, from_rank=from_rank)
 
 
-# --- bf16 hardware gate ------------------------------------------------------
-#
-# bf16 on CuPy requires CUDA compute capability >= 8.0 (Ampere). Pre-Ampere
-# silicon either has no bf16 path at all or falls back to software emulation
-# with surprise-slow kernels — silently slow training is worse than a hard
-# fail at startup. We do not separately gate dtype *availability* here:
-# `autograd.backend.resolve_dtype("bfloat16")` already raises a clear error
-# when neither `cupy.bfloat16` nor `ml_dtypes.bfloat16` is reachable.
+def broadcast_optimizer_state(
+    optimizer: Any,
+    *,
+    from_rank: int = 0,
+) -> None:
+    """Broadcast tensor-valued optimizer state from `from_rank`.
 
-
-def check_bf16_capability(parameter_dtype: str | None) -> None:
-    """Hard-fail if `parameter_dtype == 'bfloat16'` on pre-Ampere hardware.
-
-    Runs unconditionally on CuPy (single-GPU and DDP). MLX has its own bf16
-    path; numpy has no bf16 dtype. For non-CuPy backends, this is a no-op.
+    Used after checkpoint resume to make rank 0 authoritative for Adam
+    momenta too. Non-dict/scalar slots such as `timestep` are left alone.
     """
-    if parameter_dtype != "bfloat16":
+    if not is_distributed():
         return
 
-    # Look these up at call time (not import time) so test monkey-patches
-    # of `autograd.backend.{IS_CUPY,xp}` take effect.
-    from autograd.backend import IS_CUPY, xp
-
-    if not IS_CUPY:
-        return
-
-    device = xp.cuda.Device()
-    cc_str = device.compute_capability
-    name = (
-        device.attributes.get("Name", "<unknown>")
-        if hasattr(device, "attributes")
-        else "<unknown>"
-    )
-    try:
-        major = int(cc_str[:-1])
-        minor = int(cc_str[-1])
-    except (TypeError, ValueError) as exc:
-        raise RuntimeError(
-            f"Failed to parse compute capability {cc_str!r} from cupy device."
-        ) from exc
-
-    if (major, minor) < (8, 0):
-        raise RuntimeError(
-            'parameter_dtype="bfloat16" requires CUDA compute capability >= 8.0 '
-            f"(Ampere or newer). Detected device: {name}, compute capability "
-            f"{major}.{minor}. Either run on Ampere/Hopper hardware, or change "
-            'parameter_dtype to "float32" in the training config.'
-        )
+    backend = get_backend()
+    for value in optimizer._states.values():
+        if not isinstance(value, dict):
+            continue
+        for name, arr in value.items():
+            if not hasattr(arr, "dtype"):
+                continue
+            value[name] = _broadcast_array(arr, backend=backend, from_rank=from_rank)

--- a/autograd/distributed/__init__.py
+++ b/autograd/distributed/__init__.py
@@ -225,6 +225,11 @@ class _NCCLBackend:
         # NCCL broadcast mutates the buffer in place on every rank; the
         # root's contents win. We return `buf` so the call site uses the
         # same rebind pattern as `all_reduce`.
+        #
+        # Callers must hand us a dtype cupyx's NCCL wrapper recognises
+        # (fp16/fp32/fp64 + int variants). bf16 in particular is rejected
+        # here — see `broadcast_parameters` for the workaround and the
+        # cupyx-dtype-gap explanation.
         self._comm.broadcast(buf, root=from_rank)
         return buf
 
@@ -360,6 +365,12 @@ def broadcast_parameters(
     init, but platform-level non-determinism can drift them apart. One
     broadcast at startup eliminates that risk for a negligible one-time cost.
 
+    Low-precision (bf16) params are promoted to fp32 before the broadcast
+    and cast back afterwards. The reason is *not* numerical — broadcast is
+    a byte copy and bf16 round-trips losslessly — it's a cupyx plumbing
+    gap. See the inline comment at the promotion site for the upstream
+    issue trail.
+
     No-op when `world_size == 1`.
     """
     if not is_distributed():
@@ -367,19 +378,62 @@ def broadcast_parameters(
 
     backend = get_backend()
     for param in parameters.values():
-        param.data = backend.broadcast(param.data, from_rank=from_rank)
+        data = param.data
+        if data.dtype in LOW_PRECISION_FLOAT_DTYPES:
+            # Why promote bf16 → fp32 before broadcast?
+            #
+            # cupyx.distributed wraps NCCL via a small dtype-char table
+            # at `cupyx.distributed._nccl_comm._nccl_dtypes` that maps
+            # numpy char codes → NCCL type IDs. As of cupy 14.0.1 (the
+            # latest stable, Feb 2026) that table has 'e' (numpy float16
+            # → NCCL_FLOAT16) but not 'E' — the char code used by
+            # `ml_dtypes.bfloat16`, which is cupy's bf16 storage path
+            # until native `cupy.bfloat16` lands at the Python level.
+            # Hand cupyx a bf16 array and it raises:
+            #     TypeError: Unknown dtype bfloat16 for NCCL
+            #
+            # Upstream tracking (as of this writing):
+            #   * cupy/cupy#7527 — bf16 umbrella issue (closed Feb 2026)
+            #   * cupy/cupy#9494 — implementation PR (merged Feb 2026,
+            #     targets v15.0.0a1+); ships internal bf16 type handling
+            #     built on ml_dtypes, but does NOT expose `cupy.bfloat16`
+            #     and does NOT update cupyx.distributed
+            #   * cupy/cupy#9630 — open follow-ups for cupyx bf16 gaps;
+            #     `cupyx.distributed` is NOT on the list
+            #   * Searching `is:pr nccl bfloat16` in cupy/cupy returns
+            #     zero PRs (open or closed) — no scheduled upstream fix
+            #
+            # So we work around it locally. fp32 promotion is the natural
+            # fix because it mirrors the same promotion that already
+            # happens in `allreduce_grads` above — there for *numerical
+            # correctness* (bf16 accumulation loses mantissa bits as
+            # world_size grows); here it's *plumbing only* (broadcast
+            # is bit-exact regardless of dtype). One mental model, two
+            # motivations.
+            #
+            # Cost: this doubles the per-param broadcast volume (2 B → 4 B)
+            # at startup. For a 128M-param model that's a one-time
+            # 256 MB → 512 MB transfer over NCCL — negligible vs the
+            # multi-hour training run that follows.
+            d32 = data.astype(xp.float32)
+            d32 = backend.broadcast(d32, from_rank=from_rank)
+            param.data = d32.astype(data.dtype)
+        else:
+            param.data = backend.broadcast(data, from_rank=from_rank)
 
 
 # --- bf16 hardware gate ------------------------------------------------------
 #
-# bf16 on CuPy requires CUDA compute capability >= 8.0 (Ampere). Lower-cc
-# devices either don't expose `cupy.bfloat16` or fall back to software bf16
-# emulation with surprise-slow kernels. We hard-fail with an actionable
-# message instead.
+# bf16 on CuPy requires CUDA compute capability >= 8.0 (Ampere). Pre-Ampere
+# silicon either has no bf16 path at all or falls back to software emulation
+# with surprise-slow kernels — silently slow training is worse than a hard
+# fail at startup. We do not separately gate dtype *availability* here:
+# `autograd.backend.resolve_dtype("bfloat16")` already raises a clear error
+# when neither `cupy.bfloat16` nor `ml_dtypes.bfloat16` is reachable.
 
 
-def check_bf16_capability(parameter_dtype: str) -> None:
-    """Hard-fail if `parameter_dtype == 'bfloat16'` on incompatible hardware.
+def check_bf16_capability(parameter_dtype: str | None) -> None:
+    """Hard-fail if `parameter_dtype == 'bfloat16'` on pre-Ampere hardware.
 
     Runs unconditionally on CuPy (single-GPU and DDP). MLX has its own bf16
     path; numpy has no bf16 dtype. For non-CuPy backends, this is a no-op.
@@ -393,13 +447,6 @@ def check_bf16_capability(parameter_dtype: str) -> None:
 
     if not IS_CUPY:
         return
-
-    if not hasattr(xp, "bfloat16"):
-        raise RuntimeError(
-            'parameter_dtype="bfloat16" requires cupy.bfloat16, but the '
-            "installed CuPy version does not expose it. Upgrade CuPy or "
-            'change parameter_dtype to "float32" in the training config.'
-        )
 
     device = xp.cuda.Device()
     cc_str = device.compute_capability

--- a/autograd/distributed/launch.py
+++ b/autograd/distributed/launch.py
@@ -1,0 +1,174 @@
+"""Single-node multi-GPU launcher for autograd DDP.
+
+Usage:
+
+    python -m autograd.distributed.launch --nproc-per-node=N script.py [args...]
+
+Spawns N child processes, one per GPU on this node. Each child sees these
+env vars (which `autograd.distributed` and `autograd.backend` read at
+import time):
+
+- ``WORLD_SIZE``  total number of ranks (= N)
+- ``RANK``        global rank, ``0..N-1`` (same as local on single node)
+- ``LOCAL_RANK``  GPU index this rank pins to via ``cp.cuda.Device(LR).use()``
+- ``MASTER_ADDR`` rendezvous host for the NCCL bootstrap (default 127.0.0.1)
+- ``MASTER_PORT`` rendezvous port; auto-picks a free one if ``--master-port=0``
+- ``SEED``        forwarded to the script for deterministic init
+
+The launcher is intentionally simple: blocking ``subprocess.Popen`` per
+rank, ``signal`` to propagate Ctrl+C, ``wait()`` to collect exit codes.
+There is no fault tolerance and no elastic scaling — those belong in
+torchrun's complexity bracket, not here. If a child fails, the launcher
+waits for the rest to finish and exits with the worst observed code.
+
+Why subprocess instead of fork/multiprocessing?
+    Each rank needs its own CuPy/CUDA context. ``fork`` after CUDA init
+    is undefined behaviour; ``multiprocessing.spawn`` works but adds a
+    pickling-the-target layer. Plain ``subprocess`` is the cleanest
+    one-step-removed model and matches how torchrun launches its workers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import socket
+import subprocess
+import sys
+from typing import Sequence
+
+
+def _find_free_port() -> int:
+    """Bind a socket to port 0 (OS picks any free port), read it, release.
+
+    Tiny race window: another process could bind the same port between the
+    close here and the NCCL server bind in rank 0. In practice the window
+    is sub-millisecond and the launcher is the only consumer on a typical
+    training box.
+    """
+    s = socket.socket()
+    try:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+def _spawn_rank(
+    *,
+    rank: int,
+    world_size: int,
+    master_addr: str,
+    master_port: int,
+    seed: int,
+    script: str,
+    script_args: Sequence[str],
+) -> subprocess.Popen:
+    """Start one child process for ``rank``. Inherits stdin/stdout/stderr so
+    rank-0 logs land in the launcher's terminal and non-zero ranks stay
+    quiet (the trainer raises their log level via the rank-zero gate).
+    """
+    env = os.environ.copy()
+    env["WORLD_SIZE"] = str(world_size)
+    env["RANK"] = str(rank)
+    env["LOCAL_RANK"] = str(rank)
+    env["MASTER_ADDR"] = master_addr
+    env["MASTER_PORT"] = str(master_port)
+    env["SEED"] = str(seed)
+    return subprocess.Popen(
+        [sys.executable, script, *script_args],
+        env=env,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m autograd.distributed.launch",
+        description="Single-node multi-GPU launcher for autograd DDP.",
+    )
+    parser.add_argument(
+        "--nproc-per-node",
+        type=int,
+        required=True,
+        help="Number of ranks (= number of GPUs to use on this node).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Seed forwarded to children via SEED env var (default: 42).",
+    )
+    parser.add_argument(
+        "--master-addr",
+        default="127.0.0.1",
+        help="NCCL rendezvous host (default: 127.0.0.1; single-node only).",
+    )
+    parser.add_argument(
+        "--master-port",
+        type=int,
+        default=0,
+        help="NCCL rendezvous port; 0 picks a free port (default: 0).",
+    )
+    parser.add_argument("script", help="Path to the training script.")
+    parser.add_argument(
+        "script_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments forwarded verbatim to the script.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.nproc_per_node < 1:
+        parser.error(f"--nproc-per-node must be >= 1, got {args.nproc_per_node}")
+
+    if args.master_port == 0:
+        args.master_port = _find_free_port()
+
+    children = [
+        _spawn_rank(
+            rank=r,
+            world_size=args.nproc_per_node,
+            master_addr=args.master_addr,
+            master_port=args.master_port,
+            seed=args.seed,
+            script=args.script,
+            script_args=args.script_args,
+        )
+        for r in range(args.nproc_per_node)
+    ]
+
+    print(
+        f"[launcher] spawned {len(children)} ranks "
+        f"on {args.master_addr}:{args.master_port}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    # Forward Ctrl+C / SIGTERM to every child so the user can abort cleanly.
+    def _forward(signum: int, _frame: object) -> None:
+        for proc in children:
+            try:
+                proc.send_signal(signum)
+            except ProcessLookupError:
+                # Child already exited; nothing to do.
+                pass
+
+    signal.signal(signal.SIGINT, _forward)
+    signal.signal(signal.SIGTERM, _forward)
+
+    exit_codes = [proc.wait() for proc in children]
+    failures = [(r, c) for r, c in enumerate(exit_codes) if c != 0]
+    if failures:
+        for r, code in failures:
+            print(
+                f"[launcher] rank {r} exited with code {code}",
+                file=sys.stderr,
+                flush=True,
+            )
+        # Return the worst observed code; this becomes the launcher's exit.
+        return max(c for _, c in failures)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -1613,20 +1613,23 @@ class ScaledDotProductAttention(Module):
         # Dense remains the contract fallback for structural causality and for
         # everything outside the supported explicit causal self-attention slice.
 
-        attention_size = Tensor(key.shape[-1])
+        attention_scale = Tensor(
+            xp.asarray(key.shape[-1] ** -0.5, dtype=key.data.dtype),
+            requires_grad=False,
+        )
 
         # scaled dot product
         # (batch_size, num_heads, sequence_len, sequence_len)
-        att_score = (query @ key.transpose(2, 3)) / attention_size.sqrt()
+        att_score = (query @ key.transpose(2, 3)) * attention_scale
 
         # Non-MLX Causal Mask
         if mask is None and is_causal:
             seq_q = int(query.shape[-2])
             seq_k = int(key.shape[-2])
             mask = Tensor(
-                xp.triu(xp.ones((seq_q, seq_k), dtype=xp.float32), k=1).reshape(
-                    1, 1, seq_q, seq_k
-                ),
+                xp.triu(
+                    xp.ones((seq_q, seq_k), dtype=att_score.data.dtype), k=1
+                ).reshape(1, 1, seq_q, seq_k),
                 requires_grad=False,
             )
 

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -277,7 +277,10 @@ class Optimizer:
         """Scale all parameter gradients in-place by ``scale``."""
         for param in self.model_parameters.values():
             if param.grad is not None:
+                grad_dtype = param.grad.data.dtype
                 param.grad.data *= scale
+                if param.grad.data.dtype != grad_dtype:
+                    param.grad.data = param.grad.data.astype(grad_dtype)
 
     def grad_l2_norm(self) -> float:
         """Return the L2 norm of all current parameter gradients."""

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from typing import Any, Dict, Optional
 
 from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, materialize, xp
+from autograd.distributed import allreduce_grads, broadcast_parameters
 from autograd.tensor import Tensor
 
 logger = logging.getLogger(__name__)
@@ -168,6 +169,11 @@ class Optimizer:
         # Store additional hyperparams from kwargs:
         for k, v in kwargs.items():
             self._hyperparams[k] = v
+
+        # Belt-and-suspenders parameter sync at construction time so every
+        # DDP rank starts from identical weights. broadcast_parameters
+        # self-no-ops when world_size == 1, so no guard is needed here.
+        broadcast_parameters(self.model_parameters, from_rank=0)
 
     @property
     def lr(self) -> float:
@@ -376,6 +382,7 @@ class SGD(Optimizer):
         This method updates each parameter by subtracting the product of the learning rate
         and the parameter's gradient.
         """
+        allreduce_grads(self.model_parameters)
         self.timestep += 1
         self.update_lr()
 
@@ -444,6 +451,11 @@ class Adam(Optimizer):
         applies bias correction, performs a decoupled weight decay step if specified,
         and updates the parameters accordingly.
         """
+        # Average gradients across DDP ranks before Adam consumes them, so
+        # the optimizer state (m, v) is computed against the true global
+        # mean gradient — equivalent to a single forward+backward over the
+        # concatenated global batch. No-op when world_size == 1.
+        allreduce_grads(self.model_parameters)
         self.timestep += 1
         self.update_lr()
 

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -1437,6 +1437,11 @@ class Matmul(Function):
         # Save references so backward() can know which Tensors to differentiate
         self.x_shape = x.shape
         self.y_shape = y.shape
+        out_dtype = (
+            x.dtype
+            if x.dtype == y.dtype and x.dtype in LOW_PRECISION_FLOAT_DTYPES
+            else None
+        )
         if x.ndim > 2 and y.ndim == 2:
             # A common neural-net projection applies the same 2D weight matrix
             # to every leading batch position:
@@ -1449,9 +1454,11 @@ class Matmul(Function):
             x_shape = x.shape
             x_2d = x.reshape(-1, x_shape[-1])
             out_2d = xp.matmul(x_2d, y)
-            return out_2d.reshape(*x_shape[:-1], y.shape[-1])
+            out = out_2d.reshape(*x_shape[:-1], y.shape[-1])
+            return out.astype(out_dtype) if out_dtype is not None else out
 
-        return xp.matmul(x, y)
+        out = xp.matmul(x, y)
+        return out.astype(out_dtype) if out_dtype is not None else out
 
     def backward(self, grad: "Tensor") -> Tuple[Optional[Array], Optional[Array]]:
         r"""Compute the gradient for the matrix multiplication operation.

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -1437,8 +1437,21 @@ class Matmul(Function):
         # Save references so backward() can know which Tensors to differentiate
         self.x_shape = x.shape
         self.y_shape = y.shape
-        out = xp.matmul(x, y)
-        return out
+        if x.ndim > 2 and y.ndim == 2:
+            # A common neural-net projection applies the same 2D weight matrix
+            # to every leading batch position:
+            #   x:      (batch, time, hidden)
+            #   y:      (hidden, vocab)
+            #   output: (batch, time, vocab)
+            # This is equivalent to:
+            #   (batch * time, hidden) @ (hidden, vocab)
+            # then reshaping back to (batch, time, vocab).
+            x_shape = x.shape
+            x_2d = x.reshape(-1, x_shape[-1])
+            out_2d = xp.matmul(x_2d, y)
+            return out_2d.reshape(*x_shape[:-1], y.shape[-1])
+
+        return xp.matmul(x, y)
 
     def backward(self, grad: "Tensor") -> Tuple[Optional[Array], Optional[Array]]:
         r"""Compute the gradient for the matrix multiplication operation.
@@ -1509,7 +1522,17 @@ class Matmul(Function):
             # Transpose y on the last two dims (y^T)
             # xp.swapaxes(y, -1, -2) is effectively y^T for each batch.
             y_t = xp.swapaxes(y.data, -1, -2)
-            grad_x = xp.matmul(grad.data, y_t)
+            if grad.data.ndim > 2 and y_t.ndim == 2:
+                # Same shape rewrite as forward:
+                #   grad: (batch, time, vocab)
+                #   y.T:  (vocab, hidden)
+                #   dx:   (batch, time, hidden)
+                grad_shape = grad.data.shape
+                grad_2d = grad.data.reshape(-1, grad_shape[-1])
+                grad_x_2d = xp.matmul(grad_2d, y_t)
+                grad_x = grad_x_2d.reshape(*grad_shape[:-1], y_t.shape[-1])
+            else:
+                grad_x = xp.matmul(grad.data, y_t)
             # shape of grad_x should match x.data.shape
 
         if y.requires_grad:

--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -3,7 +3,7 @@ import logging
 import os
 import pickle
 import shutil
-from collections import Counter
+from collections import Counter, OrderedDict
 from itertools import batched
 from multiprocessing import Pool, cpu_count
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
@@ -41,6 +41,9 @@ class BytePairEncoder:
         "<|TOOL_CALL|>",
         "<|TOOL_RESULT|>",
     ]
+    ENCODE_CHUNK_CACHE_MAX_SIZE = 50_000
+    WORD_FREQ_BATCH_SIZE = 10_000
+    WORD_FREQ_LOG_INTERVAL = 500_000
 
     def __init__(
         self,
@@ -101,6 +104,12 @@ class BytePairEncoder:
         self._general_pattern = regex.compile(
             r"""'(?:[sdmt]|ll|ve|re)| ?\p{L}++| ?\p{N}++| ?[^\s\p{L}\p{N}]++|\s++$|\s+(?!\S)|\s"""
         )
+        # Two encode-time caches with different lifetimes/types:
+        # chunk text -> encoded ids (LRU), and learned merge pair -> priority/new id.
+        self._encoded_chunk_cache: OrderedDict[str, Tuple[int, ...]] = OrderedDict()
+        self._merge_priority_cache: Optional[Dict[Tuple[int, int], Tuple[int, int]]] = (
+            None
+        )
 
     @property
     def n_vocab(self) -> int:
@@ -111,6 +120,181 @@ class BytePairEncoder:
             >>> print(bpe.n_vocab)  # Outputs the size of the vocabulary
         """
         return len(self._unicode_to_int_vocab)
+
+    def prepare_data(
+        self,
+        texts: Iterable[str],
+        overwrite_vocabulary_file: bool = False,
+        overwrite_encoded_data: bool = False,
+    ) -> np.ndarray:
+        """Trains and applies BPE on the given texts, returning encoded token IDs.
+
+        Convenience wrapper that trains the vocabulary then writes token IDs
+        to the configured memory-mapped file.
+        ``texts`` must be re-iterable (e.g. a list or an object whose
+        ``__iter__`` returns a fresh iterator each time) because the corpus
+        is traversed once for vocabulary training and once for encoding.
+
+        Args:
+            texts (Iterable[str]): Documents to train on and encode.
+            overwrite_vocabulary_file (bool): If True, re-trains and overwrites the BPE vocabulary.
+            overwrite_encoded_data (bool): If True, overwrites an existing .npy file.
+
+        Returns:
+            np.ndarray: A memory-mapped array of token IDs.
+
+        Example:
+            >>> bpe = BytePairEncoder(num_merges=50)
+            >>> encoded_array = bpe.prepare_data(["Hello world! This is a test."])
+            >>> print(encoded_array)
+            [ ...some token IDs... ]
+        """
+        self.train_vocabulary(texts, overwrite_saved_file=overwrite_vocabulary_file)
+        self._encode_to_mmap(texts, overwrite_encoded_data=overwrite_encoded_data)
+        return np.load(self.mmap_path, mmap_mode="r")
+
+    def train_vocabulary(
+        self, texts: Iterable[str], overwrite_saved_file: bool = False
+    ) -> Tuple[Dict[bytes, int], Dict[int, bytes]]:
+        """Trains the BPE vocabulary on the given text documents.
+
+        Streams text one document at a time, so the full corpus never needs to
+        be held in memory. The learned merges and vocabulary are saved to
+        vocab_file_path.
+
+        Args:
+            texts (Iterable[str]): Documents to train on (e.g. ["doc1", "doc2"]
+                or a lazy generator). Pass a single document as [raw_text].
+                A bare str is rejected to prevent silent per-character iteration.
+            overwrite_saved_file (bool): If True, re-trains and overwrites any
+                existing vocabulary file.
+
+        Returns:
+            Tuple[Dict[bytes, int], Dict[int, bytes]]:
+                A tuple containing:
+                - A dictionary mapping byte sequences or special tokens to integer IDs.
+                - A dictionary mapping integer IDs back to byte sequences.
+
+        Examples:
+            >>> bpe = BytePairEncoder(num_merges=50)
+            >>> vocab, rev_vocab = bpe.train_vocabulary(["Hello world! Hello again!"])
+            >>> print(vocab)  # Prints the vocabulary mapping
+        """
+        if isinstance(texts, str):
+            raise TypeError(
+                "train_vocabulary expects an iterable of strings, not a bare str. "
+                "Wrap a single document as [text]."
+            )
+
+        if os.path.exists(self.vocab_file_path) and not overwrite_saved_file:
+            return self._unicode_to_int_vocab, self._int_to_unicode_vocab
+
+        self._encoded_chunk_cache.clear()
+        self._merge_priority_cache = None
+
+        if not overwrite_saved_file and os.path.exists(self.word_freq_cache_path):
+            logger.info(
+                "Loading cached word frequencies from %s", self.word_freq_cache_path
+            )
+            with open(self.word_freq_cache_path, "rb") as f:
+                word_freq = pickle.load(f)
+        else:
+            word_freq = self._build_word_freq(texts)
+            logger.info("Caching word frequencies to %s", self.word_freq_cache_path)
+            with open(self.word_freq_cache_path, "wb") as f:
+                pickle.dump(word_freq, f)
+        return self._learn_vocabulary_from_word_freq(word_freq)
+
+    def encode(self, input_text: str, *, show_progress: bool = False) -> List[int]:
+        """Encodes a raw input string into a list of BPE token IDs.
+
+        The process is:
+          1) Pre-tokenize the input into chunks (words, punctuation, special tokens).
+          2) Convert each chunk to base (byte-level) token IDs.
+          3) Greedily apply the highest-priority merge until no more merges apply.
+
+        Args:
+            input_text (str): The text to encode.
+
+        Returns:
+            List[int]: The list of integer token IDs representing the encoded text.
+
+        Example:
+            >>> bpe = BytePairEncoder(num_merges=50)
+            >>> bpe.train_vocabulary(["Hello world!"])
+            >>> token_ids = bpe.encode("Hello world!")
+            >>> print(token_ids)  # Outputs a list of token IDs
+        """
+        text_chunks = self._pretokenize(input_text)
+        logger.debug("Text chunks: %s", text_chunks[:20])
+
+        if not text_chunks:
+            return []
+
+        merge_priority = self._get_merge_priority()
+        result: List[int] = []
+        for chunk in text_chunks:
+            if chunk in self.SPECIAL_TOKENS:
+                result.append(self._unicode_to_int_vocab[chunk.encode("utf-8")])
+            else:
+                cached = self._encoded_chunk_cache.get(chunk)
+                if cached is not None:
+                    self._encoded_chunk_cache.move_to_end(chunk)
+                    result.extend(cached)
+                else:
+                    # Greedily apply the earliest-learned merge until convergence.
+                    token_ids = list(chunk.encode("utf-8"))
+                    while len(token_ids) >= 2:
+                        next_pair = None
+                        next_priority = float("inf")
+                        for i in range(len(token_ids) - 1):
+                            pair = (token_ids[i], token_ids[i + 1])
+                            info = merge_priority.get(pair)
+                            if info is not None and info[0] < next_priority:
+                                next_priority = info[0]
+                                next_pair = pair
+                        if next_pair is None:
+                            break
+                        new_id = merge_priority[next_pair][1]
+                        token_ids = list(
+                            BytePairEncoder._merge_pairs(next_pair, new_id, token_ids)
+                        )
+
+                    encoded_chunk = tuple(token_ids)
+                    if (
+                        len(self._encoded_chunk_cache)
+                        >= self.ENCODE_CHUNK_CACHE_MAX_SIZE
+                    ):
+                        self._encoded_chunk_cache.popitem(last=False)
+                    self._encoded_chunk_cache[chunk] = encoded_chunk
+                    result.extend(encoded_chunk)
+
+        return result
+
+    def decode(self, encoded_tokens: List[int]) -> str:
+        """Decodes a sequence of BPE token IDs back into a string.
+
+        Args:
+            encoded_tokens (List[int]): The list of integer token IDs to decode.
+
+        Returns:
+            str: The decoded string.
+
+        Example:
+            >>> bpe = BytePairEncoder(num_merges=50)
+            >>> bpe.train_vocabulary(["Hello world!"])
+            >>> token_ids = bpe.encode("Hello world!")
+            >>> text = bpe.decode(token_ids) # Expected: "Hello world!" (or similar)
+        """
+        result_bytes = []
+        for t in encoded_tokens:
+            if not isinstance(t, int) and hasattr(t, "item"):  # handle array scalars
+                t = t.item()
+            if t in self._int_to_unicode_vocab:
+                result_bytes.append(self._int_to_unicode_vocab[t])
+            else:
+                result_bytes.append(b"<UNK>")
+        return b"".join(result_bytes).decode("utf-8", errors="replace")
 
     def _should_parallelize(
         self, *, work_items: int, min_items_per_worker: int
@@ -184,38 +368,7 @@ class BytePairEncoder:
             unicode_to_int_vocab[special_char.encode("utf-8")] = 256 + i
         return unicode_to_int_vocab
 
-    def prepare_data(
-        self,
-        texts: Iterable[str],
-        overwrite_vocabulary_file: bool = False,
-        overwrite_encoded_data: bool = False,
-    ) -> np.ndarray:
-        """Trains and applies BPE on the given texts, returning encoded token IDs.
-
-        Convenience wrapper that calls train_vocabulary then encode_to_mmap.
-        ``texts`` must be re-iterable (e.g. a list or an object whose
-        ``__iter__`` returns a fresh iterator each time) because the corpus
-        is traversed once for vocabulary training and once for encoding.
-
-        Args:
-            texts (Iterable[str]): Documents to train on and encode.
-            overwrite_vocabulary_file (bool): If True, re-trains and overwrites the BPE vocabulary.
-            overwrite_encoded_data (bool): If True, overwrites an existing .npy file.
-
-        Returns:
-            np.ndarray: A memory-mapped array of token IDs.
-
-        Example:
-            >>> bpe = BytePairEncoder(num_merges=50)
-            >>> encoded_array = bpe.prepare_data(["Hello world! This is a test."])
-            >>> print(encoded_array)
-            [ ...some token IDs... ]
-        """
-        self.train_vocabulary(texts, overwrite_saved_file=overwrite_vocabulary_file)
-        self.encode_to_mmap(texts, overwrite_encoded_data=overwrite_encoded_data)
-        return np.load(self.mmap_path, mmap_mode="r")
-
-    def encode_to_mmap(
+    def _encode_to_mmap(
         self,
         text_iter: Iterable[str],
         overwrite_encoded_data: bool = False,
@@ -246,7 +399,7 @@ class BytePairEncoder:
             return self.mmap_path
         if iter(text_iter) is text_iter:
             raise TypeError(
-                "encode_to_mmap requires a re-iterable text source because it "
+                "_encode_to_mmap requires a re-iterable text source because it "
                 "counts encoded tokens before writing the .npy memmap. Pass a "
                 "sequence or an iterable object whose __iter__ returns a fresh iterator."
             )
@@ -282,10 +435,14 @@ class BytePairEncoder:
                 shape=(token_count,),
             )
             offset = 0
+            # Writes are positional in the memmap, so batches must arrive in
+            # input order — otherwise tokens from later docs would land in
+            # earlier slots and the file would no longer match the corpus.
             for encoded_batch in self._iter_encoded_batches(
                 text_iter,
                 text_batch_size=text_batch_size,
                 desc="Encoding text to tokens",
+                preserve_order=True,
             ):
                 for encoded_text in encoded_batch:
                     end = offset + len(encoded_text)
@@ -321,6 +478,7 @@ class BytePairEncoder:
             text_iter,
             text_batch_size=text_batch_size,
             desc="Counting encoded tokens",
+            preserve_order=False,
         ):
             for encoded_text in encoded_batch:
                 token_count += len(encoded_text)
@@ -345,148 +503,58 @@ class BytePairEncoder:
                 f"but only {free_bytes} bytes are free in {disk_check_dir!r}."
             )
 
-    def train_vocabulary(
-        self, texts: Iterable[str], overwrite_saved_file: bool = False
-    ) -> Tuple[Dict[bytes, int], Dict[int, bytes]]:
-        """Trains the BPE vocabulary on the given text documents.
-
-        Streams text one document at a time, so the full corpus never needs to
-        be held in memory. The learned merges and vocabulary are saved to
-        vocab_file_path.
-
-        Args:
-            texts (Iterable[str]): Documents to train on (e.g. ["doc1", "doc2"]
-                or a lazy generator). Pass a single document as [raw_text].
-                A bare str is rejected to prevent silent per-character iteration.
-            overwrite_saved_file (bool): If True, re-trains and overwrites any
-                existing vocabulary file.
-
-        Returns:
-            Tuple[Dict[bytes, int], Dict[int, bytes]]:
-                A tuple containing:
-                - A dictionary mapping byte sequences or special tokens to integer IDs.
-                - A dictionary mapping integer IDs back to byte sequences.
-
-        Examples:
-            >>> bpe = BytePairEncoder(num_merges=50)
-            >>> vocab, rev_vocab = bpe.train_vocabulary(["Hello world! Hello again!"])
-            >>> print(vocab)  # Prints the vocabulary mapping
-        """
-        if isinstance(texts, str):
-            raise TypeError(
-                "train_vocabulary expects an iterable of strings, not a bare str. "
-                "Wrap a single document as [text]."
-            )
-
-        if os.path.exists(self.vocab_file_path) and not overwrite_saved_file:
-            return self._unicode_to_int_vocab, self._int_to_unicode_vocab
-
-        word_freq = self._load_or_build_word_freq(texts, overwrite_saved_file)
-        return self._learn_vocabulary_from_word_freq(word_freq)
-
-    def _load_or_build_word_freq(
-        self, texts: Iterable[str], overwrite: bool
-    ) -> Counter:
-        """Load cached word frequencies or build from scratch and cache."""
-        if not overwrite and os.path.exists(self.word_freq_cache_path):
-            logger.info(
-                "Loading cached word frequencies from %s", self.word_freq_cache_path
-            )
-            with open(self.word_freq_cache_path, "rb") as f:
-                return pickle.load(f)
-
-        word_freq = self._build_word_freq(texts)
-
-        logger.info("Caching word frequencies to %s", self.word_freq_cache_path)
-        with open(self.word_freq_cache_path, "wb") as f:
-            pickle.dump(word_freq, f)
-
-        return word_freq
-
     def _build_word_freq(self, texts: Iterable[str]) -> Counter:
         """Build word frequency table from documents, parallelized when possible.
 
-        Internally counts with bytes keys (cheap from .encode()), then converts
-        to tuple-of-int keys expected by the merge loop.
+        Counts pre-tokenized word forms in document batches, then converts byte
+        keys to token-id tuples used by the merge loop.
         """
-        if self.n_workers > 1:
-            special_token_ids = {
-                tok: self._unicode_to_int_vocab[tok.encode("utf-8")]
-                for tok in self.SPECIAL_TOKENS
-            }
-            raw_freq = self._build_word_freq_parallel(texts, special_token_ids)
-        else:
-            raw_freq = self._build_word_freq_serial(texts)
-
-        # Convert bytes keys to tuple-of-int keys for the merge loop.
-        # Special token entries are already tuple keys — pass them through.
-        word_freq = Counter()
-        for key, count in raw_freq.items():
-            if isinstance(key, bytes):
-                word_freq[tuple(key)] = count
-            else:
-                word_freq[key] = count
-        return word_freq
-
-    def _build_word_freq_serial(self, texts: Iterable[str]) -> Counter:
-        word_freq = Counter()
-        doc_count = 0
-        for text in texts:
-            self._update_word_freq_from_text(word_freq, text)
-            doc_count += 1
-            if doc_count % 500_000 == 0:
-                logger.info(
-                    "Processed %d documents (%d unique word forms so far)",
-                    doc_count,
-                    len(word_freq),
-                )
-        logger.info(
-            "Word frequency table complete: %d documents, %d unique word forms",
-            doc_count,
-            len(word_freq),
-        )
-        return word_freq
-
-    def _build_word_freq_parallel(
-        self, texts: Iterable[str], special_token_ids: Dict[str, int]
-    ) -> Counter:
-        batch_size = 10_000
         pattern_str = self._general_pattern.pattern
         special_tokens_set = set(self.SPECIAL_TOKENS)
+        special_token_ids = {
+            tok: self._unicode_to_int_vocab[tok.encode("utf-8")]
+            for tok in self.SPECIAL_TOKENS
+        }
 
-        word_freq = Counter()
+        args_iter = (
+            (batch, pattern_str, special_tokens_set, special_token_ids)
+            for batch in batched(texts, self.WORD_FREQ_BATCH_SIZE)
+        )
+
+        word_freq: Counter = Counter()
         doc_count = 0
-        with Pool(self.n_workers) as pool:
-            args = (
-                (batch, pattern_str, special_tokens_set, special_token_ids)
-                for batch in batched(texts, batch_size)
-            )
+        with Pool(max(1, self.n_workers)) as pool:
             for partial_wf, batch_doc_count in pool.imap_unordered(
-                BytePairEncoder._word_freq_worker, args
+                BytePairEncoder._word_freq_worker, args_iter
             ):
                 word_freq.update(partial_wf)
                 doc_count += batch_doc_count
-                if doc_count % 500_000 < batch_size:
+                if doc_count % self.WORD_FREQ_LOG_INTERVAL < self.WORD_FREQ_BATCH_SIZE:
                     logger.info(
                         "Processed %d documents (%d unique word forms so far)",
                         doc_count,
                         len(word_freq),
                     )
+
         logger.info(
             "Word frequency table complete: %d documents, %d unique word forms",
             doc_count,
             len(word_freq),
         )
-        return word_freq
+
+        return Counter(
+            {tuple(k) if isinstance(k, bytes) else k: v for k, v in word_freq.items()}
+        )
 
     @staticmethod
     def _word_freq_worker(args):
+        """Pretokenize a document batch and count word forms."""
         docs, pattern_str, special_tokens, special_token_ids = args
         general_pat = regex.compile(pattern_str)
         special_pat = regex.compile(
             "(" + "|".join(regex.escape(k) for k in special_tokens) + ")"
         )
-        wf = Counter()
+        wf: Counter = Counter()
         for doc in docs:
             for segment in special_pat.split(doc):
                 if not segment:
@@ -497,20 +565,6 @@ class BytePairEncoder:
                     for chunk in general_pat.findall(segment):
                         wf[chunk.encode("utf-8")] += 1
         return wf, len(docs)
-
-    def _update_word_freq_from_text(self, word_freq: Counter, input_text: str) -> None:
-        """Count word frequencies using bytes keys (cheap to create from .encode()).
-        The caller converts to tuple-of-int keys before the merge loop.
-        """
-        text_chunks = self._pretokenize(input_text)
-        logger.debug("Text chunks: %s", text_chunks[:10])
-
-        for chunk in text_chunks:
-            if chunk in self.SPECIAL_TOKENS:
-                special_id = self._unicode_to_int_vocab[chunk.encode("utf-8")]
-                word_freq[(special_id,)] += 1
-            else:
-                word_freq[chunk.encode("utf-8")] += 1
 
     def _learn_vocabulary_from_word_freq(
         self,
@@ -556,8 +610,8 @@ class BytePairEncoder:
             # Pop stale/exhausted entries to find the current best pair.
             # Lazy correction: if a popped entry's count is stale but still positive,
             # re-push with the corrected count instead of discarding.
-            best_pair = None
-            best_pair_count = 0
+            most_frequent_pair = None
+            most_frequent_count = 0
             while heap:
                 neg_count, candidate = heap[0]
                 actual = pair_counts.get(candidate, 0)
@@ -567,12 +621,12 @@ class BytePairEncoder:
                 if actual != -neg_count:
                     heapq.heapreplace(heap, (-actual, candidate))
                     continue
-                best_pair = candidate
-                best_pair_count = actual
+                most_frequent_pair = candidate
+                most_frequent_count = actual
                 heapq.heappop(heap)
                 break
 
-            if best_pair is None or best_pair_count < 2:
+            if most_frequent_pair is None or most_frequent_count < 2:
                 break
 
             new_id = self.new_idx
@@ -580,27 +634,27 @@ class BytePairEncoder:
 
             # Create the merged token
             merged_bytes = (
-                self._int_to_unicode_vocab[best_pair[0]]
-                + self._int_to_unicode_vocab[best_pair[1]]
+                self._int_to_unicode_vocab[most_frequent_pair[0]]
+                + self._int_to_unicode_vocab[most_frequent_pair[1]]
             )
             self._int_to_unicode_vocab[new_id] = merged_bytes
             self._unicode_to_int_vocab[merged_bytes] = new_id
 
             # Apply merge using the inverted index for fast lookup
             self._apply_merges_to_corpus_indexed(
-                best_pair,
+                most_frequent_pair,
                 new_id,
                 word_freq,
                 pair_counts,
                 pair_to_words,
                 heap,
             )
-            self.learned_merges.append((best_pair, new_id))
+            self.learned_merges.append((most_frequent_pair, new_id))
 
             if (i + 1) % 5_000 == 0:
                 logger.info(
                     f"[{i + 1}/{self.num_merges} merge] Best Pair Merged "
-                    f"({best_pair_count} occurrences). "
+                    f"({most_frequent_count} occurrences). "
                     f"Vocab size: {len(self._unicode_to_int_vocab)}"
                 )
 
@@ -622,90 +676,13 @@ class BytePairEncoder:
         """Lazily build and cache a merge priority lookup: pair -> (priority, new_id).
         Lower priority = earlier merge = applied first during greedy encoding.
         """
-        if not hasattr(self, "_merge_priority_cache"):
-            self._merge_priority_cache = {}
+        if self._merge_priority_cache is None:
+            cache: Dict[Tuple[int, int], Tuple[int, int]] = {}
             for priority, (pair, new_id) in enumerate(self.learned_merges):
-                if pair not in self._merge_priority_cache:
-                    self._merge_priority_cache[pair] = (priority, new_id)
+                if pair not in cache:
+                    cache[pair] = (priority, new_id)
+            self._merge_priority_cache = cache
         return self._merge_priority_cache
-
-    def encode(self, input_text: str, *, show_progress: bool = False) -> List[int]:
-        """Encodes a raw input string into a list of BPE token IDs.
-
-        The process is:
-          1) Pre-tokenize the input into chunks (words, punctuation, special tokens).
-          2) Convert each chunk to base (byte-level) token IDs.
-          3) Greedily apply the highest-priority merge until no more merges apply.
-
-        Args:
-            input_text (str): The text to encode.
-
-        Returns:
-            List[int]: The list of integer token IDs representing the encoded text.
-
-        Example:
-            >>> bpe = BytePairEncoder(num_merges=50)
-            >>> bpe.train_vocabulary(["Hello world!"])
-            >>> token_ids = bpe.encode("Hello world!")
-            >>> print(token_ids)  # Outputs a list of token IDs
-        """
-        text_chunks = self._pretokenize(input_text)
-        logger.debug("Text chunks: %s", text_chunks[:20])
-
-        if not text_chunks:
-            return []
-
-        merge_priority = self._get_merge_priority()
-        result: List[int] = []
-        for chunk in text_chunks:
-            if chunk in self.SPECIAL_TOKENS:
-                result.append(self._unicode_to_int_vocab[chunk.encode("utf-8")])
-            else:
-                # Base vocab maps bytes([b]) -> b (identity)
-                token_ids = list(chunk.encode("utf-8"))
-                # Greedily apply the earliest-learned merge until convergence
-                while len(token_ids) >= 2:
-                    best_idx = -1
-                    best_priority = float("inf")
-                    for i in range(len(token_ids) - 1):
-                        p_info = merge_priority.get((token_ids[i], token_ids[i + 1]))
-                        if p_info is not None and p_info[0] < best_priority:
-                            best_priority = p_info[0]
-                            best_idx = i
-                    if best_idx == -1:
-                        break
-                    new_id = merge_priority[
-                        (token_ids[best_idx], token_ids[best_idx + 1])
-                    ][1]
-                    token_ids[best_idx : best_idx + 2] = [new_id]
-                result.extend(token_ids)
-
-        return result
-
-    def decode(self, encoded_tokens: List[int]) -> str:
-        """Decodes a sequence of BPE token IDs back into a string.
-
-        Args:
-            encoded_tokens (List[int]): The list of integer token IDs to decode.
-
-        Returns:
-            str: The decoded string.
-
-        Example:
-            >>> bpe = BytePairEncoder(num_merges=50)
-            >>> bpe.train_vocabulary(["Hello world!"])
-            >>> token_ids = bpe.encode("Hello world!")
-            >>> text = bpe.decode(token_ids) # Expected: "Hello world!" (or similar)
-        """
-        result_bytes = []
-        for t in encoded_tokens:
-            if not isinstance(t, int) and hasattr(t, "item"):  # handle array scalars
-                t = t.item()
-            if t in self._int_to_unicode_vocab:
-                result_bytes.append(self._int_to_unicode_vocab[t])
-            else:
-                result_bytes.append(b"<UNK>")
-        return b"".join(result_bytes).decode("utf-8", errors="replace")
 
     def _pretokenize(self, input_text: str) -> List[str]:
         r"""Splits the input text into smaller chunks (tokens).
@@ -745,6 +722,7 @@ class BytePairEncoder:
         *,
         text_batch_size: int,
         desc: str,
+        preserve_order: bool = True,
     ) -> Iterable[list[list[int]]]:
         if text_batch_size < 1:
             raise ValueError(f"text_batch_size must be >= 1, got {text_batch_size}")
@@ -752,8 +730,13 @@ class BytePairEncoder:
         text_batches = batched(text_iter, text_batch_size)
         if self.n_workers > 1:
             with Pool(self.n_workers) as pool:
+                encoded_batches = (
+                    pool.imap(self._encode_text_batch, text_batches)
+                    if preserve_order
+                    else pool.imap_unordered(self._encode_text_batch, text_batches)
+                )
                 yield from tqdm(
-                    pool.imap(self._encode_text_batch, text_batches),
+                    encoded_batches,
                     desc=desc,
                     unit="batch",
                 )

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -54,6 +54,12 @@ class GenericTrainingConfig:
     micro_batch_size: int = 1
     # Optional trainer-level gradient clipping threshold.
     max_grad_norm: Optional[float] = None
+    # When True under DDP, the trainer AllReduce-sums the loss numerator and
+    # token-count denominator across all ranks before dividing, so logged
+    # losses are the true global weighted mean. Default off because the
+    # extra two AllReduces per report are wasted work on a single rank, and
+    # rank-0's local loss is usually a faithful enough sanity signal.
+    log_global_loss: bool = False
 
     def __post_init__(self) -> None:
         if self.max_epochs is None and self.max_steps is None:

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -100,7 +100,29 @@ class GenericTrainingConfig:
 
     @property
     def gradient_accumulation_steps(self) -> int:
-        return self.global_batch_size // self.micro_batch_size
+        """Per-rank accumulation steps for one optimizer update.
+
+        `global_batch_size` is the *true* global batch (summed across all
+        ranks). On a single rank this reduces to the familiar
+        ``global // micro``. With N ranks each contributing a microbatch
+        per accumulation tick, the per-rank tick count is
+        ``global // (micro * world_size)``.
+
+        Fails fast if the resulting division isn't integral — the config
+        is wrong for the launched world size and we'd silently drop or
+        double-count examples otherwise.
+        """
+        from autograd.distributed import world_size
+
+        ws = world_size()
+        per_step = self.micro_batch_size * ws
+        if self.global_batch_size % per_step != 0:
+            raise ValueError(
+                f"global_batch_size ({self.global_batch_size}) must be divisible by "
+                f"micro_batch_size * world_size ({self.micro_batch_size} * {ws} = "
+                f"{per_step}). Adjust the config or the --nproc-per-node value."
+            )
+        return self.global_batch_size // per_step
 
 
 @dataclass

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -101,8 +101,32 @@ class GenericTrainingConfig:
                 "global_batch_size must be divisible by micro_batch_size, "
                 f"got {self.global_batch_size} and {self.micro_batch_size}"
             )
+        self._validate_distributed_batch_config()
         if self.max_grad_norm is not None and self.max_grad_norm <= 0:
             raise ValueError(f"max_grad_norm must be > 0, got {self.max_grad_norm}")
+
+    def _validate_distributed_batch_config(self) -> None:
+        from autograd.distributed import rank, world_size
+
+        ws = world_size()
+        if ws < 1:
+            raise ValueError(f"world_size must be >= 1, got {ws}")
+        current_rank = rank()
+        if not (0 <= current_rank < ws):
+            raise ValueError(
+                f"rank must be in [0, {ws}), got {current_rank}. "
+                "Check RANK/WORLD_SIZE or the distributed launcher."
+            )
+        if ws == 1:
+            return
+
+        per_step = self.micro_batch_size * ws
+        if self.global_batch_size % per_step != 0:
+            raise ValueError(
+                f"global_batch_size ({self.global_batch_size}) must be divisible by "
+                f"micro_batch_size * world_size ({self.micro_batch_size} * {ws} = "
+                f"{per_step}). Adjust the config or the --nproc-per-node value."
+            )
 
     @property
     def gradient_accumulation_steps(self) -> int:

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -20,11 +20,16 @@ from tqdm import tqdm
 from autograd import nn, optim
 from autograd.backend import (
     Array,
+    check_bf16_capability,
     materialize,
     xp,
 )
 from autograd.data.data_loader import DataLoader
-from autograd.distributed import check_bf16_capability, rank
+from autograd.distributed import (
+    broadcast_optimizer_state,
+    broadcast_parameters,
+    rank,
+)
 from autograd.tensor import Tensor, no_grad
 from autograd.tools.config_schema import (
     GenericTrainingConfig,
@@ -728,6 +733,8 @@ class AbstractTrainer(ABC):
             optimizer = optimizer_class(model.parameters, **optimizer_kwargs)
             # The configured model architecture must match the checkpoint.
             model.load_state_dict(loaded_ckpt["model_state_dict"])
+            # Keep loaded params identical across DDP ranks.
+            broadcast_parameters(model.parameters, from_rank=0)
             logger.info(
                 f"Loaded pretrained {model_class.__name__} weights from {pretrained_checkpoint_path}"
             )
@@ -782,6 +789,9 @@ class AbstractTrainer(ABC):
             # Load model/optimizer state
             model.load_state_dict(loaded_ckpt["model_state_dict"])
             optimizer.load_state_dict(loaded_ckpt["optimizer_state_dict"])
+            # Keep loaded params and optimizer moments identical across DDP ranks.
+            broadcast_parameters(model.parameters, from_rank=0)
+            broadcast_optimizer_state(optimizer, from_rank=0)
 
             logger.info(
                 f"Loaded {model_class.__name__} from epoch {loaded_ckpt.get('epoch', '?')} "

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -24,6 +24,7 @@ from autograd.backend import (
     xp,
 )
 from autograd.data.data_loader import DataLoader
+from autograd.distributed import rank
 from autograd.tensor import Tensor, no_grad
 from autograd.tools.config_schema import (
     GenericTrainingConfig,
@@ -250,6 +251,15 @@ class AbstractTrainer(ABC):
         """
         self.config = config
         self.loss_fn = loss_fn
+
+        # Centralized rank-zero log suppression: on non-rank-0, raise the
+        # autograd logger family to WARNING. Every logger.info() across
+        # this package (trainer, optim, nn, ...) then auto-quiets without
+        # scattered `if rank() == 0:` guards at each call site. Only
+        # operations that aren't logging — file writes, the tqdm bar —
+        # still need an explicit rank check at their call site.
+        if rank() != 0:
+            logging.getLogger("autograd").setLevel(logging.WARNING)
         # `resume_epoch` is only a checkpoint lookup hint here. Runtime training
         # progress comes from the loaded checkpoint metadata, especially step_count.
         self.model, self.optimizer, self.checkpoint = self._load_model_and_optimizer(
@@ -334,6 +344,7 @@ class AbstractTrainer(ABC):
             initial=self.global_step,
             desc="Training",
             leave=False,
+            disable=rank() != 0,
         ) as progress_bar:
             while not plan.is_done(self.global_step):
                 train_data_loader.on_epoch_start()
@@ -458,10 +469,14 @@ class AbstractTrainer(ABC):
         if self.last_grad_l2_norm is not None:
             row["grad_l2_norm"] = self.last_grad_l2_norm
 
-        # Checkpointing is only checked when report() runs. checkpoint_every
-        # marks which reported steps may save; non-report steps are skipped.
-        if plan.should_checkpoint(self.global_step):
-            self._maybe_save_checkpoint(plan=plan, val_loss=metrics["val_loss"])
+        # File writes are rank-0-only under DDP (after AllReduce in step(),
+        # every rank holds identical params, so rank 0 is authoritative).
+        # Logging auto-quiets on non-rank-0 via the logger level set in __init__.
+        if rank() == 0:
+            if plan.should_checkpoint(self.global_step):
+                self._maybe_save_checkpoint(plan=plan, val_loss=metrics["val_loss"])
+            if plan.should_save_metrics(self.global_step):
+                self._save_metrics()
 
         self.metric_rows.append(row)
         log_payload = _format_log_values(
@@ -474,9 +489,6 @@ class AbstractTrainer(ABC):
             progress_value,
             _pformat_log_dict(log_payload),
         )
-
-        if plan.should_save_metrics(self.global_step):
-            self._save_metrics()
 
         state.reset_report()
 

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -26,8 +26,11 @@ from autograd.backend import (
 )
 from autograd.data.data_loader import DataLoader
 from autograd.distributed import (
+    ReduceOp,
     broadcast_optimizer_state,
     broadcast_parameters,
+    get_backend,
+    is_distributed,
     rank,
 )
 from autograd.tensor import Tensor, no_grad
@@ -510,6 +513,14 @@ class AbstractTrainer(ABC):
             return 0.0
         # Reporting is the GPU/accelerator-to-CPU sync boundary: training keeps
         # loss sums and token counts as backend scalars until logs/metrics need floats.
+        # DDP global loss must reduce numerator and denominator separately;
+        # averaging per-rank ratios is wrong for uneven batch weights.
+        if is_distributed() and self.config.log_global_loss:
+            backend = get_backend()
+            num_arr = xp.asarray(numerator, dtype=xp.float32)
+            den_arr = xp.asarray(denominator, dtype=xp.float32)
+            numerator = backend.all_reduce(num_arr, op=ReduceOp.SUM)
+            denominator = backend.all_reduce(den_arr, op=ReduceOp.SUM)
         numerator_value = xp.to_scalar(numerator)
         denominator_value = xp.to_scalar(denominator)
         return float(numerator_value) / max(float(denominator_value), 1.0)

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -24,7 +24,7 @@ from autograd.backend import (
     xp,
 )
 from autograd.data.data_loader import DataLoader
-from autograd.distributed import rank
+from autograd.distributed import check_bf16_capability, rank
 from autograd.tensor import Tensor, no_grad
 from autograd.tools.config_schema import (
     GenericTrainingConfig,
@@ -260,6 +260,10 @@ class AbstractTrainer(ABC):
         # still need an explicit rank check at their call site.
         if rank() != 0:
             logging.getLogger("autograd").setLevel(logging.WARNING)
+        # bf16 hardware gate. No-op for non-bf16 dtypes and non-CuPy
+        # backends; hard-fails on pre-Ampere CuPy so a misconfigured run
+        # surfaces immediately instead of going silently slow.
+        check_bf16_capability(config.model_kwargs.get("parameter_dtype"))
         # `resume_epoch` is only a checkpoint lookup hint here. Runtime training
         # progress comes from the loaded checkpoint metadata, especially step_count.
         self.model, self.optimizer, self.checkpoint = self._load_model_and_optimizer(

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -143,12 +143,154 @@ class TrainingState:
         self.report_loss_total_weight = xp.array(0.0, dtype=xp.float32)
         self.report_started_at_s = time.perf_counter()
 
-    def report_tokens_per_second(self, *, now_s: Optional[float] = None) -> float:
-        elapsed_s = (now_s or time.perf_counter()) - self.report_started_at_s
+    def report_tokens_per_second(
+        self,
+        total_weight: Array,
+        *,
+        now_s: Optional[float] = None,
+    ) -> float:
+        observed_now_s = time.perf_counter() if now_s is None else now_s
+        elapsed_s = observed_now_s - self.report_started_at_s
         if elapsed_s <= 0:
             return 0.0
-        token_count = xp.to_scalar(self.report_loss_total_weight)
-        return float(token_count) / elapsed_s
+        return float(xp.to_scalar(total_weight)) / elapsed_s
+
+    def report_eval_metric(
+        self,
+        *,
+        numerator: Array,
+        denominator: Array,
+    ) -> Optional[float]:
+        denominator_value = float(xp.to_scalar(denominator))
+        if denominator_value <= 0:
+            return None
+        return float(xp.to_scalar(numerator)) / denominator_value
+
+    def _weighted_mean(
+        self,
+        numerator: Optional[float | Array],
+        denominator: Array,
+    ) -> float:
+        if numerator is None:
+            return 0.0
+        numerator_value = xp.to_scalar(numerator)
+        denominator_value = xp.to_scalar(denominator)
+        return float(numerator_value) / max(float(denominator_value), 1.0)
+
+    def metrics_row(
+        self,
+        *,
+        eval_state: Optional["TrainingState"],
+        log_global_loss: bool,
+    ) -> dict[str, Optional[float]]:
+        metrics = self._agg_dist_metrics(
+            eval_state,
+            log_global_loss=log_global_loss,
+        )
+        row: dict[str, Optional[float]] = {
+            "train_loss": self._weighted_mean(
+                metrics["train_loss_sum"],
+                metrics["train_loss_total_weight"],
+            ),
+            "tokens_per_s": self.report_tokens_per_second(
+                metrics["tokens_total_weight"]
+            ),
+            "val_loss": None
+            if eval_state is None
+            else self._weighted_mean(
+                metrics["val_loss_sum"],
+                metrics["val_loss_total_weight"],
+            ),
+        }
+        if eval_state is not None:
+            for key, (numerator, denominator) in metrics["eval_metric_totals"].items():
+                metric_value = eval_state.report_eval_metric(
+                    numerator=numerator,
+                    denominator=denominator,
+                )
+                if metric_value is not None:
+                    row[f"val_{key}"] = metric_value
+        return row
+
+    def _agg_dist_metrics(
+        self,
+        eval_state: Optional["TrainingState"],
+        *,
+        log_global_loss: bool,
+    ) -> dict[str, Any]:
+        """Return report-ready additive metric totals, reduced across ranks.
+
+        `TrainingState` owns the raw counters: loss sums, token counts, and
+        eval metric numerators/denominators. In DDP, those counters are packed
+        into one vector and AllReduce-summed once, then unpacked back into the
+        same logical totals. `metrics_row` turns these totals into ratios.
+        """
+        train_loss_sum = self.report_loss_sum
+        train_loss_total_weight = self.report_loss_total_weight
+        tokens_total_weight = self.report_loss_total_weight
+        val_loss_sum = eval_state.eval_loss_sum if eval_state is not None else None
+        val_loss_total_weight = (
+            eval_state.eval_loss_total_weight if eval_state is not None else None
+        )
+        metric_keys = sorted(eval_state.eval_metric_totals) if eval_state else []
+        eval_metric_totals = {}
+        if eval_state is not None:
+            for key in metric_keys:
+                totals = eval_state.eval_metric_totals[key]
+                eval_metric_totals[key] = (
+                    xp.asarray(totals["numerator"], dtype=xp.float32),
+                    xp.asarray(totals["denominator"], dtype=xp.float32),
+                )
+
+        if is_distributed():
+            backend = get_backend()
+            values = [xp.asarray(tokens_total_weight, dtype=xp.float32)]
+            if log_global_loss:
+                values.extend(
+                    [
+                        xp.asarray(
+                            0.0 if train_loss_sum is None else train_loss_sum,
+                            dtype=xp.float32,
+                        ),
+                        xp.asarray(train_loss_total_weight, dtype=xp.float32),
+                    ]
+                )
+                if eval_state is not None:
+                    values.extend(
+                        [
+                            xp.asarray(val_loss_sum, dtype=xp.float32),
+                            xp.asarray(val_loss_total_weight, dtype=xp.float32),
+                        ]
+                    )
+            if eval_state is not None:
+                for key in metric_keys:
+                    values.extend(eval_metric_totals[key])
+            reduced = backend.all_reduce(
+                xp.stack(values),
+                op=ReduceOp.SUM,
+            )
+            tokens_total_weight = reduced[0]
+            offset = 1
+            if log_global_loss:
+                train_loss_sum = reduced[offset]
+                train_loss_total_weight = reduced[offset + 1]
+                offset += 2
+                if eval_state is not None:
+                    val_loss_sum = reduced[offset]
+                    val_loss_total_weight = reduced[offset + 1]
+                    offset += 2
+            for key in metric_keys:
+                eval_metric_totals[key] = (reduced[offset], reduced[offset + 1])
+                offset += 2
+
+        return {
+            "train_loss_sum": train_loss_sum,
+            "train_loss_total_weight": train_loss_total_weight,
+            "tokens_total_weight": tokens_total_weight,
+            "val_loss_sum": val_loss_sum,
+            "val_loss_total_weight": val_loss_total_weight,
+            "eval_metric_totals": eval_metric_totals,
+        }
 
     def has_enough_batches(self, accumulation_steps: int):
         return self.accumulated_batches >= accumulation_steps
@@ -472,7 +614,10 @@ class AbstractTrainer(ABC):
             plan.completed_epochs(self.global_step) if plan.by_epoch else None
         )
         progress_value = plan.progress_value(self.global_step)
-        metrics = self._metrics_row(state, eval_state=eval_state)
+        metrics = state.metrics_row(
+            eval_state=eval_state,
+            log_global_loss=self.config.log_global_loss,
+        )
         row: dict[str, Optional[float]] = {
             "epoch": completed_epochs,
             "step": float(self.global_step),
@@ -503,52 +648,6 @@ class AbstractTrainer(ABC):
         )
 
         state.reset_report()
-
-    def _weighted_mean(
-        self,
-        numerator: Optional[float | Array],
-        denominator: Array,
-    ) -> float:
-        if numerator is None:
-            return 0.0
-        # Reporting is the GPU/accelerator-to-CPU sync boundary: training keeps
-        # loss sums and token counts as backend scalars until logs/metrics need floats.
-        # DDP global loss must reduce numerator and denominator separately;
-        # averaging per-rank ratios is wrong for uneven batch weights.
-        if is_distributed() and self.config.log_global_loss:
-            backend = get_backend()
-            num_arr = xp.asarray(numerator, dtype=xp.float32)
-            den_arr = xp.asarray(denominator, dtype=xp.float32)
-            numerator = backend.all_reduce(num_arr, op=ReduceOp.SUM)
-            denominator = backend.all_reduce(den_arr, op=ReduceOp.SUM)
-        numerator_value = xp.to_scalar(numerator)
-        denominator_value = xp.to_scalar(denominator)
-        return float(numerator_value) / max(float(denominator_value), 1.0)
-
-    def _metrics_row(
-        self,
-        state: TrainingState,
-        *,
-        eval_state: Optional[TrainingState],
-    ) -> dict[str, Optional[float]]:
-        row: dict[str, Optional[float]] = {
-            "train_loss": self._weighted_mean(
-                state.report_loss_sum,
-                state.report_loss_total_weight,
-            ),
-            "tokens_per_s": state.report_tokens_per_second(),
-            "val_loss": None
-            if eval_state is None
-            else self._weighted_mean(
-                eval_state.eval_loss_sum,
-                eval_state.eval_loss_total_weight,
-            ),
-        }
-        if eval_state is not None:
-            for key, totals in eval_state.eval_metric_totals.items():
-                if totals["denominator"] > 0:
-                    row[f"val_{key}"] = totals["numerator"] / totals["denominator"]
-        return row
 
     def _loss_total_weight(self, _batch_data) -> Array:
         """Denominator for accumulated summed losses.
@@ -1144,6 +1243,7 @@ class LLMTrainer(AbstractTrainer):
         if state.eval_loss_batches == 0:
             raise ValueError("val_data_loader yielded no batches.")
 
-        for callback in self.eval_callbacks:
-            callback(self.model, self.forward_fn, val_data_loader, self.config)
+        if rank() == 0:
+            for callback in self.eval_callbacks:
+                callback(self.model, self.forward_fn, val_data_loader, self.config)
         return state

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -110,6 +110,18 @@ if ! uv "${SYNC_ARGS[@]}"; then
     exit 1
 fi
 
+# 4b. Verify NCCL is present in the CuPy build. Multi-GPU DDP
+# (`python -m autograd.distributed.launch`) needs it; single-GPU and
+# non-CuPy backends don't, so we warn rather than hard-fail.
+if [[ -n "$CUPY_EXTRA" ]]; then
+    if .venv/bin/python -c "import cupy.cuda.nccl as n; assert n.available" \
+        >/dev/null 2>&1; then
+        echo "OK: NCCL is available in CuPy."
+    else
+        echo "WARNING: CuPy installed without NCCL. Single-GPU works; multi-GPU DDP will fail at init."
+    fi
+fi
+
 # 5. Install PyTorch separately for unit test validation
 echo "Installing CPU-only PyTorch for test validation..."
 uv pip install torch --index-url https://download.pytorch.org/whl/cpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.12"
 dependencies = [
     "numpy",
     "mlx; platform_system == 'Darwin'",
+    "ml_dtypes",
     "openml",  # for dataset
     "pyarrow",
     "regex",

--- a/test/autograd/test_attention.py
+++ b/test/autograd/test_attention.py
@@ -141,6 +141,40 @@ class TestScaledDotProductAttention(TestCase):
         dense = self._run_attention("dense")
         assert allclose(dense.data, result.data, atol=1e-5, rtol=1e-5)
 
+    def test_dense_attention_preserves_low_precision_dtype_without_explicit_fp32_inputs(
+        self,
+    ):
+        dtype = getattr(xp, "bfloat16", getattr(xp, "float16", None))
+        if dtype is None:
+            self.skipTest("backend has no low-precision float dtype")
+
+        query = Tensor(xp.random.normal(shape=(1, 2, 3, 4)).astype(dtype))
+        key = Tensor(xp.random.normal(shape=(1, 2, 3, 4)).astype(dtype))
+        value = Tensor(xp.random.normal(shape=(1, 2, 3, 4)).astype(dtype))
+        attention = self._make_attention()
+
+        with self._implementation_context("dense"):
+            output = attention(query, key, value)
+
+        self.assertEqual(output.data.dtype, dtype)
+
+    def test_dense_causal_attention_preserves_low_precision_dtype_without_explicit_fp32_inputs(
+        self,
+    ):
+        dtype = getattr(xp, "bfloat16", getattr(xp, "float16", None))
+        if dtype is None:
+            self.skipTest("backend has no low-precision float dtype")
+
+        query = Tensor(xp.random.normal(shape=(1, 2, 3, 4)).astype(dtype))
+        key = Tensor(xp.random.normal(shape=(1, 2, 3, 4)).astype(dtype))
+        value = Tensor(xp.random.normal(shape=(1, 2, 3, 4)).astype(dtype))
+        attention = self._make_attention()
+
+        with self._implementation_context("dense"):
+            output = attention(query, key, value, is_causal=True)
+
+        self.assertEqual(output.data.dtype, dtype)
+
     def test_mlx_custom_falls_back_to_dense_for_reverse_causal_mask(self):
         mask = Tensor(
             create_causal_mask(

--- a/test/autograd/test_backend.py
+++ b/test/autograd/test_backend.py
@@ -63,7 +63,11 @@ def _fake_cupy_module(device_count: int):
         float16=np.float16,
         random=random,
         cuda=SimpleNamespace(
-            runtime=SimpleNamespace(getDeviceCount=lambda: device_count)
+            runtime=SimpleNamespace(getDeviceCount=lambda: device_count),
+            # autograd/backend.py calls `xp.cuda.Device(LOCAL_RANK).use()`
+            # at import for DDP device pinning; the fake needs a no-op
+            # stand-in or the import-time pin raises.
+            Device=lambda _idx: SimpleNamespace(use=lambda: None),
         ),
         asnumpy=np.asarray,
     )
@@ -78,6 +82,46 @@ def test_scatter_add_accumulates_repeated_indices():
 
     assert np.array_equal(xp.to_numpy(dst), np.array([0.0, 0.0, 0.0], dtype=np.float32))
     assert np.array_equal(xp.to_numpy(out), np.array([0.0, 5.0, 0.0], dtype=np.float32))
+
+
+def test_scatter_add_accumulates_cupy_bfloat16_via_float32(monkeypatch):
+    import autograd.backend as backend
+
+    class FakeArray:
+        def __init__(self, values, dtype):
+            self.values = np.asarray(values, dtype=np.float32)
+            self.dtype = dtype
+
+        def astype(self, dtype):
+            return FakeArray(self.values, dtype)
+
+    class FakeAdd:
+        @staticmethod
+        def at(out, idx, updates):
+            if out.dtype == "bfloat16":
+                raise TypeError("cupy.add.at does not support bfloat16")
+            np.add.at(out.values, idx, updates.values)
+
+    class FakeXP:
+        float32 = "float32"
+        add = FakeAdd()
+
+        @staticmethod
+        def array(value):
+            return FakeArray(value.values.copy(), value.dtype)
+
+    monkeypatch.setattr(backend, "IS_MLX", False)
+    monkeypatch.setattr(backend, "IS_CUPY", True)
+    monkeypatch.setattr(backend, "LOW_PRECISION_FLOAT_DTYPES", ("bfloat16",))
+    monkeypatch.setattr(backend, "xp", FakeXP())
+
+    dst = FakeArray([0.0, 0.0, 0.0], "bfloat16")
+    updates = FakeArray([2.0, 3.0], "bfloat16")
+
+    out = backend._scatter_add(dst, [1, 1], updates)
+
+    assert out.dtype == "bfloat16"
+    assert np.array_equal(out.values, np.array([0.0, 5.0, 0.0], dtype=np.float32))
 
 
 def test_materialize_collects_nested_arrays_and_tensor_data(monkeypatch):
@@ -164,6 +208,36 @@ def test_random_bernoulli_returns_binary_mask():
     values = set(np.unique(xp.to_numpy(out)).tolist())
 
     assert values.issubset({0, 1, False, True})
+
+
+def test_sample_categorical_passes_scalar_size_to_choice(monkeypatch):
+    import autograd.backend as backend
+
+    observed = {}
+
+    def fake_choice(a, size=None, replace=True, p=None):
+        observed["a"] = a
+        observed["size"] = size
+        observed["replace"] = replace
+        observed["p"] = p
+        return np.asarray(1)
+
+    fake_xp = SimpleNamespace(
+        exp=np.exp,
+        max=np.max,
+        sum=np.sum,
+    )
+    monkeypatch.setattr(backend, "xp", fake_xp)
+    monkeypatch.setitem(backend._native_random_fns, "categorical", None)
+    monkeypatch.setitem(backend._native_random_fns, "choice", fake_choice)
+
+    out = backend._sample_categorical(np.asarray([0.0, 1.0, 2.0]))
+
+    assert int(out) == 1
+    assert observed["a"] == 3
+    assert observed["size"] == ()
+    assert observed["replace"] is True
+    assert np.isclose(observed["p"].sum(), 1.0)
 
 
 def test_active_backend_random_state_round_trip_replays_sample():

--- a/test/autograd/test_backend.py
+++ b/test/autograd/test_backend.py
@@ -73,6 +73,20 @@ def _fake_cupy_module(device_count: int):
     )
 
 
+def test_seed_env_initializes_backend_and_host_rng(monkeypatch):
+    monkeypatch.setenv("SEED", "123")
+    module = _load_backend_module(monkeypatch, env_backend="numpy")
+
+    got_backend = module.xp.random.randint(0, 1000, size=5)
+    got_host = np.random.randint(0, 1000, size=5)
+
+    np.random.seed(123)
+    expected_backend = np.random.randint(0, 1000, size=5)
+    expected_host = np.random.randint(0, 1000, size=5)
+    assert np.array_equal(got_backend, expected_backend)
+    assert np.array_equal(got_host, expected_host)
+
+
 def test_scatter_add_accumulates_repeated_indices():
     dst = xp.zeros(3, dtype=xp.float32)
     idx = [1, 1]

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -137,6 +137,23 @@ class TestOptimizer(TestCase):
             xp.array([1.5, 2.0], dtype=xp.float32),
         )
 
+    def test_scale_gradients_preserves_low_precision_gradient_dtype(self):
+        dtype = getattr(xp, "bfloat16", getattr(xp, "float16", None))
+        if dtype is None:
+            self.skipTest("backend has no low-precision float dtype")
+
+        param = Tensor(xp.array([1.0, -2.0], dtype=dtype))
+        param.grad = xp.array([2.0, -4.0], dtype=dtype)
+        optimizer = Optimizer({"param": param}, lr=0.01)
+
+        optimizer.scale_gradients(xp.array(0.5, dtype=xp.float32))
+
+        self.assertEqual(param.grad.data.dtype, dtype)
+        assert allclose(
+            param.grad.data.astype(xp.float32),
+            xp.array([1.0, -2.0], dtype=xp.float32),
+        )
+
     def test_grad_l2_norm_matches_expected_value(self):
         self.params["param1"].grad = Tensor(xp.array([3.0, 4.0], dtype=xp.float32))
         self.params["param2"].grad = Tensor(xp.array([12.0], dtype=xp.float32))

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -437,6 +437,46 @@ class TestTensorOps(TestTensor):
         assert allclose(x.grad.data, x_torch.grad.numpy(), rtol=1e-4, atol=1e-5)
         assert allclose(w.grad.data, w_torch.grad.numpy(), rtol=1e-4, atol=1e-5)
 
+    def test_batched_input_2d_weight_matmul_uses_2d_matmul_contract(self):
+        batch_size, seq_len, hidden_size, vocab_size = 2, 3, 4, 5
+        x = Tensor(
+            xp.random.normal(shape=(batch_size, seq_len, hidden_size)).astype(
+                xp.float32
+            ),
+            requires_grad=True,
+        )
+        w = Tensor(
+            xp.random.normal(shape=(hidden_size, vocab_size)).astype(xp.float32),
+            requires_grad=True,
+        )
+
+        matmul_calls = []
+        original_matmul = xp.matmul
+
+        def recording_matmul(lhs, rhs):
+            matmul_calls.append((lhs.shape, rhs.shape))
+            return original_matmul(lhs, rhs)
+
+        with patch("autograd.tensor.xp.matmul", side_effect=recording_matmul):
+            z = x @ w
+            z.backward(xp.ones_like(z.data))
+
+        assert z.shape == (batch_size, seq_len, vocab_size)
+        assert matmul_calls == [
+            ((batch_size * seq_len, hidden_size), (hidden_size, vocab_size)),
+            ((batch_size * seq_len, vocab_size), (vocab_size, hidden_size)),
+            ((hidden_size, batch_size * seq_len), (batch_size * seq_len, vocab_size)),
+        ]
+
+        x_torch = torch.tensor(x.data, requires_grad=True)
+        w_torch = torch.tensor(w.data, requires_grad=True)
+        z_torch = x_torch @ w_torch
+        z_torch.backward(torch.ones_like(z_torch))
+
+        assert allclose(z.data, z_torch.detach().numpy(), rtol=1e-4, atol=1e-5)
+        assert allclose(x.grad.data, x_torch.grad.numpy(), rtol=1e-4, atol=1e-5)
+        assert allclose(w.grad.data, w_torch.grad.numpy(), rtol=1e-4, atol=1e-5)
+
     def test_batch_multiplication(self):
         """Test element-wise multiplication with batched tensors"""
         result = self.batch_tensor1 * self.batch_tensor2

--- a/test/autograd/text/test_tokenizer.py
+++ b/test/autograd/text/test_tokenizer.py
@@ -76,6 +76,20 @@ class TestTokenizer(TestCase):
             self.assertEqual(encoded, [expected_id])
             self.assertEqual(self.bpe.decode(encoded), special_token)
 
+    def test_encode_reuses_cached_non_special_chunks(self):
+        text = "repeat repeat repeat repeat"
+
+        self.bpe._encoded_chunk_cache.clear()
+        first = self.bpe.encode(text)
+        # Distinct pretokenized chunks: "repeat" and " repeat".
+        cached_after_first = dict(self.bpe._encoded_chunk_cache)
+        second = self.bpe.encode(text)
+
+        self.assertEqual(first, second)
+        self.assertEqual(self.bpe.decode(second), text)
+        self.assertEqual(len(cached_after_first), 2)
+        self.assertEqual(dict(self.bpe._encoded_chunk_cache), cached_after_first)
+
     def test_load_dictionary_fallback(self):
         with open(self.bpe.vocab_file_path, "wb") as f:
             f.write(b"\x80\x03}q\x00.")  # incomplete or invalid pickle data
@@ -137,7 +151,7 @@ class TestTokenizer(TestCase):
 
             full_bpe.train_vocabulary([full_text], overwrite_saved_file=True)
             stream_bpe.train_vocabulary(iter(docs), overwrite_saved_file=True)
-            mmap_path = stream_bpe.encode_to_mmap(
+            mmap_path = stream_bpe._encode_to_mmap(
                 docs,
                 overwrite_encoded_data=True,
                 text_batch_size=2,
@@ -152,7 +166,7 @@ class TestTokenizer(TestCase):
             )
             self.assertEqual(full_bpe.encode(full_text), list(stream_encoded))
 
-    def test_encode_to_mmap_writes_direct_npy_memmap(self):
+    def test_prepare_data_writes_direct_npy_memmap(self):
         docs = ["hello<|endoftext|>", "world<|endoftext|>"]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -163,19 +177,25 @@ class TestTokenizer(TestCase):
                 n_workers=1,
             )
             bpe.train_vocabulary(docs, overwrite_saved_file=True)
+            stale_raw_tmp = f"{bpe.mmap_path}.raw.tmp"
+            with open(stale_raw_tmp, "wb") as f:
+                f.write(b"stale temp file")
 
             with patch(
                 "autograd.text.tokenizer.np.lib.format.write_array",
-                side_effect=AssertionError("encode_to_mmap should not copy raw data"),
+                side_effect=AssertionError("prepare_data should not copy raw data"),
             ):
-                mmap_path = bpe.encode_to_mmap(docs, overwrite_encoded_data=True)
+                encoded = bpe.prepare_data(
+                    docs,
+                    overwrite_vocabulary_file=False,
+                    overwrite_encoded_data=True,
+                )
 
-            encoded = np.load(mmap_path, mmap_mode="r")
             self.assertEqual(bpe.encode("".join(docs)), list(encoded))
             self.assertFalse(os.path.exists(f"{bpe.mmap_path}.raw.tmp"))
             self.assertFalse(os.path.exists(f"{bpe.mmap_path}.tmp"))
 
-    def test_encode_to_mmap_checks_disk_space_before_writing(self):
+    def test_prepare_data_checks_disk_space_before_writing(self):
         docs = ["hello<|endoftext|>"]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -191,10 +211,52 @@ class TestTokenizer(TestCase):
             with patch("autograd.text.tokenizer.shutil.disk_usage") as mock_disk_usage:
                 mock_disk_usage.return_value = disk_usage
                 with self.assertRaisesRegex(OSError, "Insufficient disk space"):
-                    bpe.encode_to_mmap(docs, overwrite_encoded_data=True)
+                    bpe.prepare_data(
+                        docs,
+                        overwrite_vocabulary_file=False,
+                        overwrite_encoded_data=True,
+                    )
 
             self.assertFalse(os.path.exists(bpe.mmap_path))
             self.assertFalse(os.path.exists(f"{bpe.mmap_path}.tmp"))
+
+    def test_count_encoded_tokens_uses_unordered_worker_results(self):
+        class RecordingPool:
+            calls = []
+
+            def __init__(self, _n_workers):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            def imap(self, fn, batches):
+                self.calls.append("imap")
+                return map(fn, batches)
+
+            def imap_unordered(self, fn, batches):
+                self.calls.append("imap_unordered")
+                return map(fn, batches)
+
+        docs = ["aa", "bbb", "c"]
+        self.bpe.n_workers = 2
+
+        with patch("autograd.text.tokenizer.Pool", RecordingPool):
+            token_count = self.bpe._count_encoded_tokens(docs, text_batch_size=1)
+            list(
+                self.bpe._iter_encoded_batches(
+                    docs,
+                    text_batch_size=1,
+                    desc="ordered",
+                    preserve_order=True,
+                )
+            )
+
+        self.assertEqual(token_count, sum(len(self.bpe.encode(doc)) for doc in docs))
+        self.assertEqual(RecordingPool.calls, ["imap_unordered", "imap"])
 
     def test_encode_roundtrips(self):
         text = "hello world"

--- a/test/autograd/tools/test_config_schema.py
+++ b/test/autograd/tools/test_config_schema.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
+from autograd import distributed as dist
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
+from test.distributed.mock import MockBackend, MockComm
 
 
 class TestTransformerTrainingConfig(TestCase):
@@ -63,3 +65,55 @@ class TestTransformerTrainingConfig(TestCase):
         )
 
         self.assertEqual(config.gradient_accumulation_steps, 8)
+
+    def test_rejects_global_batch_size_not_divisible_by_distributed_world_size(self):
+        dist._set_thread_local_rank(
+            rank_=0,
+            world_size_=3,
+            local_rank_=0,
+            backend=MockBackend(MockComm(3), 0),
+        )
+        try:
+            with self.assertRaisesRegex(
+                ValueError,
+                r"global_batch_size \(144\) must be divisible by "
+                r"micro_batch_size \* world_size \(9 \* 3 = 27\)",
+            ):
+                TransformerTrainingConfig(
+                    training_run_name="test",
+                    dataset_name="dataset",
+                    max_steps=5,
+                    checkpoint_freq=5,
+                    global_batch_size=144,
+                    micro_batch_size=9,
+                    model_kwargs={},
+                    optimizer_kwargs={"lr": 1e-3},
+                    label_smoothing=0.0,
+                    teacher_forcing=False,
+                )
+        finally:
+            dist._clear_thread_local()
+
+    def test_allows_global_batch_size_divisible_by_distributed_world_size(self):
+        dist._set_thread_local_rank(
+            rank_=0,
+            world_size_=4,
+            local_rank_=0,
+            backend=MockBackend(MockComm(4), 0),
+        )
+        try:
+            config = TransformerTrainingConfig(
+                training_run_name="test",
+                dataset_name="dataset",
+                max_steps=5,
+                checkpoint_freq=5,
+                global_batch_size=144,
+                micro_batch_size=9,
+                model_kwargs={},
+                optimizer_kwargs={"lr": 1e-3},
+                label_smoothing=0.0,
+                teacher_forcing=False,
+            )
+            self.assertEqual(config.gradient_accumulation_steps, 4)
+        finally:
+            dist._clear_thread_local()

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from autograd.backend import xp
+from autograd.backend import IS_MLX, xp
 from autograd.data.collator import FixedLengthCausalLMCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import MapDataset, PairedMapDataset
@@ -26,6 +26,7 @@ from autograd.tools.trainer import (
     TrainingPlan,
     TrainingState,
 )
+from test.distributed.mock import run_mock_ranks
 
 
 def identity_collate(batch_items):
@@ -400,7 +401,10 @@ class TestSimpleTrainer(BaseTrainerTest):
         eval_state.record_eval_metric("accuracy", numerator=3, denominator=4)
 
         with patch("autograd.tools.trainer.time.perf_counter", return_value=11.0):
-            row = self.trainer._metrics_row(state, eval_state=eval_state)
+            row = state.metrics_row(
+                eval_state=eval_state,
+                log_global_loss=self.trainer.config.log_global_loss,
+            )
 
         self.assertEqual(
             row,
@@ -411,6 +415,50 @@ class TestSimpleTrainer(BaseTrainerTest):
                 "val_accuracy": 0.75,
             },
         )
+
+    @unittest.skipIf(
+        IS_MLX,
+        "MLX lazy graphs are not thread-safe under the in-process DDP mock.",
+    )
+    def test_metrics_row_reports_global_tokens_per_second_under_ddp(self):
+        from autograd.distributed import rank
+
+        def target():
+            state = TrainingState()
+            state.report_started_at_s = 10.0
+            token_count = xp.array(float(rank() + 1), dtype=xp.float32)
+            state.record_loss(1.0, total_weight=token_count)
+            with patch("autograd.tools.trainer.time.perf_counter", return_value=11.0):
+                return state.metrics_row(
+                    eval_state=None,
+                    log_global_loss=self.trainer.config.log_global_loss,
+                )["tokens_per_s"]
+
+        results = run_mock_ranks(2, target)
+        self.assertEqual(results, [3.0, 3.0])
+
+    @unittest.skipIf(
+        IS_MLX,
+        "MLX lazy graphs are not thread-safe under the in-process DDP mock.",
+    )
+    def test_metrics_row_reports_global_eval_metric_under_ddp(self):
+        from autograd.distributed import rank
+
+        def target():
+            eval_state = TrainingState()
+            eval_state.record_eval_metric(
+                "accuracy",
+                numerator=float(rank() + 1),
+                denominator=2.0,
+            )
+            row = TrainingState().metrics_row(
+                eval_state=eval_state,
+                log_global_loss=self.trainer.config.log_global_loss,
+            )
+            return row["val_accuracy"]
+
+        results = run_mock_ranks(2, target)
+        self.assertEqual(results, [0.75, 0.75])
 
     def test_training_state_resets_report_timer(self):
         state = TrainingState()
@@ -432,6 +480,19 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         self.assertEqual(float(xp.to_scalar(state.report_loss_total_weight)), 1.0)
         self.assertEqual(float(xp.to_scalar(state.eval_loss_total_weight)), 1.0)
+
+    def test_training_state_tokens_per_second_honors_explicit_zero_time(self):
+        state = TrainingState()
+        state.report_started_at_s = -2.0
+        state.record_loss(1.0, total_weight=xp.array(4.0, dtype=xp.float32))
+
+        self.assertEqual(
+            state.report_tokens_per_second(
+                xp.array(4.0, dtype=xp.float32),
+                now_s=0.0,
+            ),
+            2.0,
+        )
 
     def test_training_boundaries_are_direct_materialize_calls(self):
         self.assertFalse(hasattr(TrainingState, "eval_accumulators"))
@@ -1527,7 +1588,10 @@ class TestSimpleTrainer(BaseTrainerTest):
         val_loader = make_data_loader(self.val_data * 2)
 
         eval_state = self.trainer.evaluate(val_loader)
-        row = self.trainer._metrics_row(TrainingState(), eval_state=eval_state)
+        row = TrainingState().metrics_row(
+            eval_state=eval_state,
+            log_global_loss=self.trainer.config.log_global_loss,
+        )
 
         self.assertAlmostEqual(row["val_loss"], 1.23, places=5)
         self.assertEqual(self.loss_fn.call_count, 2)
@@ -1537,7 +1601,10 @@ class TestSimpleTrainer(BaseTrainerTest):
         val_loader = make_data_loader(self.val_data * 2)
 
         eval_state = self.trainer.evaluate(val_loader)
-        row = self.trainer._metrics_row(TrainingState(), eval_state=eval_state)
+        row = TrainingState().metrics_row(
+            eval_state=eval_state,
+            log_global_loss=self.trainer.config.log_global_loss,
+        )
 
         self.assertAlmostEqual(row["val_loss"], 1.23, places=5)
         self.assertEqual(self.loss_fn.call_count, 1)
@@ -1576,7 +1643,10 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         eval_result = self.trainer.evaluate(self.val_loader)
 
-        row = self.trainer._metrics_row(TrainingState(), eval_state=eval_result)
+        row = TrainingState().metrics_row(
+            eval_state=eval_result,
+            log_global_loss=self.trainer.config.log_global_loss,
+        )
         self.assertAlmostEqual(row["val_loss"], 1.23, places=5)
 
     def test_report_prefixes_eval_metrics_with_val(self):
@@ -1690,7 +1760,10 @@ class TestSimpleTrainer(BaseTrainerTest):
 
     def test_evaluate_does_not_mutate_trainer_metrics(self):
         eval_result = self.trainer.evaluate(self.val_loader)
-        row = self.trainer._metrics_row(TrainingState(), eval_state=eval_result)
+        row = TrainingState().metrics_row(
+            eval_state=eval_result,
+            log_global_loss=self.trainer.config.log_global_loss,
+        )
 
         self.assertAlmostEqual(row["val_loss"], 1.23, places=5)
         self.assertEqual(row["val_accuracy"], 1.0)
@@ -1860,13 +1933,36 @@ class TestLLMTrainer(BaseTrainerTest):
         )
 
         eval_state = trainer.evaluate(self.val_loader)
-        row = trainer._metrics_row(TrainingState(), eval_state=eval_state)
+        row = TrainingState().metrics_row(
+            eval_state=eval_state,
+            log_global_loss=trainer.config.log_global_loss,
+        )
 
         self.assertAlmostEqual(row["val_loss"], 1.23, places=5)
         self.assertNotIn("val_accuracy", row)
         callback.assert_called_once_with(
             trainer.model, trainer.forward_fn, self.val_loader, trainer.config
         )
+
+    @unittest.skipIf(
+        IS_MLX,
+        "MLX lazy graphs are not thread-safe under the in-process DDP mock.",
+    )
+    def test_evaluate_runs_eval_callbacks_only_on_rank_zero_under_ddp(self):
+        def target():
+            callback = MagicMock()
+            trainer = LLMTrainer(
+                model_cls=MockModelClass,
+                optimizer_cls=MockOptimizerClass,
+                loss_fn=self.loss_fn,
+                forward_fn=self.forward_fn,
+                config=self.config,
+                eval_callbacks=[callback],
+            )
+            trainer.evaluate(self.val_loader)
+            return callback.call_count
+
+        self.assertEqual(run_mock_ranks(2, target), [1, 0])
 
     def test_llm_evaluate_rejects_empty_val_loader(self):
         with self.assertRaisesRegex(
@@ -1880,7 +1976,10 @@ class TestLLMTrainer(BaseTrainerTest):
         val_loader = make_data_loader(self.val_data * 2)
 
         eval_state = self.trainer.evaluate(val_loader)
-        row = self.trainer._metrics_row(TrainingState(), eval_state=eval_state)
+        row = TrainingState().metrics_row(
+            eval_state=eval_state,
+            log_global_loss=self.trainer.config.log_global_loss,
+        )
 
         self.assertAlmostEqual(row["val_loss"], 1.23, places=5)
         self.assertEqual(self.loss_fn.call_count, 1)
@@ -1944,7 +2043,10 @@ class TestLLMTrainer(BaseTrainerTest):
 
         train_loss = trainer._forward_and_loss(batch)
         eval_state = trainer.evaluate(loader)
-        row = trainer._metrics_row(TrainingState(), eval_state=eval_state)
+        row = TrainingState().metrics_row(
+            eval_state=eval_state,
+            log_global_loss=trainer.config.log_global_loss,
+        )
 
         self.assertAlmostEqual(
             float(train_loss.item()), float(expected_train_loss.item()), places=6

--- a/test/distributed/mock.py
+++ b/test/distributed/mock.py
@@ -51,6 +51,14 @@ def _snapshot(buf: Any) -> Any:
     re-constructed via `xp.array(buf)`. We use this in MockComm so the
     rendezvous keeps a stable snapshot even if the caller mutates `buf`
     after publishing it (e.g. AllReduce writing the result back in-place).
+
+    Caveat: MLX lazy graphs aren't safe to evaluate across threads. If a
+    caller forces materialization (e.g. `xp.to_scalar`) on a freshly-
+    AllReduced MLX array inside a rank-thread, the cross-thread `xp.eval`
+    can segfault. Callers that scalarize results inline (e.g. trainer
+    loss reporting) should either run those tests on numpy or skip them
+    on MLX. Production DDP runs one process per rank so this is a
+    mock-only concern.
     """
     if hasattr(buf, "copy"):
         return buf.copy()

--- a/test/distributed/mock.py
+++ b/test/distributed/mock.py
@@ -1,0 +1,238 @@
+"""
+In-process threading-based mock backend for DDP correctness tests.
+
+This module lives under `test/` because it is test infrastructure, not
+production code: it lets us exercise the AllReduce / broadcast / barrier
+code paths without spawning real NCCL processes or holding a multi-GPU
+box. Each "rank" is one Python thread; the shared `MockComm` synchronizes
+them through a `threading.Barrier`.
+
+TODO(phase-2-cleanup): once real NCCL is wired in
+`autograd.distributed._make_backend`, the multi-rank tests
+(`test_allreduce.py`, `test_ddp_equivalence.py`) can spawn real processes
+via the launcher and consume the real backend. At that point delete this
+file entirely along with the thread-local plumbing in
+`autograd/distributed.py`.
+
+Usage from a test:
+
+    from test.distributed.mock import run_mock_ranks
+
+    def per_rank(...):
+        ...   # this runs in a thread; rank()/world_size() reflect the thread
+
+    run_mock_ranks(world_size=2, target=per_rank)
+
+`run_mock_ranks` blocks until every rank finishes, and re-raises the first
+exception observed. Exceptions abort the rendezvous so a misbehaving rank
+cannot deadlock the others.
+
+The real comm group lives in `autograd.distributed`; this module wires
+per-thread rank/world_size into that module's thread-local hooks
+(`_set_thread_local_rank` / `_clear_thread_local`) so production-side
+helpers like `is_distributed()` / `rank()` see per-rank values without
+needing to be aware of the test harness.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable
+
+from autograd import distributed as _dist
+from autograd.backend import xp
+from autograd.distributed import ReduceOp
+
+
+def _snapshot(buf: Any) -> Any:
+    """Backend-agnostic array copy.
+
+    NumPy/CuPy arrays expose `.copy()`; MLX arrays do not but can be
+    re-constructed via `xp.array(buf)`. We use this in MockComm so the
+    rendezvous keeps a stable snapshot even if the caller mutates `buf`
+    after publishing it (e.g. AllReduce writing the result back in-place).
+    """
+    if hasattr(buf, "copy"):
+        return buf.copy()
+    return xp.array(buf)
+
+
+class MockComm:
+    """Shared rendezvous state for one mock comm group.
+
+    Threads coordinate through a single `threading.Barrier`. The result of
+    each collective is computed by rank 0 (or by the broadcaster's writer)
+    and dropped into a shared slot the other ranks read from.
+
+    A `BrokenBarrierError` from any wait() means another rank has aborted;
+    we surface it as a RuntimeError so tests get a useful traceback instead
+    of a confusing "broken barrier" message.
+    """
+
+    def __init__(self, world_size: int) -> None:
+        if world_size < 1:
+            raise ValueError(f"world_size must be >= 1, got {world_size}")
+        self.world_size = world_size
+        self._barrier = threading.Barrier(world_size)
+        # AllReduce slots: each rank deposits, rank 0 reduces, all read.
+        self._allreduce_inputs: list[Any] = [None] * world_size
+        self._allreduce_result: Any = None
+        # Broadcast slot: src deposits, others read.
+        self._broadcast_value: Any = None
+
+    def _sync(self) -> None:
+        try:
+            self._barrier.wait()
+        except threading.BrokenBarrierError as exc:
+            raise RuntimeError(
+                "MockComm barrier broken — another rank likely failed."
+            ) from exc
+
+    def all_reduce(self, rank_: int, buf: Any, op: str) -> Any:
+        # Each rank publishes a snapshot of its input. We snapshot because
+        # the caller may rebind or mutate `buf` after we return; rank 0
+        # reads from these snapshots to compute the reduction.
+        self._allreduce_inputs[rank_] = _snapshot(buf)
+        self._sync()
+
+        if rank_ == 0:
+            if op != ReduceOp.SUM:
+                raise NotImplementedError(f"MockComm only implements SUM; got {op!r}")
+            result = _snapshot(self._allreduce_inputs[0])
+            for r in range(1, self.world_size):
+                result = result + self._allreduce_inputs[r]
+            self._allreduce_result = result
+        self._sync()
+
+        # Hand each rank its own snapshot so per-thread downstream
+        # mutations (e.g. an in-place divide) cannot race.
+        out = _snapshot(self._allreduce_result)
+        self._sync()
+
+        # Rank 0 clears the rendezvous state, then everyone syncs again
+        # before returning. Without this final barrier, rank 1 can race
+        # ahead into its next all_reduce and publish before rank 0 has
+        # cleared the previous slots — wiping the new input.
+        if rank_ == 0:
+            self._allreduce_inputs = [None] * self.world_size
+            self._allreduce_result = None
+        self._sync()
+        return out
+
+    def broadcast(self, rank_: int, buf: Any, from_rank: int) -> Any:
+        if not (0 <= from_rank < self.world_size):
+            raise ValueError(
+                f"from_rank must be in [0, {self.world_size}), got {from_rank}"
+            )
+        if rank_ == from_rank:
+            self._broadcast_value = _snapshot(buf)
+        self._sync()
+
+        out = _snapshot(self._broadcast_value)
+        self._sync()
+
+        # Same final-barrier rationale as all_reduce: the broadcaster
+        # clears the slot only after everyone has snapshotted, then we
+        # barrier so the next call cannot publish into a half-cleared slot.
+        if rank_ == from_rank:
+            self._broadcast_value = None
+        self._sync()
+        return out
+
+    def barrier(self) -> None:
+        self._sync()
+
+
+class MockBackend:
+    """Per-thread `Backend` implementation bound to one rank of a `MockComm`.
+
+    Each thread spawned by `run_mock_ranks` gets its own `MockBackend`; all
+    instances in the group share the same `MockComm`. The split lets
+    `Backend.rank` be a simple attribute instead of a thread-local lookup.
+    """
+
+    def __init__(self, comm: MockComm, rank_: int) -> None:
+        if not (0 <= rank_ < comm.world_size):
+            raise ValueError(f"rank must be in [0, {comm.world_size}), got {rank_}")
+        self.comm = comm
+        self._rank = rank_
+
+    @property
+    def world_size(self) -> int:
+        return self.comm.world_size
+
+    @property
+    def rank(self) -> int:
+        return self._rank
+
+    def all_reduce(self, buf: Any, op: str = ReduceOp.SUM) -> Any:
+        return self.comm.all_reduce(self._rank, buf, op)
+
+    def broadcast(self, buf: Any, from_rank: int) -> Any:
+        return self.comm.broadcast(self._rank, buf, from_rank)
+
+    def barrier(self) -> None:
+        self.comm.barrier()
+
+    def teardown(self) -> None:
+        # Threads have no external resources to release. We could poison
+        # the shared state to make accidental reuse fail loudly, but tests
+        # already create a fresh MockComm per call.
+        pass
+
+
+def run_mock_ranks(
+    world_size: int,
+    target: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> list[Any]:
+    """Spawn `world_size` threads, each running `target(*args, **kwargs)`.
+
+    Each thread is installed as a distinct rank with its own `MockBackend`,
+    so calls to `autograd.distributed.rank()`/`world_size()` inside the
+    target observe per-rank values rather than the process-wide env defaults.
+
+    Returns the list of per-rank results in rank order. The first exception
+    raised by any rank is re-raised after all threads have joined.
+    """
+    if world_size < 1:
+        raise ValueError(f"world_size must be >= 1, got {world_size}")
+
+    comm = MockComm(world_size)
+    results: list[Any] = [None] * world_size
+    errors: list[BaseException | None] = [None] * world_size
+
+    def _runner(rank_: int) -> None:
+        backend = MockBackend(comm, rank_)
+        _dist._set_thread_local_rank(
+            rank_=rank_,
+            world_size_=world_size,
+            local_rank_=rank_,
+            backend=backend,
+        )
+        try:
+            results[rank_] = target(*args, **kwargs)
+        except BaseException as exc:  # noqa: BLE001 — re-raised below
+            errors[rank_] = exc
+            # Abort the rendezvous so peers waiting on a barrier wake up
+            # instead of deadlocking. Other ranks will see BrokenBarrier
+            # and re-raise via MockComm._sync.
+            comm._barrier.abort()
+        finally:
+            _dist._clear_thread_local()
+
+    threads = [
+        threading.Thread(target=_runner, args=(r,), name=f"mock-rank-{r}")
+        for r in range(world_size)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for exc in errors:
+        if exc is not None:
+            raise exc
+
+    return results

--- a/test/distributed/smoke_ddp_cupy.py
+++ b/test/distributed/smoke_ddp_cupy.py
@@ -1,0 +1,96 @@
+"""End-to-end Phase 1 smoke on CuPy: tiny model trained under 2-rank mock
+DDP must reach the same final params as a single-rank baseline using the
+full global batch.
+
+Not a pytest test — invoked as a module so relative imports work:
+
+    AUTOGRAD_BACKEND=cupy .venv/bin/python -m test.distributed.smoke_ddp_cupy
+
+This complements the in-tree pytest equivalence test by exercising real
+CuPy buffers (not just numpy arrays in threads) through the same
+hooks.allreduce_grads / broadcast_parameters code path that the real
+NCCL backend will hit in Phase 2.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from autograd import optim
+from autograd.backend import xp
+from autograd.tensor import Tensor
+
+from .mock import run_mock_ranks
+
+
+def _make_problem(seed: int = 42, n: int = 16, dim: int = 4):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, dim)).astype(np.float32)
+    true_w = rng.standard_normal((dim, 1)).astype(np.float32)
+    y = X @ true_w + 0.1 * rng.standard_normal((n, 1)).astype(np.float32)
+    return X, y
+
+
+def _mse_loss(W: Tensor, X, y) -> Tensor:
+    X_t = Tensor(xp.asarray(X))
+    y_t = Tensor(xp.asarray(y))
+    pred = X_t @ W
+    diff = pred - y_t
+    return (diff * diff).sum() / X.shape[0]
+
+
+def _train(W: Tensor, X, y, *, steps: int, lr: float) -> Tensor:
+    params = {"W": W}
+    optimizer = optim.SGD(params, lr=lr)
+    for _ in range(steps):
+        W.grad = None
+        loss = _mse_loss(W, X, y)
+        loss.backward()
+        optimizer.step()
+    return W
+
+
+def main() -> None:
+    X, y = _make_problem(seed=42, n=16, dim=4)
+    half = X.shape[0] // 2
+    X1, X2 = X[:half], X[half:]
+    y1, y2 = y[:half], y[half:]
+    lr = 0.1
+    n_steps = 5
+
+    # ---- baseline ----
+    W_base = Tensor(xp.zeros((X.shape[1], 1), dtype=xp.float32), requires_grad=True)
+    _train(W_base, X, y, steps=n_steps, lr=lr)
+    baseline = xp.to_numpy(W_base.data)
+    print(f"single-rank baseline W = {baseline.ravel()}")
+
+    # ---- DDP 2 ranks ----
+    def per_rank():
+        from autograd.distributed import rank
+
+        W = Tensor(xp.zeros((X.shape[1], 1), dtype=xp.float32), requires_grad=True)
+        rank_X = X1 if rank() == 0 else X2
+        rank_y = y1 if rank() == 0 else y2
+        _train(W, rank_X, rank_y, steps=n_steps, lr=lr)
+        return xp.to_numpy(W.data)
+
+    ddp_results = run_mock_ranks(2, per_rank)
+    for r, W in enumerate(ddp_results):
+        print(f"rank {r} final W = {W.ravel()}")
+
+    # ---- equivalence check ----
+    for r, W in enumerate(ddp_results):
+        np.testing.assert_allclose(
+            W,
+            baseline,
+            rtol=1e-4,
+            atol=1e-4,
+            err_msg=f"rank {r} disagrees with baseline",
+        )
+    # And ranks agree.
+    np.testing.assert_allclose(ddp_results[0], ddp_results[1])
+    print("PASS: 2-rank mock DDP on CuPy matches single-rank baseline")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/distributed/smoke_ddp_nccl.py
+++ b/test/distributed/smoke_ddp_nccl.py
@@ -1,0 +1,98 @@
+"""End-to-end Phase 2 smoke: real NCCL backend via the launcher.
+
+Invoke with:
+
+    AUTOGRAD_BACKEND=cupy .venv/bin/python -m autograd.distributed.launch \\
+        --nproc-per-node=2 test/distributed/smoke_ddp_nccl.py
+
+Each rank constructs a small tensor, calls `allreduce_grads` and
+`broadcast_parameters`, and prints the result. We then assert manually
+inside each rank that:
+
+- After allreduce_grads, every rank's grad equals the host-side mean of
+  the per-rank inputs.
+- After broadcast_parameters from rank 0, every rank's param matches
+  rank 0's.
+
+If the asserts pass on every rank, the launcher exits 0.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from autograd.backend import xp
+from autograd.distributed import (
+    allreduce_grads,
+    broadcast_parameters,
+    get_backend,
+    is_distributed,
+    rank,
+    world_size,
+)
+
+
+class _FakeGrad:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeParam:
+    def __init__(self, data, grad=None):
+        self.data = data
+        self.grad = _FakeGrad(grad) if grad is not None else None
+
+
+def main() -> None:
+    if not is_distributed():
+        raise RuntimeError(
+            "smoke_ddp_nccl must be invoked via the launcher; world_size=1 here."
+        )
+
+    r = rank()
+    ws = world_size()
+    print(f"[rank {r}] starting; world_size={ws}", flush=True)
+
+    # Force backend init (would also happen lazily on first collective).
+    backend = get_backend()
+    print(f"[rank {r}] backend ready: {type(backend).__name__}", flush=True)
+
+    # --- allreduce_grads: each rank has a different grad; expect the mean. ---
+    grad_vals = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32) * (r + 1)
+    params = {
+        "w": _FakeParam(
+            data=xp.zeros(4, dtype=xp.float32),
+            grad=xp.asarray(grad_vals),
+        )
+    }
+    allreduce_grads(params)
+
+    expected_mean = (
+        sum(
+            np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32) * (i + 1)
+            for i in range(ws)
+        )
+        / ws
+    )
+    got = xp.to_numpy(params["w"].grad.data)
+    np.testing.assert_allclose(got, expected_mean, rtol=1e-6, atol=1e-6)
+    print(f"[rank {r}] allreduce_grads OK: {got}", flush=True)
+
+    # --- broadcast_parameters: rank 0's data should propagate to all. ---
+    rank0_data = np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float32)
+    starting = (
+        rank0_data if r == 0 else np.array([99.0, 99.0, 99.0, 99.0], dtype=np.float32)
+    )
+    params = {"w": _FakeParam(data=xp.asarray(starting))}
+    broadcast_parameters(params, from_rank=0)
+    got = xp.to_numpy(params["w"].data)
+    np.testing.assert_allclose(got, rank0_data, rtol=0, atol=0)
+    print(f"[rank {r}] broadcast_parameters OK: {got}", flush=True)
+
+    # --- barrier: every rank must reach this line. ---
+    backend.barrier()
+    print(f"[rank {r}] barrier OK; PASS", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/distributed/smoke_ddp_phase3.py
+++ b/test/distributed/smoke_ddp_phase3.py
@@ -9,8 +9,8 @@ Verifies on a real multi-process / multi-GPU setup that:
 
 - `broadcast_optimizer_state` copies rank-0's tensor-valued state to all
   ranks and leaves non-dict slots (e.g. integer `timestep`) untouched.
-- `_weighted_mean` with `config.log_global_loss=True` produces the true
-  global weighted mean across ranks, not the rank-local ratio.
+- `TrainingState.metrics_row` with `log_global_loss=True` produces the true global
+  weighted mean across ranks, not the rank-local ratio.
 """
 
 from __future__ import annotations
@@ -27,7 +27,7 @@ from autograd.distributed import (
     rank,
     world_size,
 )
-from autograd.tools.trainer import AbstractTrainer
+from autograd.tools.trainer import TrainingState
 
 
 def _test_broadcast_optimizer_state(r: int, ws: int) -> None:
@@ -58,22 +58,23 @@ def _test_broadcast_optimizer_state(r: int, ws: int) -> None:
     print(f"[rank {r}] broadcast_optimizer_state OK", flush=True)
 
 
-def _test_weighted_mean_global(r: int, ws: int) -> None:
+def _test_metrics_row_global_loss(r: int, ws: int) -> None:
     """Per-rank numerator/denominator → global mean of sums."""
     # Per rank: num = (r+1) * 2, den = (r+1). With ws=2: nums=[2,4] sums=6,
     # dens=[1,2] sums=3, expected_global = 2.0.
-    num = xp.asarray((r + 1) * 2.0, dtype=xp.float32)
-    den = xp.asarray(float(r + 1), dtype=xp.float32)
-
-    fake_trainer = SimpleNamespace(config=SimpleNamespace(log_global_loss=True))
-    got = AbstractTrainer._weighted_mean(fake_trainer, num, den)
+    state = TrainingState(report_started_at_s=0.0)
+    state.record_loss(
+        xp.asarray((r + 1) * 2.0, dtype=xp.float32),
+        total_weight=xp.asarray(float(r + 1), dtype=xp.float32),
+    )
+    got = state.metrics_row(eval_state=None, log_global_loss=True)["train_loss"]
 
     nums = [(i + 1) * 2.0 for i in range(ws)]
     dens = [float(i + 1) for i in range(ws)]
     expected_global = sum(nums) / sum(dens)
     np.testing.assert_allclose(got, expected_global, rtol=1e-6, atol=1e-6)
     print(
-        f"[rank {r}] _weighted_mean(log_global_loss=True) OK: "
+        f"[rank {r}] metrics_row(log_global_loss=True) OK: "
         f"got={got:.6f} expected={expected_global:.6f}",
         flush=True,
     )
@@ -93,7 +94,7 @@ def main() -> None:
     print(f"[rank {r}] backend ready: {type(backend).__name__}", flush=True)
 
     _test_broadcast_optimizer_state(r, ws)
-    _test_weighted_mean_global(r, ws)
+    _test_metrics_row_global_loss(r, ws)
 
     backend.barrier()
     print(f"[rank {r}] barrier OK; PASS", flush=True)

--- a/test/distributed/smoke_ddp_phase3.py
+++ b/test/distributed/smoke_ddp_phase3.py
@@ -1,0 +1,103 @@
+"""End-to-end Phase 3 smoke: real NCCL exercising the new helpers.
+
+Invoke with:
+
+    AUTOGRAD_BACKEND=cupy .venv/bin/python -m autograd.distributed.launch \\
+        --nproc-per-node=2 test/distributed/smoke_ddp_phase3.py
+
+Verifies on a real multi-process / multi-GPU setup that:
+
+- `broadcast_optimizer_state` copies rank-0's tensor-valued state to all
+  ranks and leaves non-dict slots (e.g. integer `timestep`) untouched.
+- `_weighted_mean` with `config.log_global_loss=True` produces the true
+  global weighted mean across ranks, not the rank-local ratio.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from autograd.backend import xp
+from autograd.distributed import (
+    broadcast_optimizer_state,
+    get_backend,
+    is_distributed,
+    rank,
+    world_size,
+)
+from autograd.tools.trainer import AbstractTrainer
+
+
+def _test_broadcast_optimizer_state(r: int, ws: int) -> None:
+    rank0_m_vals = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+    rank0_v_vals = np.array([0.01, 0.02, 0.03], dtype=np.float32)
+
+    m_val = xp.asarray(rank0_m_vals) if r == 0 else xp.zeros(3, dtype=xp.float32)
+    v_val = xp.asarray(rank0_v_vals) if r == 0 else xp.zeros(3, dtype=xp.float32)
+
+    fake_optimizer = SimpleNamespace(
+        _states={
+            "m": {"layer.w": m_val},
+            "v": {"layer.w": v_val},
+            "timestep": r * 100,
+        }
+    )
+
+    broadcast_optimizer_state(fake_optimizer, from_rank=0)
+
+    got_m = xp.to_numpy(fake_optimizer._states["m"]["layer.w"])
+    got_v = xp.to_numpy(fake_optimizer._states["v"]["layer.w"])
+    np.testing.assert_allclose(got_m, rank0_m_vals, rtol=0, atol=0)
+    np.testing.assert_allclose(got_v, rank0_v_vals, rtol=0, atol=0)
+    # timestep must NOT have been broadcast (rank-local int still in place).
+    assert fake_optimizer._states["timestep"] == r * 100, (
+        f"rank {r}: timestep was touched: {fake_optimizer._states['timestep']}"
+    )
+    print(f"[rank {r}] broadcast_optimizer_state OK", flush=True)
+
+
+def _test_weighted_mean_global(r: int, ws: int) -> None:
+    """Per-rank numerator/denominator → global mean of sums."""
+    # Per rank: num = (r+1) * 2, den = (r+1). With ws=2: nums=[2,4] sums=6,
+    # dens=[1,2] sums=3, expected_global = 2.0.
+    num = xp.asarray((r + 1) * 2.0, dtype=xp.float32)
+    den = xp.asarray(float(r + 1), dtype=xp.float32)
+
+    fake_trainer = SimpleNamespace(config=SimpleNamespace(log_global_loss=True))
+    got = AbstractTrainer._weighted_mean(fake_trainer, num, den)
+
+    nums = [(i + 1) * 2.0 for i in range(ws)]
+    dens = [float(i + 1) for i in range(ws)]
+    expected_global = sum(nums) / sum(dens)
+    np.testing.assert_allclose(got, expected_global, rtol=1e-6, atol=1e-6)
+    print(
+        f"[rank {r}] _weighted_mean(log_global_loss=True) OK: "
+        f"got={got:.6f} expected={expected_global:.6f}",
+        flush=True,
+    )
+
+
+def main() -> None:
+    if not is_distributed():
+        raise RuntimeError(
+            "smoke_ddp_phase3 must be invoked via the launcher; world_size=1 here."
+        )
+
+    r = rank()
+    ws = world_size()
+    print(f"[rank {r}] starting Phase 3 smoke; world_size={ws}", flush=True)
+
+    backend = get_backend()
+    print(f"[rank {r}] backend ready: {type(backend).__name__}", flush=True)
+
+    _test_broadcast_optimizer_state(r, ws)
+    _test_weighted_mean_global(r, ws)
+
+    backend.barrier()
+    print(f"[rank {r}] barrier OK; PASS", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/distributed/test_allreduce.py
+++ b/test/distributed/test_allreduce.py
@@ -1,0 +1,208 @@
+"""Mock-backend AllReduce / broadcast / barrier correctness tests.
+
+These tests run multiple "ranks" as Python threads via `run_mock_ranks`,
+verifying that:
+
+- AllReduce summed across N ranks matches the host-side sum.
+- The fp32-promotion path for low-precision gradients preserves the bf16
+  end-to-end semantics — `param.grad.data` ends up with the original
+  low-precision dtype and the average of the per-rank low-precision inputs
+  rounded once at the very end.
+- `broadcast` copies the `from_rank` rank's buffer to every other rank.
+- `barrier` is a no-op aside from forcing rendezvous; we check that all
+  threads finish a barrier-only target.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, xp
+from autograd.distributed import (
+    ReduceOp,
+    allreduce_grads,
+    broadcast_parameters,
+    get_backend,
+    rank,
+    world_size,
+)
+
+from .mock import run_mock_ranks
+
+
+# A minimal Tensor stand-in that mimics the (param.grad.data, param.data)
+# attribute shape used by allreduce_grads / broadcast_parameters. We
+# deliberately don't import autograd.tensor.Tensor so the test can run
+# without setting up the full Module/Tensor stack.
+class _FakeParam:
+    def __init__(self, data, grad=None):
+        self.data = data
+        self.grad = _FakeGrad(grad) if grad is not None else None
+
+
+class _FakeGrad:
+    def __init__(self, data):
+        self.data = data
+
+
+# ---- raw collectives -----------------------------------------------------
+
+
+def test_all_reduce_sum_matches_host_sum():
+    """Sum of per-rank arrays equals the AllReduce result on every rank."""
+    ws = 4
+    per_rank_inputs = [
+        np.array([1.0, 2.0, 3.0], dtype=np.float32) * (r + 1) for r in range(ws)
+    ]
+    expected = sum(per_rank_inputs)
+
+    def target():
+        backend = get_backend()
+        # all_reduce returns the reduced array; caller binds the result
+        # so the interface works for MLX (no in-place writes) and CuPy
+        # alike.
+        return backend.all_reduce(per_rank_inputs[rank()].copy(), op=ReduceOp.SUM)
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        np.testing.assert_array_equal(out, expected, err_msg=f"rank {r}")
+
+
+def test_broadcast_copies_from_rank_to_all():
+    """Every rank ends up with the broadcaster's buffer contents."""
+    ws = 3
+    from_rank = 1
+    broadcast_value = np.array([7.0, 8.0, 9.0], dtype=np.float32)
+
+    def target():
+        backend = get_backend()
+        if rank() == from_rank:
+            buf = broadcast_value.copy()
+        else:
+            buf = np.zeros(3, dtype=np.float32)
+        return backend.broadcast(buf, from_rank=from_rank)
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        np.testing.assert_array_equal(out, broadcast_value, err_msg=f"rank {r}")
+
+
+def test_barrier_completes_on_all_ranks():
+    """All threads return successfully after a barrier rendezvous."""
+    ws = 4
+
+    def target():
+        backend = get_backend()
+        backend.barrier()
+        return rank()
+
+    results = run_mock_ranks(ws, target)
+    assert sorted(results) == list(range(ws))
+
+
+# ---- hooks against fake-param shape --------------------------------------
+
+
+def test_allreduce_grads_averages_across_ranks():
+    """allreduce_grads divides the summed grads by world_size."""
+    ws = 4
+    base_grads = [
+        np.array([1.0, 2.0, 3.0], dtype=np.float32) * (r + 1) for r in range(ws)
+    ]
+    expected_mean = sum(base_grads) / ws
+
+    def target():
+        params = {
+            "w": _FakeParam(
+                data=np.zeros(3, dtype=np.float32),
+                grad=base_grads[rank()].copy(),
+            )
+        }
+        allreduce_grads(params)
+        return params["w"].grad.data
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        np.testing.assert_allclose(out, expected_mean, err_msg=f"rank {r}")
+
+
+@pytest.mark.skipif(
+    not LOW_PRECISION_FLOAT_DTYPES,
+    reason="backend does not provide a low-precision float dtype",
+)
+def test_allreduce_grads_fp32_promotion_for_low_precision():
+    """bf16/fp16 grads reduce in fp32 then cast back; the final dtype
+    matches the input, but the precision is what fp32-reduction gives."""
+    low_dtype = LOW_PRECISION_FLOAT_DTYPES[0]
+    ws = 4
+    base_vals = [
+        np.array([1.0, 2.0, 3.0], dtype=np.float32) * (r + 1) for r in range(ws)
+    ]
+    # Round-trip through the backend's low dtype so the expectation matches
+    # what each rank actually starts with.
+    base_grads = [xp.asarray(v).astype(low_dtype) for v in base_vals]
+    # Expected: average in fp32, then cast to low_dtype once at the end.
+    summed_fp32 = sum(xp.asarray(g).astype(xp.float32) for g in base_grads)
+    expected = (summed_fp32 / ws).astype(low_dtype)
+
+    def target():
+        # xp.array(...) copies the backend array (works on MLX where
+        # .copy() is missing). The fp32-promotion path inside
+        # allreduce_grads is what's under test, not the buffer plumbing.
+        params = {
+            "w": _FakeParam(
+                data=xp.zeros(3, dtype=low_dtype),
+                grad=xp.array(base_grads[rank()]),
+            )
+        }
+        allreduce_grads(params)
+        return params["w"].grad.data
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        assert out.dtype == low_dtype, f"rank {r} dtype: {out.dtype}"
+        # Compare as fp32 to avoid bf16 stringification noise.
+        np.testing.assert_allclose(
+            xp.to_numpy(out.astype(xp.float32)),
+            xp.to_numpy(expected.astype(xp.float32)),
+            atol=0,  # the operation chain is bit-deterministic
+        )
+
+
+def test_broadcast_parameters_syncs_to_all_ranks():
+    """broadcast_parameters copies rank-0 weights to every rank."""
+    ws = 3
+    rank0_weights = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+
+    def target():
+        # Each rank starts with a different weight init.
+        params = {
+            "w": _FakeParam(
+                data=(
+                    rank0_weights.copy()
+                    if rank() == 0
+                    else np.array([9.0, 9.0, 9.0, 9.0], dtype=np.float32)
+                ),
+                grad=None,
+            )
+        }
+        broadcast_parameters(params, from_rank=0)
+        return params["w"].data
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        np.testing.assert_array_equal(out, rank0_weights, err_msg=f"rank {r}")
+
+
+# ---- single-rank short-circuit -------------------------------------------
+
+
+def test_allreduce_grads_noop_single_rank():
+    """When world_size==1, allreduce_grads must not touch the gradient."""
+    grad = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    params = {"w": _FakeParam(data=np.zeros(3), grad=grad.copy())}
+    # Calling from the main thread, no run_mock_ranks => world_size == 1.
+    assert world_size() == 1
+    allreduce_grads(params)
+    np.testing.assert_array_equal(params["w"].grad.data, grad)

--- a/test/distributed/test_bf16_gate.py
+++ b/test/distributed/test_bf16_gate.py
@@ -1,11 +1,17 @@
-"""bf16 hardware gate (autograd.distributed.comm.check_bf16_capability).
+"""bf16 hardware gate (autograd.distributed.check_bf16_capability).
 
 The gate runs unconditionally on CuPy startup. Tests:
 
 - Non-CuPy backends pass-through (the gate is a no-op on numpy/MLX).
-- When `parameter_dtype` is fp32 / float32, the gate is a no-op.
+- When `parameter_dtype` is None / fp32 / float16 / other, the gate is a no-op.
 - On CuPy, an Ampere+ device (cc >= 8.0) passes; an older device hard-fails
   with an actionable message naming compute capability and the device name.
+
+Dtype-availability is intentionally NOT gated here; `resolve_dtype` in
+`autograd.backend` already raises a clear error when neither
+`cupy.bfloat16` nor `ml_dtypes.bfloat16` is reachable. The compute-
+capability check stays because it catches a silent slow-training footgun
+that no other check covers.
 
 The CuPy paths are exercised against a monkey-patched cupy device so the
 tests don't need real hardware.
@@ -22,7 +28,8 @@ import autograd.distributed as comm_mod
 
 
 def test_noop_on_non_bf16_dtype():
-    """fp32 / float16 / other dtypes don't trigger the gate."""
+    """fp32 / float16 / other dtypes (including None) don't trigger the gate."""
+    comm_mod.check_bf16_capability(None)
     comm_mod.check_bf16_capability("float32")
     comm_mod.check_bf16_capability("float16")
     comm_mod.check_bf16_capability("int8")
@@ -38,23 +45,17 @@ def test_noop_on_non_cupy_backends(monkeypatch):
 
 
 @contextmanager
-def _fake_cupy_device(
-    *, compute_capability: str, has_bfloat16: bool, name: str = "FakeGPU"
-):
+def _fake_cupy_device(*, compute_capability: str, name: str = "FakeGPU"):
     """Install a stand-in `xp` + `IS_CUPY=True` so check_bf16_capability
     exercises its CuPy path against an in-memory fake device."""
     import autograd.backend as backend_mod
-
-    fake_xp = types.SimpleNamespace()
-    if has_bfloat16:
-        fake_xp.bfloat16 = "bfloat16-marker"
 
     class _FakeDevice:
         def __init__(self) -> None:
             self.compute_capability = compute_capability
             self.attributes = {"Name": name}
 
-    fake_xp.cuda = types.SimpleNamespace(Device=_FakeDevice)
+    fake_xp = types.SimpleNamespace(cuda=types.SimpleNamespace(Device=_FakeDevice))
 
     saved_is_cupy = backend_mod.IS_CUPY
     saved_xp = backend_mod.xp
@@ -69,22 +70,20 @@ def _fake_cupy_device(
 
 def test_passes_on_ampere():
     """Compute capability 8.0 is the supported floor — should not raise."""
-    with _fake_cupy_device(compute_capability="80", has_bfloat16=True):
+    with _fake_cupy_device(compute_capability="80"):
         comm_mod.check_bf16_capability("bfloat16")
 
 
 def test_passes_on_hopper():
     """Compute capability 9.0 should pass."""
-    with _fake_cupy_device(compute_capability="90", has_bfloat16=True):
+    with _fake_cupy_device(compute_capability="90"):
         comm_mod.check_bf16_capability("bfloat16")
 
 
 def test_hard_fails_on_pre_ampere():
     """Compute capability < 8.0 (e.g. Turing T4 at 7.5) should hard-fail
     with a message naming the dtype, the cc threshold, and the device."""
-    with _fake_cupy_device(
-        compute_capability="75", has_bfloat16=True, name="Turing-T4"
-    ):
+    with _fake_cupy_device(compute_capability="75", name="Turing-T4"):
         with pytest.raises(RuntimeError) as exc_info:
             comm_mod.check_bf16_capability("bfloat16")
 
@@ -93,13 +92,3 @@ def test_hard_fails_on_pre_ampere():
     assert "8.0" in msg
     assert "7.5" in msg
     assert "Turing-T4" in msg
-
-
-def test_hard_fails_when_cupy_lacks_bfloat16():
-    """If CuPy was built without bfloat16, raise with an upgrade message."""
-    with _fake_cupy_device(compute_capability="80", has_bfloat16=False):
-        with pytest.raises(RuntimeError) as exc_info:
-            comm_mod.check_bf16_capability("bfloat16")
-
-    msg = str(exc_info.value)
-    assert "cupy.bfloat16" in msg

--- a/test/distributed/test_bf16_gate.py
+++ b/test/distributed/test_bf16_gate.py
@@ -1,4 +1,4 @@
-"""bf16 hardware gate (autograd.distributed.check_bf16_capability).
+"""bf16 hardware gate (autograd.backend.check_bf16_capability).
 
 The gate runs unconditionally on CuPy startup. Tests:
 
@@ -24,31 +24,28 @@ from contextlib import contextmanager
 
 import pytest
 
-import autograd.distributed as comm_mod
+import autograd.backend as backend_mod
 
 
 def test_noop_on_non_bf16_dtype():
     """fp32 / float16 / other dtypes (including None) don't trigger the gate."""
-    comm_mod.check_bf16_capability(None)
-    comm_mod.check_bf16_capability("float32")
-    comm_mod.check_bf16_capability("float16")
-    comm_mod.check_bf16_capability("int8")
+    backend_mod.check_bf16_capability(None)
+    backend_mod.check_bf16_capability("float32")
+    backend_mod.check_bf16_capability("float16")
+    backend_mod.check_bf16_capability("int8")
 
 
 def test_noop_on_non_cupy_backends(monkeypatch):
     """MLX/numpy backends skip the gate (each has its own bf16 path)."""
-    import autograd.backend as backend_mod
-
     monkeypatch.setattr(backend_mod, "IS_CUPY", False)
     # Should not raise.
-    comm_mod.check_bf16_capability("bfloat16")
+    backend_mod.check_bf16_capability("bfloat16")
 
 
 @contextmanager
 def _fake_cupy_device(*, compute_capability: str, name: str = "FakeGPU"):
     """Install a stand-in `xp` + `IS_CUPY=True` so check_bf16_capability
     exercises its CuPy path against an in-memory fake device."""
-    import autograd.backend as backend_mod
 
     class _FakeDevice:
         def __init__(self) -> None:
@@ -71,13 +68,13 @@ def _fake_cupy_device(*, compute_capability: str, name: str = "FakeGPU"):
 def test_passes_on_ampere():
     """Compute capability 8.0 is the supported floor — should not raise."""
     with _fake_cupy_device(compute_capability="80"):
-        comm_mod.check_bf16_capability("bfloat16")
+        backend_mod.check_bf16_capability("bfloat16")
 
 
 def test_passes_on_hopper():
     """Compute capability 9.0 should pass."""
     with _fake_cupy_device(compute_capability="90"):
-        comm_mod.check_bf16_capability("bfloat16")
+        backend_mod.check_bf16_capability("bfloat16")
 
 
 def test_hard_fails_on_pre_ampere():
@@ -85,7 +82,7 @@ def test_hard_fails_on_pre_ampere():
     with a message naming the dtype, the cc threshold, and the device."""
     with _fake_cupy_device(compute_capability="75", name="Turing-T4"):
         with pytest.raises(RuntimeError) as exc_info:
-            comm_mod.check_bf16_capability("bfloat16")
+            backend_mod.check_bf16_capability("bfloat16")
 
     msg = str(exc_info.value)
     assert "bfloat16" in msg

--- a/test/distributed/test_bf16_gate.py
+++ b/test/distributed/test_bf16_gate.py
@@ -1,0 +1,105 @@
+"""bf16 hardware gate (autograd.distributed.comm.check_bf16_capability).
+
+The gate runs unconditionally on CuPy startup. Tests:
+
+- Non-CuPy backends pass-through (the gate is a no-op on numpy/MLX).
+- When `parameter_dtype` is fp32 / float32, the gate is a no-op.
+- On CuPy, an Ampere+ device (cc >= 8.0) passes; an older device hard-fails
+  with an actionable message naming compute capability and the device name.
+
+The CuPy paths are exercised against a monkey-patched cupy device so the
+tests don't need real hardware.
+"""
+
+from __future__ import annotations
+
+import types
+from contextlib import contextmanager
+
+import pytest
+
+import autograd.distributed as comm_mod
+
+
+def test_noop_on_non_bf16_dtype():
+    """fp32 / float16 / other dtypes don't trigger the gate."""
+    comm_mod.check_bf16_capability("float32")
+    comm_mod.check_bf16_capability("float16")
+    comm_mod.check_bf16_capability("int8")
+
+
+def test_noop_on_non_cupy_backends(monkeypatch):
+    """MLX/numpy backends skip the gate (each has its own bf16 path)."""
+    import autograd.backend as backend_mod
+
+    monkeypatch.setattr(backend_mod, "IS_CUPY", False)
+    # Should not raise.
+    comm_mod.check_bf16_capability("bfloat16")
+
+
+@contextmanager
+def _fake_cupy_device(
+    *, compute_capability: str, has_bfloat16: bool, name: str = "FakeGPU"
+):
+    """Install a stand-in `xp` + `IS_CUPY=True` so check_bf16_capability
+    exercises its CuPy path against an in-memory fake device."""
+    import autograd.backend as backend_mod
+
+    fake_xp = types.SimpleNamespace()
+    if has_bfloat16:
+        fake_xp.bfloat16 = "bfloat16-marker"
+
+    class _FakeDevice:
+        def __init__(self) -> None:
+            self.compute_capability = compute_capability
+            self.attributes = {"Name": name}
+
+    fake_xp.cuda = types.SimpleNamespace(Device=_FakeDevice)
+
+    saved_is_cupy = backend_mod.IS_CUPY
+    saved_xp = backend_mod.xp
+    backend_mod.IS_CUPY = True
+    backend_mod.xp = fake_xp
+    try:
+        yield
+    finally:
+        backend_mod.IS_CUPY = saved_is_cupy
+        backend_mod.xp = saved_xp
+
+
+def test_passes_on_ampere():
+    """Compute capability 8.0 is the supported floor — should not raise."""
+    with _fake_cupy_device(compute_capability="80", has_bfloat16=True):
+        comm_mod.check_bf16_capability("bfloat16")
+
+
+def test_passes_on_hopper():
+    """Compute capability 9.0 should pass."""
+    with _fake_cupy_device(compute_capability="90", has_bfloat16=True):
+        comm_mod.check_bf16_capability("bfloat16")
+
+
+def test_hard_fails_on_pre_ampere():
+    """Compute capability < 8.0 (e.g. Turing T4 at 7.5) should hard-fail
+    with a message naming the dtype, the cc threshold, and the device."""
+    with _fake_cupy_device(
+        compute_capability="75", has_bfloat16=True, name="Turing-T4"
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            comm_mod.check_bf16_capability("bfloat16")
+
+    msg = str(exc_info.value)
+    assert "bfloat16" in msg
+    assert "8.0" in msg
+    assert "7.5" in msg
+    assert "Turing-T4" in msg
+
+
+def test_hard_fails_when_cupy_lacks_bfloat16():
+    """If CuPy was built without bfloat16, raise with an upgrade message."""
+    with _fake_cupy_device(compute_capability="80", has_bfloat16=False):
+        with pytest.raises(RuntimeError) as exc_info:
+            comm_mod.check_bf16_capability("bfloat16")
+
+    msg = str(exc_info.value)
+    assert "cupy.bfloat16" in msg

--- a/test/distributed/test_ddp_equivalence.py
+++ b/test/distributed/test_ddp_equivalence.py
@@ -1,0 +1,160 @@
+"""
+Headline DDP correctness proof: training under N mock ranks should reach the
+same final parameters as a single-rank baseline that consumes the same
+total data, when:
+
+- the per-step grads on N ranks are the AllReduce-mean of independent
+  microbatch grads, AND
+- the baseline computes a grad of the same global batch in one shot.
+
+This test materializes that equivalence with a tiny linear regression
+problem so the check is bit-deterministic at fp32 (no nondeterminism from
+threading because all reductions are summed in rank-0's serialized loop).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from autograd import optim
+from autograd.backend import IS_MLX, xp
+from autograd.tensor import Tensor
+
+from .mock import run_mock_ranks
+
+# MLX's lazy eval is not thread-safe; calling materialize() (xp.eval) from
+# multiple threads inside MockComm rendezvous segfaults the interpreter.
+# DDP under MLX is not in scope for v1 (we run on CuPy or numpy), so we
+# skip the multi-thread integration tests there.
+pytestmark = pytest.mark.skipif(
+    IS_MLX, reason="MLX lazy eval is not thread-safe; DDP path is CuPy/numpy only"
+)
+
+
+def _make_problem(seed: int = 0, n: int = 16, dim: int = 4):
+    """A regression dataset of shape (n, dim) with a known linear target."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, dim)).astype(np.float32)
+    true_w = rng.standard_normal((dim, 1)).astype(np.float32)
+    y = X @ true_w + 0.1 * rng.standard_normal((n, 1)).astype(np.float32)
+    return X, y
+
+
+def _make_param(dim: int) -> Tensor:
+    """Identical initialization across runs: zeros."""
+    return Tensor(xp.zeros((dim, 1), dtype=xp.float32), requires_grad=True)
+
+
+def _mse_loss_and_grad(W: Tensor, X: np.ndarray, y: np.ndarray) -> Tensor:
+    """Compute MSE loss W^T X against y as an autograd-tracked Tensor.
+
+    We use autograd's Tensor + backward so the gradient is what the real
+    optimizer would consume, not a hand-derived approximation.
+    """
+    X_t = Tensor(xp.asarray(X))
+    y_t = Tensor(xp.asarray(y))
+    pred = X_t @ W
+    diff = pred - y_t
+    loss = (diff * diff).sum() / X.shape[0]
+    return loss
+
+
+def _get_or_make_sgd(params: dict, lr: float) -> optim.SGD:
+    """SGD construction wraps a broadcast on non-rank-0; we want to make
+    this once per test run, not once per step, so the broadcast is paid
+    a single time."""
+    return optim.SGD(params, lr=lr)
+
+
+def test_ddp_2rank_matches_single_rank_baseline():
+    """Two-rank mock DDP on (X1, X2) ≡ single-rank baseline on concat(X1, X2).
+
+    Argument: each rank computes a per-half MSE gradient. After
+    AllReduce-mean, the optimizer sees `(g1 + g2) / 2`. For MSE on
+    disjoint halves of equal size,
+        (g1 + g2) / 2 == grad(MSE on full batch)
+    because MSE divides by per-batch count and the per-rank batches are
+    the same size. So a single-rank baseline that uses the full batch
+    must produce the same step under SGD.
+    """
+    X, y = _make_problem(seed=42, n=16, dim=4)
+    half = X.shape[0] // 2
+    X1, X2 = X[:half], X[half:]
+    y1, y2 = y[:half], y[half:]
+    lr = 0.1
+    n_steps = 5
+
+    # ---- baseline: 1 rank, full batch ---------------------------------
+    W_baseline = _make_param(X.shape[1])
+    params_baseline = {"W": W_baseline}
+    optimizer_baseline = _get_or_make_sgd(params_baseline, lr)
+    for _ in range(n_steps):
+        W_baseline.grad = None
+        loss = _mse_loss_and_grad(W_baseline, X, y)
+        loss.backward()
+        optimizer_baseline.step()
+
+    # ---- DDP: 2 ranks, each takes one half ----------------------------
+    def per_rank_train():
+        # Match the baseline init (zeros) — no per-rank divergence.
+        from autograd.distributed import rank
+
+        W = _make_param(X.shape[1])
+        params = {"W": W}
+        optimizer = _get_or_make_sgd(params, lr)
+        rank_X = X1 if rank() == 0 else X2
+        rank_y = y1 if rank() == 0 else y2
+        for _ in range(n_steps):
+            W.grad = None
+            loss = _mse_loss_and_grad(W, rank_X, rank_y)
+            loss.backward()
+            optimizer.step()
+        return xp.to_numpy(W.data)
+
+    rank_results = run_mock_ranks(2, per_rank_train)
+
+    # Every rank ends up with the same params (AllReduce + identical init).
+    for r in range(1, 2):
+        np.testing.assert_allclose(
+            rank_results[r],
+            rank_results[0],
+            err_msg=f"rank {r} disagrees with rank 0",
+        )
+
+    # And those params match the single-rank baseline.
+    baseline_w = xp.to_numpy(W_baseline.data)
+    np.testing.assert_allclose(
+        rank_results[0],
+        baseline_w,
+        rtol=1e-5,
+        atol=1e-5,
+        err_msg="DDP 2-rank result differs from single-rank baseline",
+    )
+
+
+def test_broadcast_parameters_syncs_divergent_inits():
+    """broadcast_parameters at optimizer construction makes rank-0's
+    init the source of truth — even when rank > 0 starts with random
+    weights, after Optimizer(...) constructs, every rank holds rank-0's
+    weights."""
+    from autograd.distributed import rank
+
+    def per_rank():
+        # Pretend init is non-deterministic by seeding per-rank.
+        rng = np.random.default_rng(rank())
+        W = Tensor(
+            xp.asarray(rng.standard_normal((4, 1)).astype(np.float32)),
+            requires_grad=True,
+        )
+        params = {"W": W}
+        _get_or_make_sgd(params, lr=0.1)  # triggers broadcast_parameters
+        return xp.to_numpy(W.data)
+
+    results = run_mock_ranks(3, per_rank)
+    for r in range(1, 3):
+        np.testing.assert_array_equal(
+            results[r],
+            results[0],
+            err_msg=f"rank {r} not synced to rank 0",
+        )

--- a/test/distributed/test_phase3.py
+++ b/test/distributed/test_phase3.py
@@ -7,10 +7,9 @@ Two pieces of Phase 3 plumbing get tested here against the mock backend:
   slots (e.g. the integer `timestep`) untouched. The fp32-promotion path
   used by `broadcast_parameters` for bf16 also applies here.
 
-- `_weighted_mean` with `config.log_global_loss=True` AllReduce-sums both
-  the numerator and the denominator across ranks before dividing, so the
-  reported loss is the true global weighted mean. With the flag off, it
-  stays a rank-local computation.
+- `TrainingState.metrics_row` with `log_global_loss=True` packs additive report
+  counters into one vector, AllReduce-sums that vector, then reports the
+  true global weighted mean. With the flag off, loss stays rank-local.
 """
 
 from __future__ import annotations
@@ -26,7 +25,7 @@ from autograd.distributed import (
     rank,
     world_size,
 )
-from autograd.tools.trainer import AbstractTrainer
+from autograd.tools.trainer import TrainingState
 
 from .mock import run_mock_ranks
 
@@ -107,23 +106,11 @@ def test_broadcast_optimizer_state_fp32_promotion_round_trip():
         )
 
 
-# ---- _weighted_mean global allreduce path -------------------------------
+# ---- report metric global allreduce path --------------------------------
 
 
-def _fake_trainer(*, log_global_loss: bool) -> SimpleNamespace:
-    """Build a trainer stub with just the attributes `_weighted_mean` reads.
-
-    We don't construct a real AbstractTrainer because its __init__ pulls in
-    a model + optimizer; the AllReduce branch is a small, isolated path
-    that only needs `self.config.log_global_loss`.
-    """
-    return SimpleNamespace(config=SimpleNamespace(log_global_loss=log_global_loss))
-
-
-def test_weighted_mean_local_when_flag_off():
-    """With log_global_loss=False, the helper returns rank-local mean and
-    runs no collective — verified by passing values that would diverge
-    across ranks if AllReduced."""
+def test_weighted_mean_is_local_math():
+    """The ratio helper returns rank-local means and runs no collective."""
     ws = 4
 
     def target():
@@ -131,9 +118,7 @@ def test_weighted_mean_local_when_flag_off():
         # rank returns its own ratio unchanged.
         num = xp.array(2.0 * (rank() + 1), dtype=xp.float32)
         den = xp.array(1.0, dtype=xp.float32)
-        return AbstractTrainer._weighted_mean(
-            _fake_trainer(log_global_loss=False), num, den
-        )
+        return TrainingState()._weighted_mean(num, den)
 
     results = run_mock_ranks(ws, target)
     for r, out in enumerate(results):
@@ -143,13 +128,13 @@ def test_weighted_mean_local_when_flag_off():
 @pytest.mark.skipif(
     IS_MLX,
     reason=(
-        "MLX lazy graphs aren't thread-safe: _weighted_mean's inline "
+        "MLX lazy graphs aren't thread-safe: metrics_row's inline "
         "xp.to_scalar after AllReduce evaluates a cross-thread graph "
         "and segfaults under the in-process mock. Production DDP runs "
         "one process per rank, so this is a mock-only concern."
     ),
 )
-def test_weighted_mean_global_allreduces_when_flag_on():
+def test_metrics_row_global_allreduces_loss_when_flag_on():
     """With log_global_loss=True, every rank returns the global weighted
     mean: sum(numerators) / sum(denominators), not the per-rank ratio."""
     ws = 4
@@ -158,11 +143,15 @@ def test_weighted_mean_global_allreduces_when_flag_on():
     expected_global = sum(numerators) / sum(denominators)  # 2.5
 
     def target():
-        num = xp.array(numerators[rank()], dtype=xp.float32)
-        den = xp.array(denominators[rank()], dtype=xp.float32)
-        return AbstractTrainer._weighted_mean(
-            _fake_trainer(log_global_loss=True), num, den
+        state = TrainingState(report_started_at_s=0.0)
+        state.record_loss(
+            xp.array(numerators[rank()], dtype=xp.float32),
+            total_weight=xp.array(denominators[rank()], dtype=xp.float32),
         )
+        return state.metrics_row(
+            eval_state=None,
+            log_global_loss=True,
+        )["train_loss"]
 
     results = run_mock_ranks(ws, target)
     for r, out in enumerate(results):
@@ -174,8 +163,7 @@ def test_weighted_mean_none_numerator_returns_zero():
     rank returns 0.0 without entering the collective. (When None comes
     from `state.report_loss_sum`, all ranks observe it consistently, so
     no collective desync.)"""
-    out = AbstractTrainer._weighted_mean(
-        _fake_trainer(log_global_loss=True),
+    out = TrainingState()._weighted_mean(
         None,
         xp.array(1.0, dtype=xp.float32),
     )

--- a/test/distributed/test_phase3.py
+++ b/test/distributed/test_phase3.py
@@ -1,0 +1,182 @@
+"""Phase 3 — checkpoint broadcast + global-loss AllReduce-mean.
+
+Two pieces of Phase 3 plumbing get tested here against the mock backend:
+
+- `broadcast_optimizer_state(optimizer)` walks `Optimizer._states`, copies
+  every tensor-valued slot from rank 0 to all ranks, and leaves non-tensor
+  slots (e.g. the integer `timestep`) untouched. The fp32-promotion path
+  used by `broadcast_parameters` for bf16 also applies here.
+
+- `_weighted_mean` with `config.log_global_loss=True` AllReduce-sums both
+  the numerator and the denominator across ranks before dividing, so the
+  reported loss is the true global weighted mean. With the flag off, it
+  stays a rank-local computation.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from autograd.backend import IS_MLX, LOW_PRECISION_FLOAT_DTYPES, xp
+from autograd.distributed import (
+    broadcast_optimizer_state,
+    rank,
+    world_size,
+)
+from autograd.tools.trainer import AbstractTrainer
+
+from .mock import run_mock_ranks
+
+# ---- broadcast_optimizer_state ------------------------------------------
+
+
+def test_broadcast_optimizer_state_syncs_from_rank_zero():
+    """Every rank ends up with rank 0's `m` and `v` tensors; `timestep`
+    (non-dict slot) is left alone on every rank."""
+    ws = 3
+    rank0_m = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+    rank0_v = np.array([0.01, 0.02, 0.03], dtype=np.float32)
+
+    def target():
+        m_val = rank0_m.copy() if rank() == 0 else np.zeros(3, dtype=np.float32)
+        v_val = rank0_v.copy() if rank() == 0 else np.zeros(3, dtype=np.float32)
+        # `timestep` is intentionally rank-local here so we can assert that
+        # broadcast_optimizer_state never overwrites it.
+        fake_optimizer = SimpleNamespace(
+            _states={
+                "m": {"layer.w": m_val},
+                "v": {"layer.w": v_val},
+                "timestep": rank() * 100,
+            }
+        )
+        broadcast_optimizer_state(fake_optimizer, from_rank=0)
+        return fake_optimizer._states
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        np.testing.assert_array_equal(
+            out["m"]["layer.w"], rank0_m, err_msg=f"rank {r} m"
+        )
+        np.testing.assert_array_equal(
+            out["v"]["layer.w"], rank0_v, err_msg=f"rank {r} v"
+        )
+        assert out["timestep"] == r * 100, f"rank {r} timestep was touched"
+
+
+def test_broadcast_optimizer_state_noop_single_rank():
+    """world_size==1 — the helper must not touch any state."""
+    original_m = np.array([1.0, 2.0], dtype=np.float32)
+    fake_optimizer = SimpleNamespace(
+        _states={"m": {"layer.w": original_m.copy()}, "timestep": 7},
+    )
+    assert world_size() == 1
+    broadcast_optimizer_state(fake_optimizer, from_rank=0)
+    np.testing.assert_array_equal(fake_optimizer._states["m"]["layer.w"], original_m)
+    assert fake_optimizer._states["timestep"] == 7
+
+
+@pytest.mark.skipif(
+    not LOW_PRECISION_FLOAT_DTYPES,
+    reason="backend does not provide a low-precision float dtype",
+)
+def test_broadcast_optimizer_state_fp32_promotion_round_trip():
+    """bf16/fp16 optimizer state survives the broadcast: dtype preserved,
+    values match rank-0's bytes round-tripped through fp32."""
+    low_dtype = LOW_PRECISION_FLOAT_DTYPES[0]
+    ws = 3
+    rank0_m_fp32 = np.array([0.25, 0.5, 0.75], dtype=np.float32)
+    rank0_m = xp.asarray(rank0_m_fp32).astype(low_dtype)
+
+    def target():
+        m_val = xp.array(rank0_m) if rank() == 0 else xp.zeros(3, dtype=low_dtype)
+        fake_optimizer = SimpleNamespace(_states={"m": {"layer.w": m_val}})
+        broadcast_optimizer_state(fake_optimizer, from_rank=0)
+        return fake_optimizer._states["m"]["layer.w"]
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        assert out.dtype == low_dtype, f"rank {r} dtype drifted: {out.dtype}"
+        np.testing.assert_allclose(
+            xp.to_numpy(out.astype(xp.float32)),
+            xp.to_numpy(rank0_m.astype(xp.float32)),
+            atol=0,
+            err_msg=f"rank {r}",
+        )
+
+
+# ---- _weighted_mean global allreduce path -------------------------------
+
+
+def _fake_trainer(*, log_global_loss: bool) -> SimpleNamespace:
+    """Build a trainer stub with just the attributes `_weighted_mean` reads.
+
+    We don't construct a real AbstractTrainer because its __init__ pulls in
+    a model + optimizer; the AllReduce branch is a small, isolated path
+    that only needs `self.config.log_global_loss`.
+    """
+    return SimpleNamespace(config=SimpleNamespace(log_global_loss=log_global_loss))
+
+
+def test_weighted_mean_local_when_flag_off():
+    """With log_global_loss=False, the helper returns rank-local mean and
+    runs no collective — verified by passing values that would diverge
+    across ranks if AllReduced."""
+    ws = 4
+
+    def target():
+        # Each rank reports a different ratio. With the flag off, each
+        # rank returns its own ratio unchanged.
+        num = xp.array(2.0 * (rank() + 1), dtype=xp.float32)
+        den = xp.array(1.0, dtype=xp.float32)
+        return AbstractTrainer._weighted_mean(
+            _fake_trainer(log_global_loss=False), num, den
+        )
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        assert out == pytest.approx(2.0 * (r + 1)), f"rank {r}"
+
+
+@pytest.mark.skipif(
+    IS_MLX,
+    reason=(
+        "MLX lazy graphs aren't thread-safe: _weighted_mean's inline "
+        "xp.to_scalar after AllReduce evaluates a cross-thread graph "
+        "and segfaults under the in-process mock. Production DDP runs "
+        "one process per rank, so this is a mock-only concern."
+    ),
+)
+def test_weighted_mean_global_allreduces_when_flag_on():
+    """With log_global_loss=True, every rank returns the global weighted
+    mean: sum(numerators) / sum(denominators), not the per-rank ratio."""
+    ws = 4
+    numerators = [2.0, 4.0, 6.0, 8.0]  # sum = 20.0
+    denominators = [1.0, 2.0, 1.0, 4.0]  # sum = 8.0
+    expected_global = sum(numerators) / sum(denominators)  # 2.5
+
+    def target():
+        num = xp.array(numerators[rank()], dtype=xp.float32)
+        den = xp.array(denominators[rank()], dtype=xp.float32)
+        return AbstractTrainer._weighted_mean(
+            _fake_trainer(log_global_loss=True), num, den
+        )
+
+    results = run_mock_ranks(ws, target)
+    for r, out in enumerate(results):
+        assert out == pytest.approx(expected_global, rel=1e-6), f"rank {r}"
+
+
+def test_weighted_mean_none_numerator_returns_zero():
+    """The early `numerator is None` short-circuit must remain — every
+    rank returns 0.0 without entering the collective. (When None comes
+    from `state.report_loss_sum`, all ranks observe it consistently, so
+    no collective desync.)"""
+    out = AbstractTrainer._weighted_mean(
+        _fake_trainer(log_global_loss=True),
+        None,
+        xp.array(1.0, dtype=xp.float32),
+    )
+    assert out == 0.0

--- a/test/distributed/test_sampler.py
+++ b/test/distributed/test_sampler.py
@@ -1,0 +1,180 @@
+"""Tests for DistributedSamplerAdapter.
+
+The adapter has two strategies (with-replacement vs without-replacement)
+and the tests cover the contract on each:
+
+- Without-replacement: the union of indices across ranks equals the global
+  permutation; per-rank streams are disjoint; the partition is
+  deterministic across calls with the same (seed, epoch).
+- With-replacement: per-rank streams are independent (different seeds);
+  the per-rank length equals `len(dataset) // world_size`; the same
+  (seed, epoch, rank) is reproducible.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autograd.data.dataset import MapDataset
+from autograd.data.sampler import (
+    DistributedSamplerAdapter,
+    RandomSampler,
+    SequentialSampler,
+)
+
+
+class _ListDataset(MapDataset):
+    def __init__(self, n: int) -> None:
+        self._n = n
+
+    def __getitem__(self, index: int) -> int:
+        return index
+
+    def __len__(self) -> int:
+        return self._n
+
+    def on_epoch_start(self) -> None:
+        pass
+
+
+# ---- without-replacement / sequential -------------------------------------
+
+
+def test_sequential_disjoint_full_coverage():
+    """All ranks together cover the full index range with no overlap."""
+    n, world_size = 12, 4
+    dataset = _ListDataset(n)
+    base = SequentialSampler(dataset)
+
+    per_rank = [
+        list(
+            DistributedSamplerAdapter(
+                SequentialSampler(dataset),
+                rank=r,
+                world_size=world_size,
+            )
+        )
+        for r in range(world_size)
+    ]
+
+    # Each rank gets a quarter of the indices.
+    assert all(len(s) == n // world_size for s in per_rank)
+
+    # Disjoint: no index appears on two ranks.
+    seen: set[int] = set()
+    for shard in per_rank:
+        overlap = seen.intersection(shard)
+        assert not overlap, f"overlap across ranks: {overlap}"
+        seen.update(shard)
+
+    # Full coverage: every index is present exactly once.
+    assert seen == set(range(n))
+    # Wrapped base sampler still emits the full ordering for sanity.
+    assert list(iter(base)) == list(range(n))
+
+
+def test_sequential_padding_when_not_divisible():
+    """When len(sampler) % world_size != 0, padding fills out the partition."""
+    n, world_size = 10, 4  # 10 % 4 = 2, target = ceil(10/4)*4 = 12
+    dataset = _ListDataset(n)
+    per_rank = [
+        list(
+            DistributedSamplerAdapter(
+                SequentialSampler(dataset),
+                rank=r,
+                world_size=world_size,
+            )
+        )
+        for r in range(world_size)
+    ]
+    # All shards same length: ceil(10/4) = 3
+    assert all(len(s) == 3 for s in per_rank)
+    # Total emitted == 12 = 3 * 4; only the first (12 - 10) = 2 indices were
+    # padded (head-repeat), so the multiset of values >= n // world_size copies
+    # for each index except the head pair.
+    flat = [i for s in per_rank for i in s]
+    assert len(flat) == 12
+    for idx in range(n):
+        assert idx in flat
+
+
+def test_sequential_deterministic_across_calls():
+    """Two adapters with the same (seed, epoch) emit the same shards."""
+    dataset = _ListDataset(16)
+    s1 = DistributedSamplerAdapter(
+        SequentialSampler(dataset), rank=1, world_size=4, seed=42
+    )
+    s2 = DistributedSamplerAdapter(
+        SequentialSampler(dataset), rank=1, world_size=4, seed=42
+    )
+    assert list(s1) == list(s2)
+
+
+# ---- with-replacement -----------------------------------------------------
+
+
+def test_with_replacement_per_rank_length():
+    """Each rank receives floor(global / world_size) samples."""
+    n, world_size = 12, 4
+    dataset = _ListDataset(n)
+    base = RandomSampler(dataset, replacement=True, num_samples=n)
+    adapter = DistributedSamplerAdapter(base, rank=0, world_size=world_size)
+    assert len(adapter) == n // world_size
+
+
+def test_with_replacement_independent_streams():
+    """Different ranks use different RNG seeds, so their streams differ."""
+    n, world_size = 128, 4
+    dataset = _ListDataset(n)
+    base = RandomSampler(dataset, replacement=True, num_samples=n)
+    streams = [
+        list(DistributedSamplerAdapter(base, rank=r, world_size=world_size, seed=7))
+        for r in range(world_size)
+    ]
+    # The probability of two independent uniform streams over [0, 128) of
+    # length 32 being exactly equal is vanishing (~128^-32). Use that as
+    # the cheap "are they different?" check.
+    for r1 in range(world_size):
+        for r2 in range(r1 + 1, world_size):
+            assert streams[r1] != streams[r2]
+
+
+def test_with_replacement_deterministic_per_seed_rank_epoch():
+    """Same (seed, epoch, rank) reproduces the same per-rank stream."""
+    n = 64
+    dataset = _ListDataset(n)
+    base = RandomSampler(dataset, replacement=True, num_samples=n)
+    a = DistributedSamplerAdapter(base, rank=2, world_size=4, seed=99)
+    b = DistributedSamplerAdapter(base, rank=2, world_size=4, seed=99)
+    assert list(a) == list(b)
+
+
+def test_with_replacement_epoch_advances_stream():
+    """on_epoch_start should re-seed the stream (different from epoch 0)."""
+    n = 64
+    dataset = _ListDataset(n)
+    base = RandomSampler(dataset, replacement=True, num_samples=n)
+    a = DistributedSamplerAdapter(base, rank=0, world_size=4, seed=1)
+    e0 = list(a)
+    a.on_epoch_start()
+    e1 = list(a)
+    assert e0 != e1
+
+
+# ---- error paths ----------------------------------------------------------
+
+
+def test_rejects_invalid_rank():
+    dataset = _ListDataset(8)
+    base = SequentialSampler(dataset)
+    with pytest.raises(ValueError):
+        DistributedSamplerAdapter(base, rank=4, world_size=4)
+    with pytest.raises(ValueError):
+        DistributedSamplerAdapter(base, rank=-1, world_size=4)
+
+
+def test_rejects_invalid_world_size():
+    dataset = _ListDataset(8)
+    base = SequentialSampler(dataset)
+    with pytest.raises(ValueError):
+        DistributedSamplerAdapter(base, rank=0, world_size=0)

--- a/uv.lock
+++ b/uv.lock
@@ -5,8 +5,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
@@ -59,6 +61,7 @@ name = "autograd"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "ml-dtypes" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
     { name = "numpy" },
     { name = "openml" },
@@ -96,6 +99,7 @@ requires-dist = [
     { name = "cupy-cuda12x", marker = "sys_platform == 'linux' and extra == 'cuda12'" },
     { name = "cupy-cuda13x", marker = "python_full_version >= '3.9' and sys_platform == 'linux' and extra == 'cuda13'" },
     { name = "memray", marker = "extra == 'dev'" },
+    { name = "ml-dtypes" },
     { name = "ml-dtypes", marker = "python_full_version >= '3.9' and sys_platform == 'linux' and extra == 'cuda13'" },
     { name = "ml-dtypes", marker = "sys_platform == 'linux' and extra == 'cuda12'" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
@@ -587,20 +591,35 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
     { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
     { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
     { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
     { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
     { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
     { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
     { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
     { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
     { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
     { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context
To speed up the training process, and preserve the educational value of this repo, I'm adding distributed training capability to this training library. Initially, it will only support distributed data parallelism for simplicity. We might implement other parallelism strategies when we've run into a bottleneck.

## Notable changes:

- `autograd.distributed.launch` to launch distributed training jobs, this follows the same API as `torch.distributed.launch`, we might want to update it to something like `autograd_run` later to follow the more up-to-date `torchrun` interface.
- `autograd.distributed.__init__` contains the bulk of the primitive NCCL collectives exposed as high-level APIs (e.g. rank/world API, barrier, teardown, allreduce_grads). For reference, right now we're wrapping `cupyx.distributed` as a high-level API, in the future, for educational purposes, we could go down the `cupy.cuda.nccl.NcclCommunicator` path if needed
- DistributedSampler. This is needed because in distributed data parallelism (our first paralellism strategy), every rank has its own DataLoader, so we need to ensure the "effective" global batch/data coverage is correct or efficient. DataLoader still just consumes a Sampler, so that contract is still respected.
- metrics reporting should support all-reducing metrics from all the backend devices and report the aggregated metric instead of just rank 0
- call `broadcast_parameters` and `allreduce_grads` throughout the training flow to actually make the components distributed-aware. I hope this is the right design decision.
- `gradient_accumulation_steps` now means per-rank steps. I've added some config validations to surface invalid configs early
- for checkpointing, rank-0-loads model params and optimizer tensor state, then broadcast after pretrained/resume loads


## Other indirect changes
I had ironed out on a multi-GPU cloud server because previously I didn't have the hardware to test it thoroughly.


### BF16 Support
  - if the selected backend is CuPy or NumPy and it does not expose `xp.bfloat16`, we will use `ml_dtypes` to support that (added `ml_dtypes` python dependency)
  - `resolve_dtype("bfloat16")` for config-string dtype resolution
  - `check_bf16_capability(...)` to reject CuPy BF16 on pre-Ampere GPUs
  - There are some tensor ops like scatter-add that doesn't support BF16 in CuPy, so we will need to promote to FP32 then descale back. The memory footprint shouldn't be that much.

The contract is, if `parameter_dtype="bfloat16"` in the training config:
  - Params should be BF16.
  - Default activations/intermediates should remain BF16.
  - Explicit stability/compatibility regions may be FP32: RMSNorm/LayerNorm stats, loss logits, Adam moments, DDP transport workaround, scatter-add workaround.
  - Resume checkpoints are an exception: saved model_init_kwargs win over current config.

### Matrix Multiplication
CuPy was fragile on the ND @ 2D matmul path. We rewrite that case as equivalent 2D @ 2D GEMM plus reshape, which preserves the math while avoiding the CuPy-specific failure path.

```
#   x:      (batch, time, hidden)
#   y:      (hidden, vocab)
#   output: (batch, time, vocab)
```

Equivalent to 
```
#   (batch * time, hidden) @ (hidden, vocab)
# then reshaping back to (batch, time, vocab).
```


### Tokenizer optimization
When running in the cloud machine, I had to rebuild the vocabulary and encode the training data from scratch. This bumped into very inefficient tokenization process, so I had to optimize this to save $$ on the cloud.

Some rough comparisons

| Benchmark | `main` branch median seconds | optimized median seconds | Speedup (`main` branch /optimized) |
|---|---|---|---|
| Vocabulary training, 120k docs, n_workers=1 | 0.685 | 0.576 | 1.19x faster |
| Vocabulary training, 120k docs, n_workers=4 | 0.232 | 0.237 | 0.98x, about same |
| Cold encode, 2.0 MB natural text | 0.826 | 0.312 | 2.65x faster |
| Warm encode, 2.0 MB natural text | 0.825 | 0.248 | 3.32x faster |
| Cold encode, 3.2 MB repeated text | 1.251 | 0.440 | 2.84x faster |
| Warm encode, 3.2 MB repeated text | 1.248 | 0.441 | 2.83x faster |

### Fix some dtype implicit promotion to FP32 cases

1. In ScaledDotProductAttention, two constants were created as default/explicit FP32:
```
attention_size = Tensor(key.shape[-1])
mask = Tensor(xp.ones(..., dtype=xp.float32))
```
Those participate in attention math. With BF16 inputs, they could promote the attention path/output to FP32.


2. `Optimizer.scale_gradients(...)` may multiply a BF16/FP16 grad by an FP32 scale. Some backends promote the result to FP32 during the in-place-ish operation.


## Tests
Added unit tests.  Note that there are some distributed mock unit tests that enables us to validate distributed training logic without multiple GPUs. This is necessary since CI pipeline doesn't have multiple GPUs.


**Distributed Training**
```
(ml-by-hand) (main) root@C.36904017:/workspace/ml-by-hand$ python -m autograd.distributed.launch --nproc-per-node=2 examples/gpt_2.py
[launcher] spawned 2 ranks on 127.0.0.1:54539
2026-05-17 00:51:57,487 - INFO - Loading the vocabulary from disk.
2026-05-17 00:51:57,492 - INFO - Loading the vocabulary from disk.
2026-05-17 00:51:57,505 - INFO - Found existing encoded data at 'training_data/bpe_32768_openwebtext_encoded_data.npy', loading it without fetching raw data.
2026-05-17 00:51:57,505 - INFO - Vocabulary size: 33035
2026-05-17 00:51:57,505 - INFO - Encoded data length: 9105418757
2026-05-17 00:51:57,511 - INFO - Found existing encoded data at 'training_data/bpe_32768_openwebtext_encoded_data.npy', loading it without fetching raw data.
2026-05-17 00:51:57,511 - INFO - Vocabulary size: 33035
2026-05-17 00:51:57,511 - INFO - Encoded data length: 9105418757
2026-05-17 00:51:57,518 - INFO - No resume_epoch given; initializing model & optimizer from scratch.
2026-05-17 01:06:59,088 - INFO - Training GPT2 with 111.21M parameters.
2026-05-17 01:06:59,089 - INFO - Fit plan:
{'mode': 'steps',
 'target_step': 600000,
 'report_every_steps': 1000,
 'global_batch_size': 480,
 'micro_batch_size': 12,
 'gradient_accumulation_steps': 20}
Training:   0%|                                        | 5/600000 [01:29<2883:54:04, 17.30s/it]
```

```
|   0  NVIDIA RTX PRO 6000 Blac...    On  |   00000000:3F:00.0 Off |                    0 |
| N/A   38C    P0            289W /  600W |   83744MiB /  97887MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA RTX PRO 6000 Blac...    On  |   00000000:BB:00.0 Off |                    0 |
| N/A   36C    P0            308W /  600W |   83189MiB /  97887MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A           88025      C   python                                  550MiB |
|    0   N/A  N/A           88104      C   ...e/ml-by-hand/.venv/bin/python      83180MiB |
|    1   N/A  N/A           88105      C   ...e/ml-by-hand/.venv/bin/python      83180MiB |
```