### PR TITLE
Exclude 1D params from weight decay and fuse gradient scale+clip

### DIFF
--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -418,6 +418,16 @@ class Adam(Optimizer):
     "Decoupled Weight Decay Regularization" (https://arxiv.org/abs/1711.05101).
 
     When `weight_decay` is set to 0, AdamW is equivalent to Adam.
+
+    Weight decay is only applied to params with `ndim >= 2` (Linear / Embedding
+    weights). 1D params — LayerNorm gains, biases — are excluded, matching the
+    nanoGPT / GPT-2 / Megatron-LM convention. The reasoning:
+      * LN gain is initialized at 1.0 (identity); a prior toward 0 is silent
+        ablation, not regularization.
+      * Biases are additive shifts with no overparameterization or
+        Lipschitz-bounding argument for shrinking them to 0.
+      * 1D params sit on the pre-LN scale degeneracy direction, so WD on them
+        fights WD on the matching 2D weight.
     """
 
     def __init__(
@@ -493,6 +503,11 @@ class Adam(Optimizer):
 
             # For mixed precision, keep Adam statistics in fp32 for stability.
             param_dtype = param.data.dtype
+
+            # Apply WD only to params with ndim >= 2 (Linear/Embedding weights);
+            # exclude 1D params (LN gains, biases). See class docstring for why.
+            effective_wd = weight_decay if param.data.ndim >= 2 else 0.0
+
             if grad.dtype in LOW_PRECISION_FLOAT_DTYPES:
                 grad = grad.astype(xp.float32)
             new_m = beta1 * m_old + (1 - beta1) * grad  # update first order momentum
@@ -513,14 +528,14 @@ class Adam(Optimizer):
             # For fp32 params (no master), update `param.data` directly.
             master = self._states["master"].get(name)
             if master is not None:
-                if weight_decay > 0.0:
-                    master = master - self.lr * weight_decay * master
+                if effective_wd > 0.0:
+                    master = master - self.lr * effective_wd * master
                 master -= self.lr * m_hat / (xp.sqrt(v_hat) + epsilon)
                 self._states["master"][name] = master
                 param.data = master.astype(param_dtype)
             else:
-                if weight_decay > 0.0:
-                    param.data = param.data - self.lr * weight_decay * param.data
+                if effective_wd > 0.0:
+                    param.data = param.data - self.lr * effective_wd * param.data
                 param.data -= self.lr * m_hat / (xp.sqrt(v_hat) + epsilon)
         materialize(self.model_parameters, self._states)
         return None

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -288,6 +288,36 @@ class Optimizer:
                 if param.grad.data.dtype != grad_dtype:
                     param.grad.data = param.grad.data.astype(grad_dtype)
 
+    def scale_and_clip_gradients(
+        self,
+        scale: Array,
+        max_norm: float,
+        norm_type: float = 2.0,
+    ) -> Any:
+        """Scale gradients and clip their post-scale global norm in one pass.
+
+        Equivalent to ``scale_gradients(scale)`` followed by
+        ``clip_grad_norm(max_norm, norm_type)``, but applies a single combined
+        factor to each gradient instead of two full-parameter scaling passes.
+        """
+        total_norm = xp.asarray(0.0, dtype=xp.float32)
+        for param in self.model_parameters.values():
+            if param.grad is not None:
+                scaled_grad = param.grad.data * scale
+                total_norm += (xp.abs(scaled_grad) ** norm_type).sum()
+
+        total_norm = total_norm ** (1.0 / norm_type)
+        clip_scale = xp.minimum(1.0, max_norm / (total_norm + 1e-10))
+        final_scale = scale * clip_scale
+        for param in self.model_parameters.values():
+            if param.grad is not None:
+                grad_dtype = param.grad.data.dtype
+                param.grad.data *= final_scale
+                if param.grad.data.dtype != grad_dtype:
+                    param.grad.data = param.grad.data.astype(grad_dtype)
+
+        return total_norm
+
     def grad_l2_norm(self) -> float:
         """Return the L2 norm of all current parameter gradients."""
         grad_norm = xp.asarray(0.0, dtype=xp.float32)

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -571,16 +571,18 @@ class AbstractTrainer(ABC):
             state.accumulated_loss_total_weight,
         )
 
-        self.optimizer.scale_gradients(
-            1.0
-            / xp.maximum(
-                state.accumulated_loss_total_weight,
-                xp.array(1.0, dtype=xp.float32),
-            )
+        grad_scale = 1.0 / xp.maximum(
+            state.accumulated_loss_total_weight,
+            xp.array(1.0, dtype=xp.float32),
         )
         grad_l2_norm = None
         if self.config.max_grad_norm is not None:
-            grad_l2_norm = self.optimizer.clip_grad_norm(self.config.max_grad_norm)
+            grad_l2_norm = self.optimizer.scale_and_clip_gradients(
+                grad_scale,
+                self.config.max_grad_norm,
+            )
+        else:
+            self.optimizer.scale_gradients(grad_scale)
         self.optimizer.step()
         if record_grad_norm and grad_l2_norm is not None:
             self.last_grad_l2_norm = float(xp.to_scalar(grad_l2_norm))

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -530,12 +530,22 @@ class TestAdam(TestCase):
         """
         Verify that our custom Adam with weight_decay>0 matches PyTorch's AdamW
         implementation (which also decouples weight decay).
+
+        Uses 2D params because our Adam intentionally diverges from torch.AdamW
+        on 1D params: nanoGPT-style convention excludes LN gains / biases from
+        WD (see Adam class docstring).
         """
         wd = 0.01  # some non-zero weight decay
 
+        # Realistic "weight" shape so WD is actually applied (ndim >= 2).
+        weight_init = [[1.0, -0.5], [0.5, 2.0]]
+        bias_init = [[2.0, -1.0]]
+        param1 = Tensor(xp.array(weight_init, dtype=xp.float32))
+        param2 = Tensor(xp.array(bias_init, dtype=xp.float32))
+
         custom_params = {
-            "custom_module.weight": self.param1,
-            "custom_module.bias": self.param2,
+            "custom_module.weight": param1,
+            "custom_module.bias": param2,
         }
         custom_adam = Adam(
             model_parameters=custom_params,
@@ -547,43 +557,50 @@ class TestAdam(TestCase):
         )
 
         # Create equivalent PyTorch AdamW
-        torch_p1 = torch.nn.Parameter(torch.tensor(self.param1.data))
-        torch_p2 = torch.nn.Parameter(torch.tensor(self.param2.data))
+        torch_p1 = torch.nn.Parameter(torch.tensor(weight_init, dtype=torch.float32))
+        torch_p2 = torch.nn.Parameter(torch.tensor(bias_init, dtype=torch.float32))
         torch_adamw = torch.optim.AdamW(
             [torch_p1, torch_p2], lr=0.01, betas=(0.9, 0.999), eps=1e-8, weight_decay=wd
         )
 
         num_steps = 5
+        weight_shape = (2, 2)
+        bias_shape = (1, 2)
         for _ in range(num_steps):
-            # Set some gradient
-            grad1 = float(xp.random.normal(shape=()).item())  # or a fixed value
-            grad2 = float(xp.random.normal(shape=()).item())  # or a fixed value
+            grad1 = xp.random.normal(shape=weight_shape).astype(xp.float32)
+            grad2 = xp.random.normal(shape=bias_shape).astype(xp.float32)
 
-            # Assign to custom
-            self.param1.grad = grad1
-            self.param2.grad = grad2
-
-            # Assign to torch
+            param1.grad = Tensor(grad1, requires_grad=False)
+            param2.grad = Tensor(grad2, requires_grad=False)
             torch_p1.grad = torch.tensor(grad1, dtype=torch.float32)
             torch_p2.grad = torch.tensor(grad2, dtype=torch.float32)
 
-            # Step both optimizers
             custom_adam.step()
             torch_adamw.step()
 
-            # Zero grad for next iteration
             custom_adam.zero_grad()
             torch_adamw.zero_grad()
 
-        # Compare final parameter values
-        custom_final_p1 = self.param1.data
-        custom_final_p2 = self.param2.data
-        torch_final_p1 = torch_p1.detach().numpy()
-        torch_final_p2 = torch_p2.detach().numpy()
+        assert allclose(param1.data, torch_p1.detach().numpy(), atol=1e-6, rtol=1e-6)
+        assert allclose(param2.data, torch_p2.detach().numpy(), atol=1e-6, rtol=1e-6)
 
-        # Should match within a small tolerance
-        assert allclose(custom_final_p1, torch_final_p1, atol=1e-6, rtol=1e-6)
-        assert allclose(custom_final_p2, torch_final_p2, atol=1e-6, rtol=1e-6)
+    def test_weight_decay_skips_1d_params(self):
+        # 1D params (LN gains, biases) must step identically with and
+        # without weight decay (see Adam class docstring).
+        init = xp.array([1.0, -2.0, 0.5], dtype=xp.float32)
+        grad = xp.array([0.1, -0.3, 0.2], dtype=xp.float32)
+
+        decayed = Tensor(xp.array(init))
+        undecayed = Tensor(xp.array(init))
+        adam_wd = Adam({"ln.gain": decayed}, lr=0.01, weight_decay=0.1)
+        adam_no_wd = Adam({"ln.gain": undecayed}, lr=0.01, weight_decay=0.0)
+
+        decayed.grad = Tensor(xp.array(grad), requires_grad=False)
+        undecayed.grad = Tensor(xp.array(grad), requires_grad=False)
+        adam_wd.step()
+        adam_no_wd.step()
+
+        assert allclose(decayed.data, undecayed.data, atol=0.0, rtol=0.0)
 
     def test_bf16_step_matches_fp32_reference(self):
         if not IS_CUPY:

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -166,6 +166,50 @@ class TestOptimizer(TestCase):
             xp.array([1.0, -2.0], dtype=xp.float32),
         )
 
+    def test_scale_and_clip_gradients_matches_separate_operations(self):
+        separate_params = {
+            "param1": Tensor([1.0, 2.0, 3.0]),
+            "param2": Tensor([4.0, 5.0, 6.0]),
+        }
+        combined_params = {
+            "param1": Tensor([1.0, 2.0, 3.0]),
+            "param2": Tensor([4.0, 5.0, 6.0]),
+        }
+        separate_params["param1"].grad = Tensor(xp.array([3.0, 4.0], dtype=xp.float32))
+        separate_params["param2"].grad = Tensor(xp.array([12.0], dtype=xp.float32))
+        combined_params["param1"].grad = Tensor(xp.array([3.0, 4.0], dtype=xp.float32))
+        combined_params["param2"].grad = Tensor(xp.array([12.0], dtype=xp.float32))
+
+        separate = Optimizer(separate_params, lr=0.01)
+        combined = Optimizer(combined_params, lr=0.01)
+        scale = xp.array(0.5, dtype=xp.float32)
+
+        separate.scale_gradients(scale)
+        separate_norm = separate.clip_grad_norm(max_norm=1.0, norm_type=2.0)
+        combined_norm = combined.scale_and_clip_gradients(
+            scale,
+            max_norm=1.0,
+            norm_type=2.0,
+        )
+
+        self.assertAlmostEqual(
+            float(xp.to_scalar(combined_norm)),
+            float(xp.to_scalar(separate_norm)),
+            places=6,
+        )
+        assert allclose(
+            combined_params["param1"].grad.data,
+            separate_params["param1"].grad.data,
+            rtol=1e-6,
+            atol=1e-7,
+        )
+        assert allclose(
+            combined_params["param2"].grad.data,
+            separate_params["param2"].grad.data,
+            rtol=1e-6,
+            atol=1e-7,
+        )
+
     def test_grad_l2_norm_matches_expected_value(self):
         self.params["param1"].grad = Tensor(xp.array([3.0, 4.0], dtype=xp.float32))
         self.params["param2"].grad = Tensor(xp.array([12.0], dtype=xp.float32))

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -1500,7 +1500,7 @@ class TestSimpleTrainer(BaseTrainerTest):
 
         self.assertAlmostEqual(trainer.metric_rows[0]["grad_l2_norm"], 20.0, places=5)
 
-    def test_clip_enabled_uses_clip_grad_norm_for_reporting(self):
+    def test_clip_enabled_uses_scale_and_clip_for_reporting(self):
         config = GenericTrainingConfig(
             max_epochs=1,
             checkpoint_freq=1,
@@ -1535,13 +1535,13 @@ class TestSimpleTrainer(BaseTrainerTest):
             ),
             patch.object(
                 trainer.optimizer,
-                "clip_grad_norm",
-                wraps=trainer.optimizer.clip_grad_norm,
-            ) as mock_clip_grad_norm,
+                "scale_and_clip_gradients",
+                wraps=trainer.optimizer.scale_and_clip_gradients,
+            ) as mock_scale_and_clip,
         ):
             trainer.fit(train_loader)
 
-        self.assertEqual(mock_clip_grad_norm.call_count, 1)
+        self.assertEqual(mock_scale_and_clip.call_count, 1)
         self.assertAlmostEqual(trainer.metric_rows[0]["grad_l2_norm"], 20.0, places=5)
 
     def test_leftover_accumulation_matches_single_batch_update(self):


### PR DESCRIPTION
## Summary
- Adam applies decoupled weight decay only to params with `ndim >= 2` (Linear / Embedding weights), matching the nanoGPT / GPT-2 / Megatron-LM convention. LayerNorm gains start at 1.0, so decaying them toward 0 is silent ablation rather than regularization; biases carry no overparameterization argument for shrinking to 0. This is a deliberate behavior change for runs with `weight_decay > 0` — a training-quality/convention alignment, not a perf claim.
- New `Optimizer.scale_and_clip_gradients` computes the post-scale global norm first and applies a single combined scale×clip factor per gradient, replacing the two full-parameter passes of `scale_gradients` + `clip_grad_norm`. The trainer uses the fused path whenever `max_grad_norm` is set; the reported pre-clip grad norm is unchanged.

## Evidence
Benchmarked on GPT-2 124M, RTX 4090 (CuPy backend): the fused pass is a real isolated win — `0.00892s` vs `0.01041s` per optimizer phase, ~1.5 ms/step — but E2E throughput is flat within noise (`380,472` vs `387,897` tok/s in a ~1.3s step). Kept because it removes a full-gradient rewrite pass and simplifies the call site with no downside; the win should matter more as the optimizer phase grows relative to compute.

## Test plan
- `test_weight_decay_skips_1d_params` pins the 1D exclusion (verified failing against the old behavior).
- `test_weight_decay` torch.AdamW comparison moves to 2D params since 1D is now a deliberate divergence.
- `test_scale_and_clip_gradients_matches_separate_operations` pins equivalence of the fused path with separate scale + clip.
- Trainer test updated to assert the fused method is the one reporting the grad norm.
- Full suite: 559 passed, 11 skipped.