### PR TITLE
Fix bf16 checkpoint round-trip and DDP val-loss reduction

### DIFF
--- a/autograd/tools/model.py
+++ b/autograd/tools/model.py
@@ -7,11 +7,36 @@ import json
 import os
 from typing import Any, Dict
 
-from autograd.backend import ARRAY_TYPE, xp
+from autograd.backend import ARRAY_TYPE, resolve_dtype, xp
 from autograd.tensor import Tensor
 
 # Define a type for the serialized metadata structure
 SerializedMeta = Dict[str, Any]
+
+
+def _dtype_name(arr: Any) -> str:
+    """Return a backend-neutral short dtype name (e.g. "bfloat16").
+
+    Needed because numpy/CuPy report dtypes as "bfloat16" but MLX reports
+    them as "mlx.core.bfloat16" — keying off the short tail makes the JSON
+    sidecar portable across backends.
+    """
+    return str(arr.dtype).rsplit(".", 1)[-1]
+
+
+def _restore_array(meta: SerializedMeta, data: Dict[str, Any]) -> Any:
+    # numpy's .npy format can't natively store extension dtypes like
+    # ml_dtypes.bfloat16 — those round-trip as opaque void bytes (e.g.
+    # |V2). The sidecar carries each array's original dtype so we can
+    # view-reinterpret bytes back to it instead of guessing. Checkpoints
+    # saved before the dtype field existed load as-stored.
+    arr = data[meta["key"]]
+    if "dtype" not in meta:
+        return arr
+    target = resolve_dtype(meta["dtype"])
+    if arr.dtype != target:
+        arr = arr.view(target)
+    return arr
 
 
 def save_checkpoint(
@@ -94,6 +119,7 @@ def save_checkpoint(
             return {
                 "_type": "tensor",
                 "key": key,
+                "dtype": _dtype_name(arrays[key]),
             }
 
         if isinstance(obj, ARRAY_TYPE) or hasattr(obj, "__array__"):
@@ -102,6 +128,7 @@ def save_checkpoint(
             return {
                 "_type": "array",
                 "key": key,
+                "dtype": _dtype_name(arrays[key]),
             }
 
         # Primitive scalar types
@@ -125,8 +152,9 @@ def save_checkpoint(
     with open(json_path, "w") as f:
         json.dump(meta, f, indent=2)
 
-    # Save arrays to NPZ
-    xp.savez_compressed(npz_path, **arrays_dict)
+    # Save arrays to NPZ without compression: dense weights barely compress
+    # and the deflate pass dominates checkpoint save time.
+    xp.savez(npz_path, **arrays_dict)
     return json_path, npz_path
 
 
@@ -187,10 +215,10 @@ def load_checkpoint(
             return items if t == "list" else tuple(items)
 
         if t == "tensor":
-            return Tensor(data[meta["key"]])
+            return Tensor(_restore_array(meta, data))
 
         if t == "array":
-            return data[meta["key"]]
+            return _restore_array(meta, data)
 
         if t == "class":
             module = importlib.import_module(meta["module"])
@@ -200,7 +228,7 @@ def load_checkpoint(
             return resolved
 
         if "key" in meta and "items" not in meta and "value" not in meta:
-            return data[meta["key"]]
+            return _restore_array(meta, data)
 
         if t in ("scalar", "raw"):
             return meta["value"]

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -255,13 +255,13 @@ class TrainingState:
                         xp.asarray(train_loss_total_weight, dtype=xp.float32),
                     ]
                 )
-                if eval_state is not None:
-                    values.extend(
-                        [
-                            xp.asarray(val_loss_sum, dtype=xp.float32),
-                            xp.asarray(val_loss_total_weight, dtype=xp.float32),
-                        ]
-                    )
+            if eval_state is not None:
+                values.extend(
+                    [
+                        xp.asarray(val_loss_sum, dtype=xp.float32),
+                        xp.asarray(val_loss_total_weight, dtype=xp.float32),
+                    ]
+                )
             if eval_state is not None:
                 for key in metric_keys:
                     values.extend(eval_metric_totals[key])
@@ -275,10 +275,10 @@ class TrainingState:
                 train_loss_sum = reduced[offset]
                 train_loss_total_weight = reduced[offset + 1]
                 offset += 2
-                if eval_state is not None:
-                    val_loss_sum = reduced[offset]
-                    val_loss_total_weight = reduced[offset + 1]
-                    offset += 2
+            if eval_state is not None:
+                val_loss_sum = reduced[offset]
+                val_loss_total_weight = reduced[offset + 1]
+                offset += 2
             for key in metric_keys:
                 eval_metric_totals[key] = (reduced[offset], reduced[offset + 1])
                 offset += 2

--- a/test/autograd/tools/test_model.py
+++ b/test/autograd/tools/test_model.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+import zipfile
 from copy import deepcopy
 from unittest import TestCase
 
@@ -178,6 +179,22 @@ class TestModel(TestCase):
         if os.path.isdir(checkpoint_dir):
             os.rmdir(checkpoint_dir)
 
+    def test_save_checkpoint_writes_uncompressed_npz_members(self):
+        save_checkpoint(
+            self.model.state_dict(),
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
+        )
+
+        with zipfile.ZipFile(self.npz_path) as archive:
+            self.assertTrue(archive.infolist())
+            self.assertTrue(
+                all(
+                    info.compress_type == zipfile.ZIP_STORED
+                    for info in archive.infolist()
+                )
+            )
+
     def test_load_checkpoint_accepts_legacy_np_ndarray_metadata(self):
         save_checkpoint(
             self.model.state_dict(),
@@ -223,3 +240,70 @@ class TestModel(TestCase):
         loaded = load_checkpoint(json_path=self.json_path, npz_path=self.npz_path)
 
         self.assertIs(loaded["lr_scheduler_cls"], CosineScheduler)
+
+    def test_save_persists_dtype_in_sidecar(self):
+        # The JSON sidecar must carry the original dtype for every array
+        # so loading is exact, not inferred from raw bytes.
+        save_checkpoint(
+            {"parameters": {"w": Tensor(xp.ones((3,), dtype=xp.float32))}},
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
+        )
+
+        with open(self.json_path, "r", encoding="utf-8") as handle:
+            meta = json.load(handle)
+        weight_meta = meta["items"]["parameters"]["items"]["w"]
+        self.assertEqual(weight_meta["_type"], "tensor")
+        self.assertEqual(weight_meta["dtype"], "float32")
+
+    def test_load_restores_bf16_from_void_npz(self):
+        # numpy's .npy format can't store ml_dtypes.bfloat16 natively, so on
+        # cupy/numpy backends a saved bf16 array round-trips as opaque |V2
+        # void. The persisted dtype in JSON lets the load path reinterpret
+        # those bytes as bf16 with no implicit assumptions.
+        bf16 = getattr(xp, "bfloat16", None)
+        if bf16 is None:
+            self.skipTest("backend does not expose bfloat16")
+
+        original = xp.array([1.0, 2.0, 0.5, -1.5], dtype=bf16)
+        save_checkpoint(
+            {"parameters": {"w": Tensor(original)}},
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
+        )
+
+        loaded = load_checkpoint(json_path=self.json_path, npz_path=self.npz_path)
+        restored = loaded["parameters"]["w"].data
+
+        self.assertEqual(restored.dtype, bf16)
+        self.assertTrue(xp.all(restored == original))
+
+    def test_load_accepts_checkpoints_saved_without_dtype_metadata(self):
+        # Checkpoints saved before the dtype sidecar field existed must still
+        # load; without dtype we trust the array bytes as stored.
+        save_checkpoint(
+            {"parameters": {"w": Tensor(xp.ones((3,), dtype=xp.float32))}},
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
+        )
+        with open(self.json_path, "r", encoding="utf-8") as handle:
+            meta = json.load(handle)
+
+        def strip_dtype(node):
+            if isinstance(node, dict):
+                node.pop("dtype", None)
+                for value in node.values():
+                    strip_dtype(value)
+            elif isinstance(node, list):
+                for value in node:
+                    strip_dtype(value)
+
+        strip_dtype(meta)
+        with open(self.json_path, "w", encoding="utf-8") as handle:
+            json.dump(meta, handle)
+
+        loaded = load_checkpoint(json_path=self.json_path, npz_path=self.npz_path)
+
+        restored = loaded["parameters"]["w"].data
+        self.assertEqual(restored.dtype, xp.float32)
+        self.assertTrue(xp.all(restored == 1.0))

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -460,6 +460,31 @@ class TestSimpleTrainer(BaseTrainerTest):
         results = run_mock_ranks(2, target)
         self.assertEqual(results, [0.75, 0.75])
 
+    @unittest.skipIf(
+        IS_MLX,
+        "MLX lazy graphs are not thread-safe under the in-process DDP mock.",
+    )
+    def test_metrics_row_allreduces_val_loss_even_when_train_loss_stays_local(
+        self,
+    ):
+        from autograd.distributed import rank
+
+        def target():
+            eval_state = TrainingState()
+            if rank() != 0:
+                eval_state.record_eval_loss(
+                    8.0,
+                    total_weight=xp.array(4.0, dtype=xp.float32),
+                )
+            row = TrainingState().metrics_row(
+                eval_state=eval_state,
+                log_global_loss=False,
+            )
+            return row["val_loss"]
+
+        results = run_mock_ranks(2, target)
+        self.assertEqual(results, [2.0, 2.0])
+
     def test_training_state_resets_report_timer(self):
         state = TrainingState()
         state.record_loss(1.0, total_weight=xp.array(4.0, dtype=xp.float32))


### PR DESCRIPTION
## Summary
- Persist each array's dtype in the checkpoint JSON sidecar and restore it on load. numpy's .npy format cannot store ml_dtypes extension dtypes like bfloat16, so bf16 checkpoints round-tripped as opaque `|V2` void bytes; the sidecar dtype lets the load path view-reinterpret the stored bytes back to the original dtype. Checkpoints saved before the dtype field existed still load as-stored.
- Save checkpoint arrays with `savez` instead of `savez_compressed`: dense weights barely compress and the deflate pass dominated checkpoint save time.
- Fix DDP validation-loss reporting: `metrics_row` only allreduced the val-loss pair inside the `log_global_loss` branch, so eval-only reporting (`log_global_loss=False`) returned each rank's local validation loss instead of the global one.

## Test plan
- New tests: dtype recorded in sidecar; bf16 round-trips through void npz bytes; checkpoints without dtype metadata still load; npz members are uncompressed; val loss is allreduced under DDP when train loss stays local (fails before the fix).
- Full suite: 557 passed, 11 skipped.