### PR TITLE
Add GSM8K dataset and special-token SFT chat format

### DIFF
--- a/autograd/data/gsm8k.py
+++ b/autograd/data/gsm8k.py
@@ -1,0 +1,69 @@
+import json
+import os
+from typing import Optional, cast
+
+from autograd.data.utils import load_data, load_parquet_rows
+
+# TODO: move this to a dedicated class/module organized with other dataset-specific logic for better maintainability
+
+GSM8K_PARQUET_MANIFEST_URL = (
+    "https://datasets-server.huggingface.co/parquet?dataset=openai%2Fgsm8k&config=main"
+)
+
+
+def split_gsm8k_answer(answer: str) -> tuple[str, str]:
+    reasoning, separator, final_answer = answer.partition("####")
+    if separator == "":
+        raise ValueError("GSM8K answer must contain a final answer after '####'")
+    return reasoning.strip(), final_answer.strip()
+
+
+def load_gsm8k_rows(
+    split: str,
+    max_rows: Optional[int] = None,
+) -> list[dict[str, str]]:
+    payload = json.loads(
+        cast(
+            str,
+            load_data(
+                GSM8K_PARQUET_MANIFEST_URL,
+                "training_data/gsm8k_parquet_manifest.json",
+            ),
+        )
+    )
+    parquet_files = [
+        parquet_file
+        for parquet_file in payload["parquet_files"]
+        if parquet_file["split"] == split
+    ]
+    if not parquet_files:
+        available_splits = sorted(
+            {parquet_file["split"] for parquet_file in payload["parquet_files"]}
+        )
+        raise ValueError(
+            f"GSM8K split {split!r} not found. Available splits: {available_splits}"
+        )
+
+    rows: list[dict[str, str]] = []
+    for parquet_file in parquet_files:
+        if max_rows is not None and len(rows) >= max_rows:
+            break
+        remaining_rows = None if max_rows is None else max_rows - len(rows)
+        raw_rows = load_parquet_rows(
+            parquet_file["url"],
+            os.path.join(
+                "training_data",
+                f"gsm8k_{parquet_file['split']}_{parquet_file['filename']}",
+            ),
+            max_rows=remaining_rows,
+        )
+        for row in raw_rows:
+            question = row.get("question")
+            answer = row.get("answer")
+            if not isinstance(question, str) or not isinstance(answer, str):
+                raise ValueError(
+                    "GSM8K rows must contain string question and answer fields"
+                )
+            rows.append({"question": question, "answer": answer})
+
+    return rows

--- a/autograd/data/sft.py
+++ b/autograd/data/sft.py
@@ -16,11 +16,11 @@ from autograd.text.tokenizer import BytePairEncoder
 logger = logging.getLogger(__name__)
 _WORKER_BPE: "BytePairEncoder | None" = None
 _WORKER_ROLE_TOKENS: "dict[str, list[int]] | None" = None
-SFT_TURN_SEPARATOR = "<|endoftext|>"
+SFT_TURN_SEPARATOR = "<|END_OF_TURN|>"
 SFT_ROLE_MARKERS = {
-    "system": "System: ",
-    "user": "User: ",
-    "assistant": "Assistant: ",
+    "system": "<|SYSTEM|>",
+    "user": "<|USER|>",
+    "assistant": "<|ASSISTANT|>",
 }
 
 
