### PR TITLE
Some fixes to run GPT-2 with distributed training 

### DIFF
--- a/autograd/data/sampler.py
+++ b/autograd/data/sampler.py
@@ -168,6 +168,7 @@ class DistributedSamplerAdapter(Sampler):
         self._seed = int(seed)
         self._epoch = 0
         self._with_replacement = bool(getattr(sampler, "replacement", False))
+        self._is_sequential = isinstance(sampler, SequentialSampler)
 
         global_samples = len(sampler)
         if self._with_replacement:
@@ -176,9 +177,6 @@ class DistributedSamplerAdapter(Sampler):
             self._per_rank_samples = (global_samples + world_size - 1) // world_size
 
         self._indices: list[int] = []
-        self._refresh_indices()
-
-    def _refresh_indices(self) -> None:
         if self._with_replacement:
             dataset = getattr(self._sampler, "dataset", None)
             if dataset is None:
@@ -187,15 +185,19 @@ class DistributedSamplerAdapter(Sampler):
                     "for with-replacement sampling so it can sample from "
                     "the full index range."
                 )
-            n = len(dataset)
-            # Mix (seed, epoch, rank) into a single 64-bit seed. Naive
-            # tuple hashing in some RNGs only uses the first element,
-            # which would correlate streams across ranks.
-            h = 0
-            for s in (self._seed, self._epoch, self._rank):
-                h = (h * 1_000_003 + int(s)) & 0xFFFF_FFFF_FFFF_FFFF
-            rng = np.random.default_rng(h)
-            self._indices = rng.integers(0, n, size=self._per_rank_samples).tolist()
+            self._replacement_population = len(dataset)
+        else:
+            self._refresh_indices()
+
+    def _refresh_indices(self) -> None:
+        if self._with_replacement:
+            return
+
+        # SequentialSampler yields range(n) deterministically. Materializing
+        # `list(iter(sampler))` for a billion-element eval set is ~25 GB of
+        # Python ints and ~40 s of CPU, stalling DDP at every eval start.
+        # The per-rank strided indices are derivable from range objects.
+        if self._is_sequential:
             return
 
         # Without-replacement: materialize global order, pad to multiple
@@ -209,6 +211,23 @@ class DistributedSamplerAdapter(Sampler):
             full = full[:target]
         self._indices = full[self._rank :: self._world_size]
 
+    def _iter_sequential_strided(self) -> Iterator[int]:
+        """Lazy per-rank strided indices for a SequentialSampler.
+
+        Virtual padded global order is ``[0..n-1] + [0..deficit-1]`` where
+        ``deficit = target - n`` (at most ``world_size - 1``). The rank's
+        view is positions ``[rank, target)`` stride ``world_size``; the
+        base part stays inside ``[0, n)`` and the optional wrap part picks
+        the few padded indices that fall on this rank.
+        """
+        n = len(self._sampler)
+        target = self._per_rank_samples * self._world_size
+        yield from range(self._rank, min(n, target), self._world_size)
+        if target > n:
+            deficit = target - n
+            wrap_start = (self._rank - n) % self._world_size
+            yield from range(wrap_start, deficit, self._world_size)
+
     def on_epoch_start(self) -> None:
         self._epoch += 1
         # Forward to the wrapped sampler so its internal RNG advances
@@ -216,11 +235,33 @@ class DistributedSamplerAdapter(Sampler):
         self._sampler.on_epoch_start()
         self._refresh_indices()
 
+    def _iter_with_replacement(self) -> Iterator[int]:
+        # Mix (seed, epoch, rank) into a single 64-bit seed. Naive
+        # tuple hashing in some RNGs only uses the first element,
+        # which would correlate streams across ranks.
+        h = 0
+        for s in (self._seed, self._epoch, self._rank):
+            h = (h * 1_000_003 + int(s)) & 0xFFFF_FFFF_FFFF_FFFF
+        rng = np.random.default_rng(h)
+
+        remaining = self._per_rank_samples
+        chunk_size = min(self._replacement_population, 1_000_000)
+        while remaining > 0:
+            batch = min(chunk_size, remaining)
+            yield from rng.integers(
+                0, self._replacement_population, size=batch
+            ).tolist()
+            remaining -= batch
+
     def __iter__(self) -> Iterator[int]:
+        if self._with_replacement:
+            return self._iter_with_replacement()
+        if self._is_sequential:
+            return self._iter_sequential_strided()
         return iter(self._indices)
 
     def __len__(self) -> int:
-        return len(self._indices)
+        return self._per_rank_samples
 
 
 class TokenLengthGroupedRandomSampler(Sampler):

