### PR TITLE
Make eval batch size an explicit config knob

### DIFF
--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -52,6 +52,9 @@ class GenericTrainingConfig:
     global_batch_size: int = 1
     # Per-forward/backward batch size that must fit in memory.
     micro_batch_size: int = 1
+    # Validation/inference batch size. Keep independent from micro_batch_size so
+    # changing training memory does not change the validation sample count.
+    eval_batch_size: int = 1
     # Optional trainer-level gradient clipping threshold.
     max_grad_norm: Optional[float] = None
     # When True under DDP, the trainer AllReduce-sums the loss numerator and
@@ -95,6 +98,10 @@ class GenericTrainingConfig:
         if self.micro_batch_size < 1:
             raise ValueError(
                 f"micro_batch_size must be >= 1, got {self.micro_batch_size}"
+            )
+        if self.eval_batch_size < 1:
+            raise ValueError(
+                f"eval_batch_size must be >= 1, got {self.eval_batch_size}"
             )
         if self.global_batch_size % self.micro_batch_size != 0:
             raise ValueError(

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -776,6 +776,7 @@ class AbstractTrainer(ABC):
             "report_every_steps": plan.report_every_steps,
             "global_batch_size": self.config.global_batch_size,
             "micro_batch_size": self.config.micro_batch_size,
+            "eval_batch_size": self.config.eval_batch_size,
             "gradient_accumulation_steps": self.config.gradient_accumulation_steps,
             "target_epochs": (
                 cast(int, self.config.max_epochs) if plan.by_epoch else None

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -222,6 +222,7 @@ if __name__ == "__main__":
         checkpoint_freq=4,
         global_batch_size=train_global_batch_size,
         micro_batch_size=train_global_batch_size // 4,
+        eval_batch_size=2,
         max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 6,  # GPT-2 small uses 12
@@ -270,6 +271,7 @@ if __name__ == "__main__":
         report_every_steps=50,
         global_batch_size=76,
         micro_batch_size=19,
+        eval_batch_size=9,
         max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 9,  # GPT-2 small uses 12
@@ -319,6 +321,7 @@ if __name__ == "__main__":
         report_every_steps=100,
         global_batch_size=480,
         micro_batch_size=120,
+        eval_batch_size=60,
         max_grad_norm=1.0,
         model_kwargs={
             "num_attention_heads": 12,
@@ -491,7 +494,7 @@ if __name__ == "__main__":
     )
     test_data_loader = DataLoader(
         dataset=test_dataset,
-        batch_size=max(1, CONFIG.micro_batch_size // 2),
+        batch_size=CONFIG.eval_batch_size,
         collator=CausalLMWindowCollator(),
         sampler=test_sampler,
     )

--- a/examples/sft_gpt_2.py
+++ b/examples/sft_gpt_2.py
@@ -96,6 +96,7 @@ if __name__ == "__main__":
         report_every_steps=50,
         global_batch_size=32,
         micro_batch_size=4,
+        eval_batch_size=4,
         model_kwargs={
             # Architecture must match the openwebtext_gpt2_124m_baseline
             # pretraining checkpoint loaded via pretrained_checkpoint_path.
@@ -228,13 +229,12 @@ if __name__ == "__main__":
         pad_idx=pad_idx,
         sort_buffer_size=CONFIG.global_batch_size,
     )
-    val_batch_size = max(1, CONFIG.micro_batch_size // 2)
     val_data_loader = build_data_loader(
         val_examples,
-        batch_size=val_batch_size,
+        batch_size=CONFIG.eval_batch_size,
         max_tokens=max_tokens,
         pad_idx=pad_idx,
-        sort_buffer_size=val_batch_size,
+        sort_buffer_size=CONFIG.eval_batch_size,
     )
 
     trainer.fit(train_data_loader, val_data_loader)

--- a/test/autograd/tools/test_config_schema.py
+++ b/test/autograd/tools/test_config_schema.py
@@ -58,6 +58,7 @@ class TestTransformerTrainingConfig(TestCase):
             checkpoint_freq=5,
             global_batch_size=32,
             micro_batch_size=4,
+            eval_batch_size=16,
             model_kwargs={},
             optimizer_kwargs={"lr": 1e-3},
             label_smoothing=0.0,
@@ -65,6 +66,23 @@ class TestTransformerTrainingConfig(TestCase):
         )
 
         self.assertEqual(config.gradient_accumulation_steps, 8)
+        self.assertEqual(config.eval_batch_size, 16)
+
+    def test_rejects_non_positive_eval_batch_size(self):
+        with self.assertRaisesRegex(ValueError, "eval_batch_size must be >= 1"):
+            TransformerTrainingConfig(
+                training_run_name="test",
+                dataset_name="dataset",
+                max_steps=5,
+                checkpoint_freq=5,
+                global_batch_size=32,
+                micro_batch_size=4,
+                eval_batch_size=0,
+                model_kwargs={},
+                optimizer_kwargs={"lr": 1e-3},
+                label_smoothing=0.0,
+                teacher_forcing=False,
+            )
 
     def test_rejects_global_batch_size_not_divisible_by_distributed_world_size(self):
         dist._set_thread_local_rank(


### PR DESCRIPTION
## Summary
- Add `eval_batch_size` to `GenericTrainingConfig` with `>= 1` validation, and log it in the trainer's fit plan alongside the other batch sizes.
- Wire `examples/gpt_2.py` and `examples/sft_gpt_2.py` validation loaders through it, replacing the implicit `max(1, micro_batch_size // 2)` derivation.

## Why
Validation forward passes store no gradients or optimizer state, so the eval batch size has a different memory budget than `micro_batch_size`. Deriving one from the other couples them: tuning `micro_batch_size` to fit training memory silently changes how many samples each eval batch sees. An explicit, validated config field removes that hidden coupling and makes runs easier to reason about and reproduce.

No performance claim — this is a configuration-clarity change. Example values are behavior-preserving for `gpt_2.py` (2/9/60 match the old `micro // 2` derivation); `sft_gpt_2.py` moves from 2 to 4, matching the setting used for the SFT runs on the experimental branch.

## Test plan
- New: `test_rejects_non_positive_eval_batch_size`, plus round-trip assertion in the accumulation test.
- Full suite: 568 passed, 11 skipped. Ruff lint + format clean.