@@ -184,12 +184,8 @@ def tokenize_sft_messages(
     - `loss_mask`: same length as `tokens`; 1 means this token should be predicted.
 
     Example, conceptually:
-        User: A <|endoftext|> Assistant: B <|endoftext|>
-        mask: 0...0              0...0       1...
-
-    The textual role markers avoid tokenizer/checkpoint migration for now.
-    TODO: replace them with dedicated special tokens after vocab resizing and
-    checkpoint loading support explicit embedding/output-weight growth.
+        <|USER|>A<|END_OF_TURN|><|ASSISTANT|>B<|END_OF_TURN|>
+        mask:    0...0           0              0           1...
     """
     tokens, loss_mask = _tokenize_sft_messages_to_lists(
         chat_example,

--- a/autograd/data/sft.py
+++ b/autograd/data/sft.py
@@ -10,6 +10,7 @@ import numpy as np
 from tqdm import tqdm
 
 from autograd.backend import Array
+from autograd.data.gsm8k import load_gsm8k_rows, split_gsm8k_answer
 from autograd.data.utils import load_data, load_parquet_rows
 from autograd.text.tokenizer import BytePairEncoder
 
@@ -22,6 +23,15 @@ SFT_ROLE_MARKERS = {
     "user": "<|USER|>",
     "assistant": "<|ASSISTANT|>",
 }
+# Template adapted from DeepSeek-R1-Zero, Table 1:
+# https://arxiv.org/abs/2501.12948
+SFT_SYSTEM_PROMPT = (
+    "A conversation between User and Assistant. The user asks a question, and "
+    "the Assistant solves it. The assistant first thinks about the reasoning "
+    "process in the mind and then provides the user with the answer. The "
+    "reasoning process and answer are enclosed within <think>...</think> and "
+    "<answer>...</answer> tags, respectively."
+)
 
 
 def _normalize_sft_messages(messages: Any) -> list[dict[str, str]]:
@@ -125,6 +135,34 @@ def load_no_robots_sft(split: str = "train") -> list[dict[str, Any]]:
 
     logger.info(
         "%s No Robots %s chat examples. Sample: %s",
+        len(chat_examples),
+        split,
+        chat_examples[0],
+    )
+    return chat_examples
+
+
+def load_gsm8k_grpo_sft(split: str = "train") -> list[dict[str, Any]]:
+    chat_examples = []
+    for row in load_gsm8k_rows(split=split):
+        reasoning, final_answer = split_gsm8k_answer(row["answer"])
+        chat_examples.append(
+            {
+                "messages": [
+                    {"role": "system", "content": SFT_SYSTEM_PROMPT},
+                    {"role": "user", "content": row["question"]},
+                    {
+                        "role": "assistant",
+                        "content": (
+                            f"<think>{reasoning}</think><answer>{final_answer}</answer>"
+                        ),
+                    },
+                ]
+            }
+        )
+
+    logger.info(
+        "%s GSM8K %s chat examples. Sample: %s",
         len(chat_examples),
         split,
         chat_examples[0],

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -270,6 +270,7 @@ def generate_text(
     max_length: int = 50,
     temperature: float = 1.0,
     top_k: Optional[int] = None,
+    stop_token: str = "<|endoftext|>",
 ) -> str:
     """Generate and print text from a string prompt.
 
@@ -287,6 +288,8 @@ def generate_text(
         max_length: Maximum total token length, including prompt tokens.
         temperature: Sampling temperature passed through to `generate`.
         top_k: Optional top-k filter passed through to `generate`.
+        stop_token: Token string that stops generation when sampled. Chat
+            checkpoints stop at the turn separator instead of `<|endoftext|>`.
 
     Returns:
         Decoded prompt plus generated completion text.
@@ -308,7 +311,7 @@ def generate_text(
             max_new_tokens=max_length - prompt_len,
             temperature=temperature,
             top_k=top_k,
-            eos_token_id=bpe.encode("<|endoftext|>")[0],
+            eos_token_id=bpe.encode(stop_token)[0],
             num_generations=1,
             # Text generation only needs the tokens; skip the per-step
             # log-softmax work since nothing reads the logprobs.

--- a/examples/sft_gpt_2.py
+++ b/examples/sft_gpt_2.py
@@ -5,7 +5,14 @@ from autograd.data.collator import BatchMaxLengthCausalLMCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import MapDataset
 from autograd.data.sampler import TokenLengthGroupedRandomSampler
-from autograd.data.sft import load_no_robots_sft, prepare_sft_token_sequences
+from autograd.data.sft import (
+    SFT_ROLE_MARKERS,
+    SFT_SYSTEM_PROMPT,
+    SFT_TURN_SEPARATOR,
+    load_gsm8k_grpo_sft,
+    load_no_robots_sft,
+    prepare_sft_token_sequences,
+)
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.text.utils import generate_text
 from autograd.tools.config_schema import CustomBpeConfig, TransformerTrainingConfig
@@ -42,6 +49,16 @@ def build_data_loader(
     return DataLoader(dataset, batch_size, collator, sampler=sampler)
 
 
+def format_sft_prompt(user_content: str, *, system_content: str | None = None) -> str:
+    prefix = ""
+    if system_content is not None:
+        prefix = f"{SFT_ROLE_MARKERS['system']}{system_content}{SFT_TURN_SEPARATOR}"
+    return (
+        f"{prefix}{SFT_ROLE_MARKERS['user']}{user_content}"
+        f"{SFT_TURN_SEPARATOR}{SFT_ROLE_MARKERS['assistant']}"
+    )
+
+
 if __name__ == "__main__":
     import sys
 
@@ -49,21 +66,48 @@ if __name__ == "__main__":
 
     from gpt_2 import GPT2, GPT2ForwardFn
 
+    # Supported: "gsm8k", "no_robots".
+    SFT_DATASET = "gsm8k"
+
+    if SFT_DATASET == "gsm8k":
+        load_sft_split = load_gsm8k_grpo_sft
+        training_run_name = f"sft_{SFT_DATASET}_grpo_system"
+        encoded_dataset_name = f"{SFT_DATASET}_grpo_system"
+        eval_start_string = format_sft_prompt(
+            "Natalia sold clips to 48 of her friends in April, and then she "
+            "sold half as many clips in May. How many clips did Natalia sell "
+            "altogether in April and May?",
+            system_content=SFT_SYSTEM_PROMPT,
+        )
+    elif SFT_DATASET == "no_robots":
+        load_sft_split = load_no_robots_sft
+        training_run_name = f"sft_{SFT_DATASET}"
+        encoded_dataset_name = SFT_DATASET
+        eval_start_string = format_sft_prompt("What is the weather today?")
+    else:
+        raise ValueError("SFT_DATASET must be one of: gsm8k, no_robots")
+
     CONFIG = TransformerTrainingConfig(
-        training_run_name="sft_0428",
-        dataset_name="no_robots",
+        training_run_name=training_run_name,
+        dataset_name=SFT_DATASET,
         max_steps=900,
-        max_eval_steps=10,
+        max_eval_steps=20,
         checkpoint_freq=300,
-        report_every_steps=20,
+        report_every_steps=50,
         global_batch_size=32,
-        micro_batch_size=8,
+        micro_batch_size=4,
         model_kwargs={
-            "num_attention_heads": 9,  # GPT-2 small uses 12
-            "hidden_size": 576,  # GPT-2 small uses 768, must be divisible by num_attention_heads
-            "dropout_prob": 0.1,
-            "max_seq_len": 1024,  # GPT-2 uses 1024
-            "num_decoder_layers": 8,  # GPT-2 uses 12
+            # Architecture must match the openwebtext_gpt2_124m_baseline
+            # pretraining checkpoint loaded via pretrained_checkpoint_path.
+            "num_attention_heads": 12,
+            "hidden_size": 768,
+            # Padded vocab (next multiple of 64 above GPT-2's 50,257) for
+            # efficient matmul; matches the pretraining config.
+            "vocab_size": 50_304,
+            # dropout=0 matches the GPT-2 paper's finetuning recipe.
+            "dropout_prob": 0.0,
+            "max_seq_len": 1024,
+            "num_decoder_layers": 12,
             "activation_checkpointing": False,
             "parameter_dtype": "bfloat16",
         },
@@ -80,18 +124,19 @@ if __name__ == "__main__":
         max_grad_norm=1.0,
         # Basename without .json/.npz. The configured model architecture below
         # must match this checkpoint; load_state_dict will fail otherwise.
-        pretrained_checkpoint_path=project_path("checkpoints", "wiki_GPT2_18000"),
+        pretrained_checkpoint_path=project_path(
+            "checkpoints", "openwebtext_gpt2_124m_baseline_GPT2_14000"
+        ),
         label_smoothing=0.1,
         teacher_forcing=False,
-        eval_start_string="User: What is the weather today?<|endoftext|>Assistant: ",
+        eval_start_string=eval_start_string,
         custom_bpe=CustomBpeConfig(
-            num_merges=12000,
+            num_merges=49990,
             encoded_data_path=project_path(
-                "training_data", "bpe_12000_no_robots_encoded_data_sft.npz"
+                "training_data",
+                f"bpe_49990_{encoded_dataset_name}_encoded_data_sft.npz",
             ),
-            vocab_path=project_path(
-                "training_data", "wikipedia_simpleenglish_vocab_12000.pkl"
-            ),
+            vocab_path=project_path("training_data", "openwebtext_vocab_49990.pkl"),
             overwrite_encoded_data=False,
             overwrite_vocabulary_file=False,
             start_token="<SOS>",
@@ -99,8 +144,8 @@ if __name__ == "__main__":
         ),
     )
 
-    train_chat_examples = load_no_robots_sft(split="train")
-    val_chat_examples = load_no_robots_sft(split="test")
+    train_chat_examples = load_sft_split(split="train")
+    val_chat_examples = load_sft_split(split="test")
     bpe_config = CONFIG.custom_bpe
     if bpe_config is None:
         raise ValueError(
@@ -115,7 +160,29 @@ if __name__ == "__main__":
         encoded_data_path=bpe_config.encoded_data_path,
     )
 
-    CONFIG.model_kwargs["vocab_size"] = bpe.n_vocab
+    # Model embeds the padded vocab; BPE token IDs must fit within it.
+    if bpe.n_vocab > CONFIG.model_kwargs["vocab_size"]:
+        raise ValueError(
+            f"BPE vocab ({bpe.n_vocab}) exceeds model vocab_size "
+            f"({CONFIG.model_kwargs['vocab_size']})."
+        )
+
+    def generate_eval_samples(
+        model,
+        _forward_fn,
+        _val_data_loader,
+        config: TransformerTrainingConfig,
+    ) -> None:
+        generate_text(
+            model=model,
+            prediction_func=GPT2ForwardFn(),
+            bpe=bpe,
+            start_tokens=config.eval_start_string,
+            max_length=min(256, int(model.max_seq_len)),
+            temperature=0.8,
+            top_k=config.eval_top_k,
+            stop_token=SFT_TURN_SEPARATOR,
+        )
 
     trainer = LLMTrainer(
         model_cls=GPT2,
@@ -123,6 +190,7 @@ if __name__ == "__main__":
         loss_fn=functional.cross_entropy,
         config=CONFIG,
         forward_fn=GPT2ForwardFn(),
+        eval_callbacks=[generate_eval_samples],
     )
 
     pad_idx = bpe.encode("<PAD>")[0]
@@ -153,7 +221,6 @@ if __name__ == "__main__":
         f"raw_train={split} raw_val={len(token_sequences) - split} "
         f"fit_train={len(train_examples)} fit_val={len(val_examples)}"
     )
-    val_batch_size = max(1, CONFIG.micro_batch_size // 2)
     train_data_loader = build_data_loader(
         train_examples,
         batch_size=CONFIG.micro_batch_size,
@@ -161,6 +228,7 @@ if __name__ == "__main__":
         pad_idx=pad_idx,
         sort_buffer_size=CONFIG.global_batch_size,
     )
+    val_batch_size = max(1, CONFIG.micro_batch_size // 2)
     val_data_loader = build_data_loader(
         val_examples,
         batch_size=val_batch_size,
@@ -181,5 +249,6 @@ if __name__ == "__main__":
             max_length=int(trainer.model.max_seq_len),
             temperature=0.8,
             top_k=CONFIG.eval_top_k,
+            stop_token=SFT_TURN_SEPARATOR,
         )
         print("\n------------------------\n")

--- a/test/autograd/data/test_gsm8k.py
+++ b/test/autograd/data/test_gsm8k.py
@@ -1,0 +1,81 @@
+from json import dumps
+from unittest import TestCase
+from unittest.mock import patch
+
+from autograd.data.gsm8k import load_gsm8k_rows, split_gsm8k_answer
+
+
+class TestGSM8KData(TestCase):
+    @patch("autograd.data.gsm8k.load_parquet_rows")
+    @patch("autograd.data.gsm8k.load_data")
+    def test_load_gsm8k_rows_loads_requested_split(
+        self,
+        mock_load_data,
+        mock_load_parquet_rows,
+    ):
+        mock_load_data.return_value = dumps(
+            {
+                "parquet_files": [
+                    {
+                        "split": "test",
+                        "filename": "0000.parquet",
+                        "url": "https://example.test/gsm8k/test.parquet",
+                    },
+                    {
+                        "split": "train",
+                        "filename": "0000.parquet",
+                        "url": "https://example.test/gsm8k/train.parquet",
+                    },
+                ]
+            }
+        )
+        mock_load_parquet_rows.return_value = [
+            {
+                "question": "Jan has 2 apples. Tom gives her 3. How many?",
+                "answer": "Jan has 2 + 3 = 5 apples. #### 5",
+            }
+        ]
+
+        rows = load_gsm8k_rows(split="train")
+
+        self.assertEqual(
+            rows,
+            [
+                {
+                    "question": "Jan has 2 apples. Tom gives her 3. How many?",
+                    "answer": "Jan has 2 + 3 = 5 apples. #### 5",
+                }
+            ],
+        )
+        mock_load_parquet_rows.assert_called_once_with(
+            "https://example.test/gsm8k/train.parquet",
+            "training_data/gsm8k_train_0000.parquet",
+            max_rows=None,
+        )
+
+    @patch("autograd.data.gsm8k.load_data")
+    def test_load_gsm8k_rows_rejects_missing_split(self, mock_load_data):
+        mock_load_data.return_value = dumps(
+            {
+                "parquet_files": [
+                    {
+                        "split": "train",
+                        "filename": "0000.parquet",
+                        "url": "https://example.test/gsm8k/train.parquet",
+                    }
+                ]
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "Available splits"):
+            load_gsm8k_rows(split="validation")
+
+    def test_split_gsm8k_answer_extracts_reasoning_and_final_answer(self):
+        self.assertEqual(
+            split_gsm8k_answer("scratch work #### 22,500"),
+            ("scratch work", "22,500"),
+        )
+
+    def test_split_gsm8k_answer_rejects_missing_marker(self):
+        with self.assertRaisesRegex(ValueError, "after '####'"):
+            split_gsm8k_answer("scratch work only")

--- a/test/autograd/data/test_sft.py
+++ b/test/autograd/data/test_sft.py
@@ -10,6 +10,8 @@ from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import PairedMapDataset
 from autograd.data.sampler import RandomSampler
 from autograd.data.sft import (
+    SFT_SYSTEM_PROMPT,
+    load_gsm8k_grpo_sft,
     load_no_robots_sft,
     load_sft,
     prepare_sft_token_sequences,
@@ -248,6 +250,45 @@ class TestSFTData(TestCase):
 
         with self.assertRaisesRegex(ValueError, "Available splits"):
             load_no_robots_sft(split="validation")
+
+    @patch("autograd.data.sft.load_gsm8k_rows")
+    def test_load_gsm8k_grpo_sft_formats_questions_as_tagged_chat(
+        self, mock_load_gsm8k_rows
+    ):
+        mock_load_gsm8k_rows.return_value = [
+            {
+                "question": "Jan has 2 apples. Tom gives her 3. How many?",
+                "answer": "Jan has 2 + 3 = 5 apples. #### 5",
+            }
+        ]
+
+        examples = load_gsm8k_grpo_sft(split="train")
+
+        self.assertEqual(
+            examples,
+            [
+                {
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": SFT_SYSTEM_PROMPT,
+                        },
+                        {
+                            "role": "user",
+                            "content": "Jan has 2 apples. Tom gives her 3. How many?",
+                        },
+                        {
+                            "role": "assistant",
+                            "content": (
+                                "<think>Jan has 2 + 3 = 5 apples.</think>"
+                                "<answer>5</answer>"
+                            ),
+                        },
+                    ]
+                }
+            ],
+        )
+        mock_load_gsm8k_rows.assert_called_once_with(split="train")
 
     def test_tokenize_sft_messages_supervises_all_assistant_turns(self):
         example = tokenize_sft_messages(

--- a/test/autograd/data/test_sft.py
+++ b/test/autograd/data/test_sft.py
@@ -22,27 +22,40 @@ from test.helpers import array_equal
 
 
 class MockBPE:
+    special_ids = {
+        "<PAD>": 0,
+        "<SOS>": 1,
+        "<|endoftext|>": 2,
+        "<UNK>": 3,
+        "<|USER|>": 4,
+        "<|ASSISTANT|>": 5,
+        "<|SYSTEM|>": 6,
+        "<|END_OF_TURN|>": 7,
+    }
+
     def encode(self, token, allowed_special=set()):
         if token in allowed_special:
-            if token == "<PAD>":
-                return [0]
-            if token == "<SOS>":
-                return [1]
-            if token == "<|endoftext|>":
-                return [2]
-        special_token = "<|endoftext|>"
-        if token == special_token:
-            return [2]
+            return [self.special_ids[token]]
+        if token in self.special_ids:
+            return [self.special_ids[token]]
 
         encoded = []
         start = 0
         while True:
-            special_index = token.find(special_token, start)
-            if special_index == -1:
+            next_special = min(
+                (
+                    (special_index, special_token)
+                    for special_token in self.special_ids
+                    if (special_index := token.find(special_token, start)) != -1
+                ),
+                default=None,
+            )
+            if next_special is None:
                 encoded.extend(ord(char) for char in token[start:])
                 break
+            special_index, special_token = next_special
             encoded.extend(ord(char) for char in token[start:special_index])
-            encoded.append(2)
+            encoded.append(self.special_ids[special_token])
             start = special_index + len(special_token)
         return encoded
 
@@ -251,34 +264,34 @@ class TestSFTData(TestCase):
 
         expected_tokens = xp.array(
             [
-                *[ord(char) for char in "User: "],
+                4,
                 65,
-                2,
-                *[ord(char) for char in "Assistant: "],
+                7,
+                5,
                 66,
-                2,
-                *[ord(char) for char in "User: "],
+                7,
+                4,
                 67,
-                2,
-                *[ord(char) for char in "Assistant: "],
+                7,
+                5,
                 68,
                 69,
-                2,
+                7,
             ],
             dtype=xp.int32,
         )
         expected_loss_mask = xp.array(
             [
-                *([0] * len("User: ")),
                 0,
                 0,
-                *([0] * len("Assistant: ")),
+                0,
+                0,
                 1,
                 1,
-                *([0] * len("User: ")),
                 0,
                 0,
-                *([0] * len("Assistant: ")),
+                0,
+                0,
                 1,
                 1,
                 1,
@@ -336,7 +349,7 @@ class TestSFTData(TestCase):
             xp.array_equal(
                 batch.labels[0],
                 xp.array(
-                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, 2],
+                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, 7],
                     dtype=xp.int32,
                 ),
             )
@@ -365,14 +378,14 @@ class TestSFTData(TestCase):
         self.assertTrue(
             xp.array_equal(
                 batch.input_ids[0],
-                xp.array([116, 58, 32, 68, 69], dtype=xp.int32),
+                xp.array([67, 7, 5, 68, 69], dtype=xp.int32),
             )
         )
         self.assertTrue(
             xp.array_equal(
                 batch.labels[0],
                 xp.array(
-                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, 2],
+                    [IGNORE_INDEX, IGNORE_INDEX, 68, 69, 7],
                     dtype=xp.int32,
                 ),
             )
@@ -397,13 +410,13 @@ class TestSFTData(TestCase):
 
         self.assertTrue(
             xp.array_equal(
-                batch.input_ids[0], xp.array([32, 69, 70, 71], dtype=xp.int32)
+                batch.input_ids[0], xp.array([5, 69, 70, 71], dtype=xp.int32)
             )
         )
         self.assertTrue(
             xp.array_equal(
                 batch.labels[0],
-                xp.array([69, 70, 71, 2], dtype=xp.int32),
+                xp.array([69, 70, 71, 7], dtype=xp.int32),
             )
         )
 

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -28,13 +28,18 @@ class MockedBPE:
     def encode(self, text: str):
         if text == "<|endoftext|>":
             return [9]
+        if text == "<|END_OF_TURN|>":
+            return [7]
         if text == "<SOS>":
             return [0]
         # For simplicity, convert each uppercase letter to an integer (A=0, B=1, …)
         return [ord(ch) - 65 for ch in text if ch.isupper()]
 
     def decode(self, tokens: list) -> str:
-        return "".join("<|endoftext|>" if t == 9 else chr(t + 65) for t in tokens)
+        return "".join(
+            "<|endoftext|>" if t == 9 else "<|END_OF_TURN|>" if t == 7 else chr(t + 65)
+            for t in tokens
+        )
 
 
 class BytesResponse:
@@ -564,6 +569,31 @@ class TestTextUtils(TestCase):
         )
 
         self.assertEqual(result, self.bpe.decode([0, 1, 9]))
+        self.assertEqual(prediction_func.call_count, 2)
+
+    @patch("autograd.text.utils.xp.sample_categorical")
+    def test_generate_text_stops_at_configured_stop_token(self, mock_choice):
+        def fake_prediction(model, batch_data, mode):
+            seq_len = batch_data.shape[1]
+            dummy_obj = MagicMock()
+            dummy_obj.data = xp.zeros((1, seq_len, 10))
+            return dummy_obj
+
+        mock_choice.side_effect = [1, 7, 1]
+        prediction_func = MagicMock(side_effect=fake_prediction)
+
+        result = generate_text(
+            model=MagicMock(),
+            prediction_func=prediction_func,
+            bpe=self.bpe,  # type: ignore
+            start_tokens="<SOS>",
+            max_length=5,
+            temperature=1.0,
+            top_k=5,
+            stop_token="<|END_OF_TURN|>",
+        )
+
+        self.assertEqual(result, self.bpe.decode([0, 1, 7]))
         self.assertEqual(prediction_func.call_count, 2)
 
     @patch("autograd.text.utils.xp.sample_categorical")


### PR DESCRIPTION
## Summary
- SFT chat format moves from textual role markers (`User: `, `Assistant: `) and `<|endoftext|>` turn separation to the dedicated special tokens the tokenizer already reserves: `<|USER|>`, `<|ASSISTANT|>`, `<|SYSTEM|>`, `<|END_OF_TURN|>`. One token per marker makes loss-mask boundaries exact, markers can't be split by BPE merges, and `<|endoftext|>` stays a pure document separator. `generate_text` gains a `stop_token` parameter so chat checkpoints stop at the turn separator.
- New `autograd/data/gsm8k.py`: `load_gsm8k_rows` (openai/gsm8k parquet via the existing manifest/cache path) and `split_gsm8k_answer` (chain-of-thought vs the `####` final answer). `load_gsm8k_grpo_sft` formats each problem as a system/user/assistant example using the DeepSeek-R1-Zero system prompt (Table 1, arXiv:2501.12948) with the assistant turn wrapped in `<think>/<answer>` tags — SFT teaches exactly the output format the GRPO reward parser will score.
- `examples/sft_gpt_2.py` finetunes from the openwebtext GPT-2 124M baseline checkpoint with its 49,990-merge tokenizer and matching architecture; an eval callback samples a fixed GSM8K question after each evaluation.

## Evidence
From the experiment notes (GSM8K test split, N=16, greedy temp 0.05, 124M model): 300 SFT steps on this format lifted format adherence from 0.000 (base checkpoint) to 0.312 — the model learns the chat envelope, `<think>/<answer>` tags, and the `<|END_OF_TURN|>` close — while pass@1 stayed 0.000. This PR is the data/format plumbing that makes that measurable; answer capability is what GRPO training (later PR) targets.

## Test plan
- GSM8K loader tests (mocked manifest/parquet): split selection, missing-split error, answer splitting, missing-`####` rejection.
- `load_gsm8k_grpo_sft` formatting pinned end to end (system prompt, think/answer tags).
- SFT tokenization tests updated to single-token markers; loss-mask expectations re-derived.
- `test_generate_text_stops_at_configured_stop_token` pins the stop_token path.
- Full suite: 567 passed, 11 skipped.

## Excluded (intentional)
`eval_batch_size` config (next PR), `use_packed_qkv` (kernel work stays on the experimental branch), and two unrelated tokenizer bugfixes (retrain-state reset, empty-mmap) that will come separately.