--- a/autograd/data/sft.py
+++ b/autograd/data/sft.py
@@ -328,10 +328,11 @@ def prepare_sft_token_sequences(
         flat_loss_mask_ids.extend(loss_mask)
         example_offsets.append(len(flat_token_ids))
 
-    if bpe._should_parallelize(
-        work_items=len(chat_examples),
-        min_items_per_worker=64,
-    ):
+    # On small workloads, Pool startup/pickling dominates the actual work,
+    # especially on macOS where multiprocessing uses `spawn`. Only fan out
+    # when each worker has enough items to amortize that fixed overhead.
+    min_items_per_worker = 64
+    if bpe.n_workers > 1 and len(chat_examples) >= bpe.n_workers * min_items_per_worker:
         with Pool(
             bpe.n_workers,
             initializer=_init_sft_tokenizer_worker,

--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -2,7 +2,6 @@ import heapq
 import logging
 import os
 import pickle
-import shutil
 from collections import Counter, OrderedDict
 from itertools import batched
 from multiprocessing import Pool, cpu_count
@@ -45,6 +44,11 @@ class BytePairEncoder:
     WORD_FREQ_BATCH_SIZE = 10_000
     WORD_FREQ_LOG_INTERVAL = 500_000
 
+    # Worker-side handle for the encode Pool. Set by ``_init_encode_worker``
+    # in each spawned worker process so subsequent ``imap`` calls can reach
+    # the BPE without re-pickling ``self`` per batch.
+    _WORKER_BPE: Optional["BytePairEncoder"] = None
+
     def __init__(
         self,
         num_merges: int = 500,
@@ -58,7 +62,7 @@ class BytePairEncoder:
         Args:
             num_merges (int): Number of BPE merges to learn during training.
             vocab_file_path (str): Path to store or load the pickled vocabulary.
-            encoded_data_path (str): Path to store or load the encoded data as an NPZ file.
+            encoded_data_path (str): Path to store or load the encoded data. The extension is replaced with ``.bin`` (the stored file is a raw little-endian int32 stream); see :meth:`load_encoded`.
             n_workers (Optional[int]): Number of processes for parallel operations. If None,
                 defaults to the number of CPU cores minus one.
             min_word_freq (int): Minimum frequency for a word form to be included in
@@ -74,7 +78,9 @@ class BytePairEncoder:
         self.min_word_freq = min_word_freq
         self.vocab_file_path = vocab_file_path
         self.encoded_data_path = encoded_data_path
-        self.mmap_path = os.path.splitext(encoded_data_path)[0] + ".npy"
+        # We store the encoded corpus as a raw little-endian int32 stream.
+        # No header — the count is recovered at load time from the file size.
+        self.mmap_path = os.path.splitext(encoded_data_path)[0] + ".bin"
         base, ext = os.path.splitext(vocab_file_path)
         self.word_freq_cache_path = base + ".word_freq" + ext
 
@@ -93,7 +99,7 @@ class BytePairEncoder:
 
         # Parallelism
         if n_workers is None:
-            self.n_workers = max(1, cpu_count() - 1)
+            self.n_workers = min(32, max(1, cpu_count() - 1))
         else:
             self.n_workers = n_workers
 
@@ -130,15 +136,16 @@ class BytePairEncoder:
         """Trains and applies BPE on the given texts, returning encoded token IDs.
 
         Convenience wrapper that trains the vocabulary then writes token IDs
-        to the configured memory-mapped file.
-        ``texts`` must be re-iterable (e.g. a list or an object whose
-        ``__iter__`` returns a fresh iterator each time) because the corpus
-        is traversed once for vocabulary training and once for encoding.
+        to the configured memory-mapped file. ``texts`` is consumed twice
+        when both passes run — once to build word frequencies during training,
+        once to encode — so it must be re-iterable (e.g. a list or an object
+        whose ``__iter__`` returns a fresh iterator each time). A bare
+        generator will be exhausted before encoding starts.
 
         Args:
             texts (Iterable[str]): Documents to train on and encode.
             overwrite_vocabulary_file (bool): If True, re-trains and overwrites the BPE vocabulary.
-            overwrite_encoded_data (bool): If True, overwrites an existing .npy file.
+            overwrite_encoded_data (bool): If True, overwrites an existing encoded file.
 
         Returns:
             np.ndarray: A memory-mapped array of token IDs.
@@ -151,7 +158,7 @@ class BytePairEncoder:
         """
         self.train_vocabulary(texts, overwrite_saved_file=overwrite_vocabulary_file)
         self._encode_to_mmap(texts, overwrite_encoded_data=overwrite_encoded_data)
-        return np.load(self.mmap_path, mmap_mode="r")
+        return self.load_encoded(self.mmap_path)
 
     def train_vocabulary(
         self, texts: Iterable[str], overwrite_saved_file: bool = False
@@ -205,7 +212,7 @@ class BytePairEncoder:
                 pickle.dump(word_freq, f)
         return self._learn_vocabulary_from_word_freq(word_freq)
 
-    def encode(self, input_text: str, *, show_progress: bool = False) -> List[int]:
+    def encode(self, input_text: str) -> List[int]:
         """Encodes a raw input string into a list of BPE token IDs.
 
         The process is:
@@ -276,6 +283,8 @@ class BytePairEncoder:
 
         Args:
             encoded_tokens (List[int]): The list of integer token IDs to decode.
+                Numpy arrays must be converted with ``.tolist()`` first; this
+                keeps the dict lookup on the hot path free of scalar coercion.
 
         Returns:
             str: The decoded string.
@@ -288,29 +297,20 @@ class BytePairEncoder:
         """
         result_bytes = []
         for t in encoded_tokens:
-            if not isinstance(t, int) and hasattr(t, "item"):  # handle array scalars
-                t = t.item()
             if t in self._int_to_unicode_vocab:
                 result_bytes.append(self._int_to_unicode_vocab[t])
             else:
                 result_bytes.append(b"<UNK>")
         return b"".join(result_bytes).decode("utf-8", errors="replace")
 
-    def _should_parallelize(
-        self, *, work_items: int, min_items_per_worker: int
-    ) -> bool:
-        # On small workloads, Pool startup/pickling dominates the actual work,
-        # especially on macOS where multiprocessing uses `spawn`. Only fan out
-        # when each worker has enough items to amortize that fixed overhead.
-        return (
-            self.n_workers > 1 and work_items >= self.n_workers * min_items_per_worker
-        )
-
     def _load_dictionary(self) -> None:
         """Loads the dictionary (vocab + merges) from disk if it exists.
 
-        If the vocabulary file does not exist or fails to load, creates a new base
-        dictionary (all single-byte chars plus special tokens).
+        If the file does not exist, creates a fresh base dictionary (all
+        single-byte chars plus special tokens). If the file exists but fails
+        to load, raises RuntimeError — silently rebuilding would discard the
+        learned merges the caller asked us to load. Delete the file (or point
+        ``vocab_file_path`` elsewhere) to force a clean retrain.
 
         Examples:
             >>> bpe = BytePairEncoder(num_merges=50, vocab_file_path="nonexistent.pkl")
@@ -327,7 +327,6 @@ class BytePairEncoder:
             self.learned_merges = []
             return
 
-        # If the file exists, attempt to load; fallback to new dictionary if there's an error.
         try:
             with open(self.vocab_file_path, "rb") as f:
                 logger.info("Loading the vocabulary from disk.")
@@ -338,15 +337,11 @@ class BytePairEncoder:
                     self.learned_merges,
                 ) = data
         except (pickle.UnpicklingError, EOFError, ValueError) as e:
-            logger.warning(
-                f"Failed to load the vocabulary from {self.vocab_file_path}. "
-                f"Reason: {e}. Creating new dictionary."
-            )
-            self._unicode_to_int_vocab = self._construct_unicode_to_int_vocab()
-            self._int_to_unicode_vocab = {
-                v: k for k, v in self._unicode_to_int_vocab.items()
-            }
-            self.learned_merges = []
+            raise RuntimeError(
+                f"Failed to load vocabulary from {self.vocab_file_path}: {e}. "
+                "Delete the file (or pass a different vocab_file_path) "
+                "to retrain from scratch."
+            ) from e
 
     def _construct_unicode_to_int_vocab(self) -> Dict[bytes, int]:
         """Constructs a base vocabulary for all single-byte values plus special tokens.
@@ -375,133 +370,112 @@ class BytePairEncoder:
         *,
         text_batch_size: int = 256,
     ) -> str:
-        """Encodes streamed text to a .npy memmap file without holding all tokens in memory.
+        """Encodes streamed text to a raw int32 binary file.
 
-        Encodes the corpus once to count tokens, checks that the output
-        filesystem has enough free space, then encodes again directly into a
-        temporary .npy memmap before atomically replacing the final file.
-        ``text_iter`` must be re-iterable so both passes see the same corpus.
+        Writes each encoded batch's tokens directly with ``ndarray.tofile``,
+        then atomically renames the temporary file to ``self.mmap_path``.
+        The file has no header — readers recover the token count from the
+        file size via :meth:`load_encoded`.
 
         Args:
             text_iter (Iterable[str]): Documents to encode (e.g. a list of strings or
                 a lazy generator). The vocabulary must already be trained.
-            overwrite_encoded_data (bool): If True, overwrites an existing .npy file.
+            overwrite_encoded_data (bool): If True, overwrites an existing file.
             text_batch_size (int): Number of documents to encode per batch.
 
         Returns:
-            str: The path to the .npy memmap file.
+            str: The path to the encoded binary file.
         """
+        if text_batch_size < 1:
+            raise ValueError(f"text_batch_size must be >= 1, got {text_batch_size}")
+
         if os.path.exists(self.mmap_path) and not overwrite_encoded_data:
             logger.info(
                 f"Found existing memory-mapped encoded data at '{self.mmap_path}', "
                 "reusing it instead of re-encoding."
             )
             return self.mmap_path
-        if iter(text_iter) is text_iter:
-            raise TypeError(
-                "_encode_to_mmap requires a re-iterable text source because it "
-                "counts encoded tokens before writing the .npy memmap. Pass a "
-                "sequence or an iterable object whose __iter__ returns a fresh iterator."
-            )
-
         parent_dir = os.path.dirname(self.mmap_path)
         if parent_dir:
             os.makedirs(parent_dir, exist_ok=True)
-        disk_check_dir = parent_dir or "."
 
         int32_dtype = np.dtype("<i4")
-        tmp_npy_path = f"{self.mmap_path}.tmp"
-        stale_raw_path = f"{self.mmap_path}.raw.tmp"
+        tmp_path = f"{self.mmap_path}.tmp"
 
         try:
-            for stale_path in (tmp_npy_path, stale_raw_path):
-                if os.path.exists(stale_path):
-                    os.remove(stale_path)
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
 
-            token_count = self._count_encoded_tokens(
-                text_iter,
-                text_batch_size=text_batch_size,
-            )
-            self._check_encoded_mmap_disk_space(
-                disk_check_dir=disk_check_dir,
-                token_count=token_count,
-                dtype=int32_dtype,
-            )
+            with open(tmp_path, "wb") as out_file:
+                text_batches = batched(text_iter, text_batch_size)
+                if self.n_workers > 1:
+                    # Pool initializer pickles `self` once per worker process;
+                    # imap then only ships text batches across the boundary
+                    # instead of re-pickling the BPE state per batch.
+                    with Pool(
+                        self.n_workers,
+                        initializer=BytePairEncoder._init_encode_worker,
+                        initargs=(self,),
+                    ) as pool:
+                        encoded_batches = pool.imap(
+                            BytePairEncoder._encode_text_batch_array_worker,
+                            text_batches,
+                        )
+                        for flat_batch in tqdm(
+                            encoded_batches,
+                            desc="Encoding text to tokens",
+                            unit="batch",
+                        ):
+                            flat_batch.tofile(out_file)
+                else:
+                    for text_batch in tqdm(
+                        text_batches,
+                        desc="Encoding text to tokens",
+                        unit="batch",
+                    ):
+                        flat_batch = np.fromiter(
+                            (
+                                token
+                                for text in text_batch
+                                for token in self.encode(text)
+                            ),
+                            dtype=int32_dtype,
+                        )
+                        flat_batch.tofile(out_file)
 
-            encoded_mmap = np.lib.format.open_memmap(
-                tmp_npy_path,
-                mode="w+",
-                dtype=int32_dtype,
-                shape=(token_count,),
-            )
-            offset = 0
-            # Writes are positional in the memmap, so batches must arrive in
-            # input order — otherwise tokens from later docs would land in
-            # earlier slots and the file would no longer match the corpus.
-            for encoded_batch in self._iter_encoded_batches(
-                text_iter,
-                text_batch_size=text_batch_size,
-                desc="Encoding text to tokens",
-                preserve_order=True,
-            ):
-                for encoded_text in encoded_batch:
-                    end = offset + len(encoded_text)
-                    encoded_mmap[offset:end] = np.asarray(
-                        encoded_text,
-                        dtype=int32_dtype,
-                    )
-                    offset = end
-            if offset != token_count:
-                raise RuntimeError(
-                    "Encoded token count changed between counting and writing: "
-                    f"counted {token_count}, wrote {offset}. "
-                    "Use a deterministic re-iterable text source."
-                )
-            encoded_mmap.flush()
-            del encoded_mmap
-
-            os.replace(tmp_npy_path, self.mmap_path)
+            os.replace(tmp_path, self.mmap_path)
         finally:
-            if os.path.exists(tmp_npy_path):
-                os.remove(tmp_npy_path)
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
 
         return self.mmap_path
 
-    def _count_encoded_tokens(
-        self,
-        text_iter: Iterable[str],
-        *,
-        text_batch_size: int,
-    ) -> int:
-        token_count = 0
-        for encoded_batch in self._iter_encoded_batches(
-            text_iter,
-            text_batch_size=text_batch_size,
-            desc="Counting encoded tokens",
-            preserve_order=False,
-        ):
-            for encoded_text in encoded_batch:
-                token_count += len(encoded_text)
-        return token_count
+    @staticmethod
+    def load_encoded(path: str) -> np.ndarray:
+        """Memory-maps a raw int32 token stream written by ``_encode_to_mmap``.
 
-    def _check_encoded_mmap_disk_space(
-        self,
-        *,
-        disk_check_dir: str,
-        token_count: int,
-        dtype: np.dtype,
-    ) -> None:
-        header_allowance_bytes = 1024 * 1024
-        required_bytes = (token_count * dtype.itemsize) + header_allowance_bytes
-        required_with_buffer = int(required_bytes * 1.2)
-        free_bytes = shutil.disk_usage(disk_check_dir).free
-        if free_bytes < required_with_buffer:
-            raise OSError(
-                "Insufficient disk space to encode token data: "
-                f"need at least {required_with_buffer} bytes "
-                f"({required_bytes} bytes plus 20% buffer), "
-                f"but only {free_bytes} bytes are free in {disk_check_dir!r}."
-            )
+        The file has no header, so the token count is the file size divided
+        by ``int32.itemsize`` (4 bytes per token).
+        """
+        int32_dtype = np.dtype("<i4")
+        token_count = os.path.getsize(path) // int32_dtype.itemsize
+        return np.memmap(path, dtype=int32_dtype, mode="r", shape=(token_count,))
+
+    @staticmethod
+    def _init_encode_worker(bpe: "BytePairEncoder") -> None:
+        # Pool ``initializer`` hook: runs once per spawned worker process so
+        # the heavy BPE state is pickled only at startup, not per batch.
+        BytePairEncoder._WORKER_BPE = bpe
+
+    @staticmethod
+    def _encode_text_batch_array_worker(text_batch: Sequence[str]) -> np.ndarray:
+        bpe = BytePairEncoder._WORKER_BPE
+        if bpe is None:
+            raise RuntimeError("Tokenizer worker was not initialized")
+        return np.fromiter(
+            (token for text in text_batch for token in bpe.encode(text)),
+            dtype=np.dtype("<i4"),
+        )
 
     def _build_word_freq(self, texts: Iterable[str]) -> Counter:
         """Build word frequency table from documents, parallelized when possible.
@@ -715,37 +689,6 @@ class BytePairEncoder:
                 final_chunks.extend(self._general_pattern.findall(segment))
 
         return [tok for tok in final_chunks if tok]
-
-    def _iter_encoded_batches(
-        self,
-        text_iter: Iterable[str],
-        *,
-        text_batch_size: int,
-        desc: str,
-        preserve_order: bool = True,
-    ) -> Iterable[list[list[int]]]:
-        if text_batch_size < 1:
-            raise ValueError(f"text_batch_size must be >= 1, got {text_batch_size}")
-
-        text_batches = batched(text_iter, text_batch_size)
-        if self.n_workers > 1:
-            with Pool(self.n_workers) as pool:
-                encoded_batches = (
-                    pool.imap(self._encode_text_batch, text_batches)
-                    if preserve_order
-                    else pool.imap_unordered(self._encode_text_batch, text_batches)
-                )
-                yield from tqdm(
-                    encoded_batches,
-                    desc=desc,
-                    unit="batch",
-                )
-        else:
-            for text_batch in tqdm(text_batches, desc=desc, unit="batch"):
-                yield self._encode_text_batch(text_batch)
-
-    def _encode_text_batch(self, text_batch: Sequence[str]) -> list[list[int]]:
-        return [self.encode(text) for text in text_batch]
 
     def _apply_merges_to_corpus_indexed(
         self,

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -1228,20 +1228,32 @@ class LLMTrainer(AbstractTrainer):
             EvalResult: The average validation loss and derived metrics.
         """
         state = TrainingState()
-        for batch_data in tqdm(iter(val_data_loader), desc="Evaluation", leave=False):
-            if (
-                self.config.max_eval_steps is not None
-                and state.eval_loss_batches >= self.config.max_eval_steps
+        # In DDP, eval_callbacks (e.g. autoregressive text generation) only
+        # run on rank 0 and can take much longer than the eval loop itself.
+        # Rank 0 skips its share of the eval batches so the callback overlaps
+        # with the other ranks' eval work, instead of serializing them at the
+        # all_reduce barrier in `report()`. Rank 0 then contributes
+        # (sum=0, weight=0) to the metrics all_reduce, which is mathematically
+        # the rank-N>0 aggregate — no bias, just fewer total eval samples.
+        skip_eval_loop = is_distributed() and rank() == 0 and bool(self.eval_callbacks)
+
+        if not skip_eval_loop:
+            for batch_data in tqdm(
+                iter(val_data_loader), desc="Evaluation", leave=False
             ):
-                break
-            # Report hard-label CE/NLL for validation; smoothing is a training regularizer.
-            loss = self._forward_and_loss(batch_data, label_smoothing=0.0)
-            state.record_eval_loss(
-                loss,
-                total_weight=self._loss_total_weight(batch_data),
-            )
-        if state.eval_loss_batches == 0:
-            raise ValueError("val_data_loader yielded no batches.")
+                if (
+                    self.config.max_eval_steps is not None
+                    and state.eval_loss_batches >= self.config.max_eval_steps
+                ):
+                    break
+                # Hard-label CE/NLL for validation; smoothing is a training regularizer.
+                loss = self._forward_and_loss(batch_data, label_smoothing=0.0)
+                state.record_eval_loss(
+                    loss,
+                    total_weight=self._loss_total_weight(batch_data),
+                )
+            if state.eval_loss_batches == 0:
+                raise ValueError("val_data_loader yielded no batches.")
 
         if rank() == 0:
             for callback in self.eval_callbacks:

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -4,8 +4,6 @@ import logging
 import sys
 from pathlib import Path
 
-import numpy as np
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -380,10 +378,10 @@ if __name__ == "__main__":
             n_workers=CONFIG.custom_bpe.n_workers,
             min_word_freq=5,  # this is about 99.7% coverage
         )
-        encoded_npy_path = Path(bpe.mmap_path)
+        encoded_path = Path(bpe.mmap_path)
         vocab_path = Path(CONFIG.custom_bpe.vocab_path)
         use_cached_encoded_data = (
-            encoded_npy_path.exists()
+            encoded_path.exists()
             and vocab_path.exists()
             and not CONFIG.custom_bpe.overwrite_encoded_data
             and not CONFIG.custom_bpe.overwrite_vocabulary_file
@@ -391,9 +389,9 @@ if __name__ == "__main__":
         if use_cached_encoded_data:
             logger.info(
                 "Found existing encoded data at '%s', loading it without fetching raw data.",
-                encoded_npy_path,
+                encoded_path,
             )
-            encoded_data = np.load(str(encoded_npy_path), mmap_mode="r")
+            encoded_data = BytePairEncoder.load_encoded(str(encoded_path))
             logger.info(f"Vocabulary size: {bpe.n_vocab}")
             logger.info(f"Encoded data length: {len(encoded_data)}")
         else:

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -11,13 +11,18 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from autograd import functional, nn, optim
-from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, xp
+from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, resolve_dtype, xp
 from autograd.data.collator import CausalLMWindowCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import TokenWindowMapDataset
-from autograd.data.sampler import RandomSampler, SequentialSampler
+from autograd.data.sampler import (
+    DistributedSamplerAdapter,
+    RandomSampler,
+    SequentialSampler,
+)
 from autograd.data.types import CausalLMBatch
 from autograd.data.utils import train_test_split
+from autograd.distributed import is_distributed, rank, world_size
 from autograd.tensor import Tensor, checkpoint
 from autograd.text import utils as text_utils
 from autograd.text.tokenizer import BytePairEncoder
@@ -62,7 +67,7 @@ class GPT2(nn.Module):
     ) -> None:
         super().__init__(**kwargs)
         if isinstance(parameter_dtype, str):
-            parameter_dtype = getattr(xp, parameter_dtype)
+            parameter_dtype = resolve_dtype(parameter_dtype)
         self.hidden_size = hidden_size
         self.max_seq_len = max_seq_len
         self.activation_checkpointing = activation_checkpointing
@@ -218,7 +223,7 @@ if __name__ == "__main__":
         max_eval_steps=50,
         checkpoint_freq=4,
         global_batch_size=train_global_batch_size,
-        micro_batch_size=train_global_batch_size,
+        micro_batch_size=train_global_batch_size // 4,
         max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 6,  # GPT-2 small uses 12
@@ -302,46 +307,61 @@ if __name__ == "__main__":
         ),
     )
 
+    GPT2_TOKENIZER_VOCAB_SIZE = 50_257
+    GPT2_PADDED_VOCAB_SIZE = 50_304
+    GPT2_CUSTOM_BPE_NUM_MERGES = (
+        GPT2_TOKENIZER_VOCAB_SIZE - 256 - len(BytePairEncoder.SPECIAL_TOKENS)
+    )
     OPENWEBTEXT_CONFIG = TransformerTrainingConfig(
-        training_run_name="openwebtext",
+        training_run_name="openwebtext_gpt2_124m_baseline",
         dataset_name="openwebtext",
-        max_steps=25000,
-        max_eval_steps=20,
-        checkpoint_freq=1000,
-        report_every_steps=50,
-        global_batch_size=76,
-        micro_batch_size=19,
+        max_steps=5000,
+        max_eval_steps=200,
+        checkpoint_freq=200,
+        report_every_steps=100,
+        global_batch_size=480,
+        micro_batch_size=120,
         max_grad_norm=1.0,
         model_kwargs={
-            "num_attention_heads": 9,
-            "hidden_size": 576,
-            "dropout_prob": 0.1,
+            "num_attention_heads": 12,
+            "hidden_size": 768,
+            "vocab_size": GPT2_PADDED_VOCAB_SIZE,
+            # Match nanoGPT's OpenWebText GPT-2 reproduction: pretraining uses
+            # no dropout, and the loss config below uses plain next-token CE.
+            "dropout_prob": 0.0,
             "max_seq_len": 1024,
-            "num_decoder_layers": 8,
+            "num_decoder_layers": 12,
             "activation_checkpointing": False,
             "parameter_dtype": "bfloat16",
         },
         optimizer_kwargs={
-            "lr": 1e-3,
-            "beta2": 0.99,
+            "lr": 6e-4,
+            "beta2": 0.95,
             "weight_decay": 0.1,
             "lr_scheduler_kwargs": {
                 "lr_scheduler_cls": optim.CosineScheduler,
-                "warmup_steps": 3750,
-                "lr_decay_iters": 20000,
+                "warmup_steps": 750,
+                "lr_decay_iters": 5000,
             },
         },
-        resume_epoch=7000,
+        resume_epoch=None,
         teacher_forcing=False,
-        label_smoothing=0.1,
+        label_smoothing=0.0,
         eval_start_string="The",
         custom_bpe=CustomBpeConfig(
-            num_merges=32768,
-            encoded_data_path="training_data/bpe_32768_openwebtext_encoded_data.npz",
-            vocab_path="training_data/openwebtext_vocab_32768.pkl",
+            # Matches GPT-2's 50,257-token cardinality with this repo's custom
+            # BPE. Exact GPT-2 tokenizer parity requires GPT-2's merge ranks.
+            num_merges=GPT2_CUSTOM_BPE_NUM_MERGES,
+            encoded_data_path=(
+                f"training_data/bpe_{GPT2_CUSTOM_BPE_NUM_MERGES}_"
+                "openwebtext_encoded_data.npz"
+            ),
+            vocab_path=(
+                f"training_data/openwebtext_vocab_{GPT2_CUSTOM_BPE_NUM_MERGES}.pkl"
+            ),
             overwrite_encoded_data=False,
             overwrite_vocabulary_file=False,
-            start_token="<SOS>",
+            start_token="",
             split_token="<|endoftext|>",
             parquet_shards_per_batch=32,
         ),
@@ -414,7 +434,21 @@ if __name__ == "__main__":
     train_data, test_data = train_test_split(encoded_data, test_size=0.1, shuffle=False)
     del encoded_data
 
-    CONFIG.model_kwargs["vocab_size"] = bpe.n_vocab
+    def generate_eval_samples(
+        model,
+        _forward_fn,
+        _val_data_loader,
+        config: TransformerTrainingConfig,
+    ) -> None:
+        generate_text(
+            model=model,
+            prediction_func=GPT2ForwardFn(),
+            bpe=bpe,
+            start_tokens=config.eval_start_string,
+            max_length=min(256, int(model.max_seq_len)),
+            temperature=0.8,
+            top_k=config.eval_top_k,
+        )
 
     trainer = LLMTrainer(
         model_cls=GPT2,
@@ -422,6 +456,7 @@ if __name__ == "__main__":
         loss_fn=functional.cross_entropy,
         config=CONFIG,
         forward_fn=GPT2ForwardFn(),
+        eval_callbacks=[generate_eval_samples],
     )
 
     train_dataset = TokenWindowMapDataset(
@@ -436,21 +471,31 @@ if __name__ == "__main__":
         # so a length-T model context needs a raw window of length T + 1.
         window_len=trainer.model.max_seq_len + 1,
     )
+    train_sampler = RandomSampler(
+        train_dataset,
+        replacement=True,
+        num_samples=len(train_dataset),
+    )
+    test_sampler = SequentialSampler(test_dataset)
+    if is_distributed():
+        train_sampler = DistributedSamplerAdapter(
+            train_sampler, rank=rank(), world_size=world_size()
+        )
+        test_sampler = DistributedSamplerAdapter(
+            test_sampler, rank=rank(), world_size=world_size()
+        )
+
     train_data_loader = DataLoader(
         dataset=train_dataset,
         batch_size=CONFIG.micro_batch_size,
         collator=CausalLMWindowCollator(),
-        sampler=RandomSampler(
-            train_dataset,
-            replacement=True,
-            num_samples=len(train_dataset),
-        ),
+        sampler=train_sampler,
     )
     test_data_loader = DataLoader(
         dataset=test_dataset,
         batch_size=max(1, CONFIG.micro_batch_size // 2),
         collator=CausalLMWindowCollator(),
-        sampler=SequentialSampler(test_dataset),
+        sampler=test_sampler,
     )
 
     trainer.fit(train_data_loader, test_data_loader)

--- a/test/autograd/text/test_tokenizer.py
+++ b/test/autograd/text/test_tokenizer.py
@@ -1,10 +1,6 @@
 import os
-import shutil
 import tempfile
 from unittest import TestCase
-from unittest.mock import patch
-
-import numpy as np
 
 from autograd.text.tokenizer import BytePairEncoder
 from test.helpers import array_equal
@@ -90,14 +86,14 @@ class TestTokenizer(TestCase):
         self.assertEqual(len(cached_after_first), 2)
         self.assertEqual(dict(self.bpe._encoded_chunk_cache), cached_after_first)
 
-    def test_load_dictionary_fallback(self):
+    def test_load_dictionary_raises_on_corrupt_file(self):
         with open(self.bpe.vocab_file_path, "wb") as f:
             f.write(b"\x80\x03}q\x00.")  # incomplete or invalid pickle data
-        # Now re-initialize the BytePairEncoder; it should catch the error and rebuild
-        bpe_new = BytePairEncoder(
-            num_merges=50, vocab_file_path=self.bpe.vocab_file_path
-        )
-        self.assertGreater(len(bpe_new._unicode_to_int_vocab), 0)
+        # Construction must refuse to silently rebuild: silently overwriting
+        # learned merges would lose user data. The caller is forced to delete
+        # the file (or change the path) before retrying.
+        with self.assertRaisesRegex(RuntimeError, "Failed to load vocabulary"):
+            BytePairEncoder(num_merges=50, vocab_file_path=self.bpe.vocab_file_path)
 
     def test_train_vocabulary_skip_if_loaded_and_no_overwrite(self):
         # First train
@@ -139,13 +135,13 @@ class TestTokenizer(TestCase):
             full_bpe = BytePairEncoder(
                 num_merges=20,
                 vocab_file_path=os.path.join(tmpdir, "full_vocab.pkl"),
-                encoded_data_path=os.path.join(tmpdir, "full_encoded.npy"),
+                encoded_data_path=os.path.join(tmpdir, "full_encoded.bin"),
                 n_workers=1,
             )
             stream_bpe = BytePairEncoder(
                 num_merges=20,
                 vocab_file_path=os.path.join(tmpdir, "stream_vocab.pkl"),
-                encoded_data_path=os.path.join(tmpdir, "stream_encoded.npy"),
+                encoded_data_path=os.path.join(tmpdir, "stream_encoded.bin"),
                 n_workers=1,
             )
 
@@ -157,7 +153,7 @@ class TestTokenizer(TestCase):
                 text_batch_size=2,
             )
 
-            stream_encoded = np.load(mmap_path, mmap_mode="r")
+            stream_encoded = BytePairEncoder.load_encoded(mmap_path)
 
             self.assertEqual(full_bpe.learned_merges, stream_bpe.learned_merges)
             self.assertEqual(
@@ -166,7 +162,7 @@ class TestTokenizer(TestCase):
             )
             self.assertEqual(full_bpe.encode(full_text), list(stream_encoded))
 
-    def test_prepare_data_writes_direct_npy_memmap(self):
+    def test_prepare_data_cleans_up_tmp_file(self):
         docs = ["hello<|endoftext|>", "world<|endoftext|>"]
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -177,26 +173,28 @@ class TestTokenizer(TestCase):
                 n_workers=1,
             )
             bpe.train_vocabulary(docs, overwrite_saved_file=True)
-            stale_raw_tmp = f"{bpe.mmap_path}.raw.tmp"
-            with open(stale_raw_tmp, "wb") as f:
-                f.write(b"stale temp file")
 
-            with patch(
-                "autograd.text.tokenizer.np.lib.format.write_array",
-                side_effect=AssertionError("prepare_data should not copy raw data"),
-            ):
-                encoded = bpe.prepare_data(
-                    docs,
-                    overwrite_vocabulary_file=False,
-                    overwrite_encoded_data=True,
-                )
+            encoded = bpe.prepare_data(
+                docs,
+                overwrite_vocabulary_file=False,
+                overwrite_encoded_data=True,
+            )
 
             self.assertEqual(bpe.encode("".join(docs)), list(encoded))
-            self.assertFalse(os.path.exists(f"{bpe.mmap_path}.raw.tmp"))
             self.assertFalse(os.path.exists(f"{bpe.mmap_path}.tmp"))
 
-    def test_prepare_data_checks_disk_space_before_writing(self):
-        docs = ["hello<|endoftext|>"]
+    def test_encode_to_mmap_consumes_text_iter_once(self):
+        docs = ["hello<|endoftext|>", "world<|endoftext|>"]
+
+        class OneShotDocs:
+            def __init__(self):
+                self.iterations = 0
+
+            def __iter__(self):
+                self.iterations += 1
+                if self.iterations > 1:
+                    raise AssertionError("text iterator was consumed more than once")
+                yield from docs
 
         with tempfile.TemporaryDirectory() as tmpdir:
             bpe = BytePairEncoder(
@@ -206,57 +204,43 @@ class TestTokenizer(TestCase):
                 n_workers=1,
             )
             bpe.train_vocabulary(docs, overwrite_saved_file=True)
-            disk_usage = shutil._ntuple_diskusage(total=10, used=9, free=1)
+            text_source = OneShotDocs()
 
-            with patch("autograd.text.tokenizer.shutil.disk_usage") as mock_disk_usage:
-                mock_disk_usage.return_value = disk_usage
-                with self.assertRaisesRegex(OSError, "Insufficient disk space"):
-                    bpe.prepare_data(
-                        docs,
-                        overwrite_vocabulary_file=False,
-                        overwrite_encoded_data=True,
-                    )
-
-            self.assertFalse(os.path.exists(bpe.mmap_path))
-            self.assertFalse(os.path.exists(f"{bpe.mmap_path}.tmp"))
-
-    def test_count_encoded_tokens_uses_unordered_worker_results(self):
-        class RecordingPool:
-            calls = []
-
-            def __init__(self, _n_workers):
-                pass
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_args):
-                return None
-
-            def imap(self, fn, batches):
-                self.calls.append("imap")
-                return map(fn, batches)
-
-            def imap_unordered(self, fn, batches):
-                self.calls.append("imap_unordered")
-                return map(fn, batches)
-
-        docs = ["aa", "bbb", "c"]
-        self.bpe.n_workers = 2
-
-        with patch("autograd.text.tokenizer.Pool", RecordingPool):
-            token_count = self.bpe._count_encoded_tokens(docs, text_batch_size=1)
-            list(
-                self.bpe._iter_encoded_batches(
-                    docs,
-                    text_batch_size=1,
-                    desc="ordered",
-                    preserve_order=True,
-                )
+            mmap_path = bpe._encode_to_mmap(
+                text_source,
+                overwrite_encoded_data=True,
+                text_batch_size=1,
             )
+            encoded = BytePairEncoder.load_encoded(mmap_path)
 
-        self.assertEqual(token_count, sum(len(self.bpe.encode(doc)) for doc in docs))
-        self.assertEqual(RecordingPool.calls, ["imap_unordered", "imap"])
+            self.assertEqual(text_source.iterations, 1)
+            self.assertEqual(bpe.encode("".join(docs)), list(encoded))
+
+    def test_parallel_encode_to_mmap_preserves_token_order(self):
+        docs = [
+            "first document<|endoftext|>",
+            "second document<|endoftext|>",
+            "third document<|endoftext|>",
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bpe = BytePairEncoder(
+                num_merges=10,
+                vocab_file_path=os.path.join(tmpdir, "vocab.pkl"),
+                encoded_data_path=os.path.join(tmpdir, "encoded.npz"),
+                n_workers=2,
+            )
+            bpe.train_vocabulary(docs, overwrite_saved_file=True)
+
+            mmap_path = bpe._encode_to_mmap(
+                docs,
+                overwrite_encoded_data=True,
+                text_batch_size=1,
+            )
+            encoded = BytePairEncoder.load_encoded(mmap_path)
+
+            self.assertEqual(bpe.encode("".join(docs)), list(encoded))
+            self.assertEqual(bpe.decode(encoded.tolist()), "".join(docs))
 
     def test_encode_roundtrips(self):
         text = "hello world"

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -1964,6 +1964,81 @@ class TestLLMTrainer(BaseTrainerTest):
 
         self.assertEqual(run_mock_ranks(2, target), [1, 0])
 
+    @unittest.skipIf(
+        IS_MLX,
+        "MLX lazy graphs are not thread-safe under the in-process DDP mock.",
+    )
+    def test_evaluate_skips_eval_loop_on_rank_zero_when_callbacks_present(self):
+        """Under DDP with eval_callbacks, rank 0 skips the eval batch loop
+        so the slow single-rank text generation overlaps with other ranks'
+        eval batches instead of serializing them at the all_reduce barrier.
+
+        Other ranks contribute the full eval signal; rank 0 contributes
+        zero-loss/zero-weight to the all_reduce, which is mathematically
+        neutral (sum/weight stays the rank-N>0 aggregate)."""
+
+        def target():
+            callback = MagicMock()
+            # Per-thread mocks so call counts cleanly attribute to each rank.
+            forward_fn = MagicMock()
+            forward_fn.train.return_value = Tensor(self.fake_pred)
+            forward_fn.return_value = (
+                Tensor(self.fake_pred),
+                xp.zeros((2, 10), dtype=xp.int32),
+            )
+            loss_fn = MagicMock(return_value=Tensor(1.23))
+
+            trainer = LLMTrainer(
+                model_cls=MockModelClass,
+                optimizer_cls=MockOptimizerClass,
+                loss_fn=loss_fn,
+                forward_fn=forward_fn,
+                config=self.config,
+                eval_callbacks=[callback],
+            )
+            trainer.evaluate(self.val_loader)
+            return loss_fn.call_count, callback.call_count
+
+        per_rank = run_mock_ranks(2, target)
+        # Rank 0: no eval batches processed; callback ran once.
+        self.assertEqual(per_rank[0], (0, 1))
+        # Rank 1: ran the eval loop; no callbacks.
+        rank_one_loss_calls, rank_one_callback_calls = per_rank[1]
+        self.assertGreaterEqual(rank_one_loss_calls, 1)
+        self.assertEqual(rank_one_callback_calls, 0)
+
+    @unittest.skipIf(
+        IS_MLX,
+        "MLX lazy graphs are not thread-safe under the in-process DDP mock.",
+    )
+    def test_evaluate_runs_full_eval_loop_on_rank_zero_when_no_callbacks(self):
+        """Without callbacks, rank 0 has no parallel work to overlap, so
+        the optimization MUST NOT skip its eval loop — otherwise eval
+        contribution is silently halved with no benefit."""
+
+        def target():
+            forward_fn = MagicMock()
+            forward_fn.train.return_value = Tensor(self.fake_pred)
+            forward_fn.return_value = (
+                Tensor(self.fake_pred),
+                xp.zeros((2, 10), dtype=xp.int32),
+            )
+            loss_fn = MagicMock(return_value=Tensor(1.23))
+            trainer = LLMTrainer(
+                model_cls=MockModelClass,
+                optimizer_cls=MockOptimizerClass,
+                loss_fn=loss_fn,
+                forward_fn=forward_fn,
+                config=self.config,
+            )
+            trainer.evaluate(self.val_loader)
+            return loss_fn.call_count
+
+        per_rank = run_mock_ranks(2, target)
+        # Both ranks must run the eval loop at least once.
+        for rank_calls in per_rank:
+            self.assertGreaterEqual(rank_calls, 1)
+
     def test_llm_evaluate_rejects_empty_val_loader(self):
         with self.assertRaisesRegex(
             ValueError,

--- a/test/distributed/test_sampler.py
+++ b/test/distributed/test_sampler.py
@@ -110,6 +110,27 @@ def test_sequential_deterministic_across_calls():
     assert list(s1) == list(s2)
 
 
+def test_sequential_does_not_materialize_indices(monkeypatch):
+    """Huge sequential samplers must derive strided per-rank indices
+    analytically instead of materializing `list(iter(sampler))`. On a
+    billion-element eval dataset the eager path is ~25 GB of Python ints
+    and ~40 s of pure CPU work at every eval start, stalling DDP."""
+    dataset = _ListDataset(10_000_000_000)
+    base = SequentialSampler(dataset)
+
+    def fail_iter(_self):
+        raise AssertionError("eager iteration of wrapped SequentialSampler")
+
+    monkeypatch.setattr(SequentialSampler, "__iter__", fail_iter)
+
+    adapter = DistributedSamplerAdapter(base, rank=0, world_size=2)
+    assert len(adapter) == 5_000_000_000
+
+    # First few yielded indices: the per-rank strided range 0, 2, 4, ...
+    it = iter(adapter)
+    assert [next(it) for _ in range(3)] == [0, 2, 4]
+
+
 # ---- with-replacement -----------------------------------------------------
 
 
@@ -120,6 +141,25 @@ def test_with_replacement_per_rank_length():
     base = RandomSampler(dataset, replacement=True, num_samples=n)
     adapter = DistributedSamplerAdapter(base, rank=0, world_size=world_size)
     assert len(adapter) == n // world_size
+
+
+def test_with_replacement_does_not_materialize_indices_at_construction(monkeypatch):
+    """Huge replacement samplers must stay lazy until iteration starts."""
+    dataset = _ListDataset(10_000)
+    base = RandomSampler(dataset, replacement=True, num_samples=10_000_000_000)
+
+    class FailOnDraw:
+        def integers(self, *args, **kwargs):
+            raise AssertionError("eager random index draw")
+
+    monkeypatch.setattr(
+        "autograd.data.sampler.np.random.default_rng",
+        lambda _seed: FailOnDraw(),
+    )
+
+    adapter = DistributedSamplerAdapter(base, rank=0, world_size=2)
+
+    assert len(adapter) == 5_000_000_000
 
 
 def test_with_replacement_independent_streams():


### PR DESCRIPTION
## Description
- Improved the tokenization process. Previously, `_encode_to_mmap` was two full corpus passes (count tokens, then write), now one. Pickle the tokenizer class only once per worker process at startup, instead of per batch. `pool.imap(self._encode_text_batch, batches)` -> `Pool(initializer=..., initargs=(self,))`
- Perform true lazy data sample indexing via iterators instead of materializing the full indices array. This is very costly for OpenWebText dataset with ~25GB of index ints.
- Updated the GPT 2 hyperparameters to better match the full-scale training setup
- In distributed training setting, use rank 0 do to eval callbacks, and run eval loop on other ranks in parallel, so that we don't waste time doing eval callbacks and eval sequentially. We lose rank 0's eval results, but that's fine since eval is always on a small number of steps.

## Tests
Updated unit tests.


