### PR TITLE
Overhaul GRPO training loop around exact-only rewards

### DIFF
--- a/autograd/tools/model.py
+++ b/autograd/tools/model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 from autograd.backend import ARRAY_TYPE, resolve_dtype, xp
 from autograd.tensor import Tensor
@@ -258,3 +258,60 @@ def load_checkpoint(
         return deserialized_data.get("parameters", deserialized_data)
 
     return deserialized_data
+
+
+def _deserialize_metadata(meta: SerializedMeta) -> Any:
+    """Reconstruct non-array values from the JSON sidecar alone."""
+    t = meta["_type"]
+
+    if t == "dict":
+        return {k: _deserialize_metadata(v) for k, v in meta["items"].items()}
+
+    if t in ("list", "tuple"):
+        items = [_deserialize_metadata(x) for x in meta["items"]]
+        return items if t == "list" else tuple(items)
+
+    if t == "class":
+        module = importlib.import_module(meta["module"])
+        resolved = module
+        for attr in meta["qualname"].split("."):
+            resolved = getattr(resolved, attr)
+        return resolved
+
+    if t in ("scalar", "raw"):
+        return meta["value"]
+
+    raise ValueError(
+        f"Checkpoint metadata cannot contain array data (got _type={t!r}); "
+        "use load_checkpoint to deserialize arrays from the NPZ file"
+    )
+
+
+def load_checkpoint_metadata(
+    json_path: str,
+    *,
+    skip_keys: Iterable[str] = ("model_state_dict", "optimizer_state_dict"),
+) -> Any:
+    """Load checkpoint metadata (step count, init kwargs, ...) from the JSON
+    sidecar without opening the NPZ or deserializing any arrays.
+
+    Callers that only need bookkeeping values — e.g. reading
+    `model_init_kwargs` to build a config before the trainer loads the real
+    weights — should use this instead of `load_checkpoint`, which materializes
+    every model and optimizer array just to throw them away.
+    """
+    if not os.path.exists(json_path):
+        raise ValueError(f"Checkpoint file not found: {json_path}")
+
+    with open(json_path, "r") as f:
+        meta: SerializedMeta = json.load(f)
+
+    if meta["_type"] != "dict":
+        return _deserialize_metadata(meta)
+
+    skipped = set(skip_keys)
+    return {
+        key: _deserialize_metadata(value)
+        for key, value in meta["items"].items()
+        if key not in skipped
+    }

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -9,7 +9,13 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from autograd import functional, nn, optim
-from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, resolve_dtype, xp
+from autograd.backend import (
+    LOW_PRECISION_FLOAT_DTYPES,
+    Array,
+    ArrayLike,
+    resolve_dtype,
+    xp,
+)
 from autograd.data.collator import CausalLMWindowCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import TokenWindowMapDataset
@@ -104,10 +110,14 @@ class GPT2(nn.Module):
             for parameter in self.parameters.values():
                 parameter.data = parameter.data.astype(parameter_dtype)
 
-    def forward(self, tokens: Tensor) -> Tensor:
+    def forward(
+        self, tokens: Tensor, selected_token_indices: ArrayLike | None = None
+    ) -> Tensor:
         """
         Forward pass for GPT-2.
         tokens: shape (batch_size, seq_len)
+        selected_token_indices: optional flattened token positions to project.
+            When provided, only those positions return logits.
         """
         batch_size, seq_len = tokens.shape
 
@@ -129,6 +139,12 @@ class GPT2(nn.Module):
                 h_0 = checkpoint(sublayer, h_0)
             else:
                 h_0 = sublayer(h_0)
+
+        # GRPO only scores generated tokens, so callers can skip final
+        # layernorm + vocab projection for prompt/pad positions.
+        if selected_token_indices is not None:
+            flat_h = h_0.reshape(-1, h_0.shape[-1])
+            h_0 = flat_h[xp.asarray(selected_token_indices, dtype=xp.int32)]
 
         # Final normalization
         output = self.layer_norm(h_0)

--- a/examples/grpo.py
+++ b/examples/grpo.py
@@ -1,38 +1,49 @@
-import json
-import os
+# ruff: noqa: E402
+
 import re
+import sys
 from abc import abstractmethod
-from dataclasses import dataclass, field
-from typing import Any, List, Optional, Sequence, cast
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Sequence
 
 import numpy as np
 from tqdm import tqdm
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from autograd import functional
-from autograd.backend import Array, ArrayLike, xp
+from autograd.backend import Array, ArrayLike, materialize, xp
 from autograd.data.collator import Collator, pad_right_1d
-from autograd.data.utils import load_data, load_parquet_rows
+from autograd.data.gsm8k import load_gsm8k_rows, split_gsm8k_answer
+from autograd.data.sft import (
+    SFT_ROLE_MARKERS,
+    SFT_SYSTEM_PROMPT,
+    SFT_TURN_SEPARATOR,
+)
 from autograd.nn import Module
 from autograd.optim import Adam
 from autograd.tensor import Tensor, no_grad
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.text.utils import generate
 from autograd.tools.config_schema import GenericTrainingConfig
-from autograd.tools.model import load_checkpoint
+from autograd.tools.model import load_checkpoint_metadata, save_checkpoint
 from autograd.tools.trainer import AbstractTrainer, TrainingState
 from examples.gpt_2 import GPT2, GPT2ForwardFn
 
-# Template for DeepSeek-R1-Zero. Table 1
-# Paper: https://arxiv.org/pdf/2501.12948
-SYSTEM_PROMPT = """
-A conversation between User and Assistant. The user asks a question, and the Assistant solves
-it. The assistant first thinks about the reasoning process in the mind and then provides the user
-with the answer. The reasoning process and answer are enclosed within <think>...</think>
-and <answer>...</answer> tags, respectively, i.e., <think> reasoning process here </think>
-<answer> answer here </answer>.
-"""
+EOS_TOKEN = SFT_TURN_SEPARATOR
+PRETRAINED_CHECKPOINT_PATH = "checkpoints/openwebtext_gpt2_124m_baseline_GPT2_14000"
+TOKENIZER_VOCAB_PATH = "training_data/openwebtext_vocab_49990.pkl"
+VALIDATION_TEMPERATURE = 0.05
+TRAIN_VALIDATION_COUNT = 64
 
-EOS_TOKEN = "<|endoftext|>"
+
+def _clear_backend_cache() -> None:
+    clear_cache = getattr(xp, "clear_cache", None)
+    if callable(clear_cache):
+        clear_cache()
 
 
 @dataclass(kw_only=True)
@@ -43,6 +54,7 @@ class GRPOTrainingConfig(GenericTrainingConfig):
     top_k: Optional[int]
     # GRPO group size G: number of completions sampled for one prompt.
     num_generations: int
+    validation_num_generations: int = 1
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -50,11 +62,16 @@ class GRPOTrainingConfig(GenericTrainingConfig):
             raise ValueError(
                 f"max_generation_tokens must be >= 1, got {self.max_generation_tokens}"
             )
-        if self.temperature != 1.0 or self.top_k is not None:
-            raise ValueError("GRPO rollout requires temperature=1.0 and top_k=None")
+        if self.temperature <= 0.0 or self.top_k is not None:
+            raise ValueError("GRPO rollout requires temperature > 0 and top_k=None")
         if self.num_generations < 1:
             raise ValueError(
                 f"num_generations must be >= 1, got {self.num_generations}"
+            )
+        if self.validation_num_generations < 1:
+            raise ValueError(
+                "validation_num_generations must be >= 1, "
+                f"got {self.validation_num_generations}"
             )
 
 
@@ -125,6 +142,12 @@ class Task:
     metadata: Optional[dict] = None
 
 
+@dataclass(frozen=True)
+class CurriculumDatasets:
+    gsm8k_train: list[Task]
+    gsm8k_validation: list[Task]
+
+
 @dataclass
 class RolloutGroup:
     """
@@ -150,21 +173,30 @@ class RolloutGroup:
 class GRPOBatch:
     input_ids: ArrayLike
     labels: ArrayLike
+    # Cached rollout-time logprobs (log π_old). Unused by the current loss; kept
+    # for E39's clipped surrogate to form the importance ratio.
     sampled_token_logprobs: ArrayLike
     generated_token_mask: ArrayLike
     advantages: ArrayLike
+    # Sparse output-head speed optimization: flat indices into (batch*seq) where
+    # generated_token_mask == 1, plus their count. Lets the trainer project only
+    # generated-token rows through the tied vocab head instead of the full sequence.
+    generated_token_indices: Optional[ArrayLike] = None
+    has_nonzero_advantage: Optional[bool] = None
+    generated_token_count: Optional[int] = None
 
 
 class GRPOCollator(Collator):
     """
-    Builds fixed-length GRPO batches from rollout groups.
+    Builds GRPO batches from rollout groups.
 
     A rollout group is one prompt plus G sampled completions. In the first
     one-task loop, the collated batch has `group_size` training rows.
 
-    `max_tokens` is the total row length before causal shifting:
-    `len(prompt_tokens) + len(completion_tokens)`. It is not the rollout
-    generation limit, which only caps completion length.
+    `max_tokens` is the configured upper bound; the actual batch is padded to the
+    batch-local maximum (`batch_max_tokens`) to avoid padding to `self.max_tokens`
+    when the actual rows are shorter. This is the dominant rollout-stage cost
+    saver.
 
     Boundary decision: DataLoader calls this with RolloutGroup objects and this
     returns the trainer-facing GRPOBatch. The trainer should not need to know how
@@ -185,6 +217,15 @@ class GRPOCollator(Collator):
         batch_sampled_token_logprobs = []
         batch_generated_token_mask = []
         batch_advantages = []
+        has_nonzero_advantage = False
+
+        # this avoids batching to the self.max_tokens
+        # instead we use the actual maximum tokens in this group
+        batch_max_tokens = max(
+            len(rollout_group.prompt_tokens) + len(sample.completion_tokens)
+            for rollout_group in rollout_groups
+            for sample in rollout_group.samples
+        )
 
         for rollout_group in rollout_groups:
             for sample in rollout_group.samples:
@@ -194,13 +235,23 @@ class GRPOCollator(Collator):
                     sampled_token_logprobs,
                     generated_token_mask,
                     advantages,
-                ) = self._build_row(rollout_group.prompt_tokens, sample)
+                ) = self._build_row(
+                    rollout_group.prompt_tokens, sample, batch_max_tokens
+                )
 
                 batch_input_ids.append(input_ids)
                 batch_labels.append(labels)
                 batch_sampled_token_logprobs.append(sampled_token_logprobs)
                 batch_generated_token_mask.append(generated_token_mask)
                 batch_advantages.append(advantages)
+                has_nonzero_advantage = has_nonzero_advantage or bool(
+                    sample.advantage != 0.0
+                )
+
+        generated_token_mask_np = np.stack(batch_generated_token_mask, axis=0)
+        generated_token_indices = np.flatnonzero(
+            generated_token_mask_np.reshape(-1)
+        ).astype(np.int32)
 
         return GRPOBatch(
             input_ids=xp.array(np.stack(batch_input_ids, axis=0)),
@@ -208,15 +259,25 @@ class GRPOCollator(Collator):
             sampled_token_logprobs=xp.array(
                 np.stack(batch_sampled_token_logprobs, axis=0)
             ),
-            generated_token_mask=xp.array(np.stack(batch_generated_token_mask, axis=0)),
+            generated_token_mask=xp.array(generated_token_mask_np),
             advantages=xp.array(np.stack(batch_advantages, axis=0)),
+            generated_token_indices=xp.array(generated_token_indices),
+            has_nonzero_advantage=has_nonzero_advantage,
+            generated_token_count=int(generated_token_mask_np.sum()),
         )
 
     def _build_row(
         self,
         prompt_tokens: Array,
         sample: Sample,
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        batch_max_tokens: int,
+    ) -> tuple[
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+    ]:
         completion_tokens = np.asarray(sample.completion_tokens)
 
         prompt_np = np.asarray(prompt_tokens, dtype=np.int32)
@@ -259,18 +320,16 @@ class GRPOCollator(Collator):
             sample.advantage
         )
 
-        # Fixed padding keeps this first GRPO collator simple. We can switch to
-        # dynamic padding later if padding waste becomes a measured bottleneck.
-        tokens = pad_right_1d(tokens, self.max_tokens, self.pad_idx)
-        generated_token_mask = pad_right_1d(generated_token_mask, self.max_tokens, 0)
+        tokens = pad_right_1d(tokens, batch_max_tokens, self.pad_idx)
+        generated_token_mask = pad_right_1d(generated_token_mask, batch_max_tokens, 0)
         aligned_sampled_token_logprobs = pad_right_1d(
             aligned_sampled_token_logprobs,
-            self.max_tokens,
+            batch_max_tokens,
             0.0,
         )
         aligned_advantages = pad_right_1d(
             aligned_advantages,
-            self.max_tokens,
+            batch_max_tokens,
             0.0,
         )
 
@@ -299,7 +358,11 @@ class Environment:
     def _render_prompt(self, user_prompt: str) -> str:
         # Private template helper. This should stay string-in/string-out and not
         # know about Task, rewards, or rollout state.
-        return SYSTEM_PROMPT + f"User: {user_prompt}{EOS_TOKEN}Assistant: "
+        return (
+            f"{SFT_ROLE_MARKERS['system']}{SFT_SYSTEM_PROMPT}"
+            f"{SFT_TURN_SEPARATOR}{SFT_ROLE_MARKERS['user']}{user_prompt}"
+            f"{SFT_TURN_SEPARATOR}{SFT_ROLE_MARKERS['assistant']}"
+        )
 
     @abstractmethod
     def _compute_reward(self, task: Task, sample: Sample) -> float:  # pyright: ignore[reportReturnType]
@@ -324,15 +387,20 @@ class MathEnvironment(Environment):
 
     Math is chosen because rewards can be rule-based and fast: exact final-answer
     checking is enough to prove the full loop learns.
+
+    Exact-only reward: format-valid + correct numeric answer earns 1.0, anything
+    else earns 0.0. Settled by E24/E33 — shaped wrong-answer rewards collapse
+    diversity without lifting pass@1.
     """
 
     # This regex should be consistent with the SYSTEM_PROMPT defined at the
     # top of this module
-    ANSWER_RE = re.compile(r"<answer>\s*(.*?)\s*</answer>", re.DOTALL)
-    GSM8K_FINAL_ANSWER_RE = re.compile(r"####\s*(.+?)\s*$")
-    GSM8K_PARQUET_MANIFEST_URL = (
-        "https://datasets-server.huggingface.co/parquet?"
-        "dataset=openai%2Fgsm8k&config=main"
+    RESPONSE_RE = re.compile(
+        r"\A\s*<think>((?:(?!</?think>|</?answer>).)*?)</think>\s*"
+        r"<answer>\s*((?:(?!</?think>|</?answer>).)*?)\s*</answer>\s*"
+        + re.escape(SFT_TURN_SEPARATOR)
+        + r"\s*\Z",
+        re.DOTALL,
     )
 
     @staticmethod
@@ -340,11 +408,32 @@ class MathEnvironment(Environment):
         return answer.strip().replace(",", "")
 
     @classmethod
+    def parse_numeric_answer(cls, answer: str) -> Optional[float]:
+        normalized = cls.normalize_answer(answer).strip()
+        if normalized.startswith("$"):
+            normalized = normalized[1:].strip()
+        if not re.fullmatch(r"[-+]?\d+(?:\.\d+)?", normalized):
+            return None
+        return float(normalized)
+
+    @classmethod
+    def answers_match(cls, predicted_answer: str, expected_answer: str) -> bool:
+        predicted = cls.normalize_answer(predicted_answer)
+        expected = cls.normalize_answer(expected_answer)
+        if predicted == expected:
+            return True
+        predicted_number = cls.parse_numeric_answer(predicted)
+        expected_number = cls.parse_numeric_answer(expected)
+        return (
+            predicted_number is not None
+            and expected_number is not None
+            and predicted_number == expected_number
+        )
+
+    @classmethod
     def extract_gsm8k_final_answer(cls, answer: str) -> str:
-        match = cls.GSM8K_FINAL_ANSWER_RE.search(answer)
-        if match is None:
-            raise ValueError("GSM8K answer must contain a final answer after '####'")
-        return cls.normalize_answer(match.group(1))
+        _, final_answer = split_gsm8k_answer(answer)
+        return cls.normalize_answer(final_answer)
 
     @classmethod
     def gsm8k_row_to_task(cls, row_idx: int, row: dict[str, Any]) -> Task:
@@ -354,86 +443,58 @@ class MathEnvironment(Environment):
             raise ValueError(
                 "GSM8K rows must contain string question and answer fields"
             )
+        reasoning, final_answer = split_gsm8k_answer(answer)
         return Task(
             task_id=f"gsm8k-{row_idx}",
             raw_input=question,
-            answer=cls.extract_gsm8k_final_answer(answer),
-            metadata={"source": "openai/gsm8k"},
+            answer=cls.normalize_answer(final_answer),
+            metadata={"source": "openai/gsm8k", "reasoning": reasoning},
         )
 
     @classmethod
     def load_gsm8k_tasks(cls, split: str, max_tasks: Optional[int]) -> list[Task]:
-        metadata_path = "training_data/gsm8k_parquet_manifest.json"
-        payload = json.loads(
-            cast(
-                str,
-                load_data(
-                    cls.GSM8K_PARQUET_MANIFEST_URL,
-                    metadata_path,
-                ),
-            )
-        )
-        parquet_files = [
-            parquet_file
-            for parquet_file in payload["parquet_files"]
-            if parquet_file["split"] == split
-        ]
-        if not parquet_files:
-            available_splits = sorted(
-                {parquet_file["split"] for parquet_file in payload["parquet_files"]}
-            )
-            raise ValueError(
-                f"GSM8K split {split!r} not found. Available splits: {available_splits}"
-            )
-
-        rows: list[dict[str, Any]] = []
-        for parquet_file in parquet_files:
-            if max_tasks is not None and len(rows) >= max_tasks:
-                break
-            remaining_rows = None if max_tasks is None else max_tasks - len(rows)
-            rows.extend(
-                load_parquet_rows(
-                    parquet_file["url"],
-                    os.path.join(
-                        "training_data",
-                        f"gsm8k_{parquet_file['split']}_{parquet_file['filename']}",
-                    ),
-                    max_rows=remaining_rows,
-                )
-            )
-
+        rows = load_gsm8k_rows(split=split, max_rows=max_tasks)
         return [cls.gsm8k_row_to_task(row_idx, row) for row_idx, row in enumerate(rows)]
 
     def _compute_reward(self, task: Task, sample: Sample) -> float:
-        reward = 0.0
-        if "<think>" in sample.completion_text:
-            reward += 0.1
-        if "</think>" in sample.completion_text:
-            reward += 0.1
-        if "<answer>" in sample.completion_text:
-            reward += 0.1
-        if "</answer>" in sample.completion_text:
-            reward += 0.1
+        match = self.RESPONSE_RE.match(sample.completion_text)
+        format_valid = match is not None
+        parsed_answer = None
+        parsed_answer_number = None
+        expected_answer_number = self.parse_numeric_answer(task.answer)
+        relative_error = None
+        exact_match = False
+        if format_valid:
+            parsed_answer = self.normalize_answer(match.group(2))
+            parsed_answer_number = self.parse_numeric_answer(parsed_answer)
+            exact_match = self.answers_match(parsed_answer, task.answer)
+            if parsed_answer_number is not None and expected_answer_number is not None:
+                abs_error = abs(parsed_answer_number - expected_answer_number)
+                relative_error = abs_error / max(1.0, abs(expected_answer_number))
 
-        match = self.ANSWER_RE.search(sample.completion_text)
-        if match is None:
-            return reward
+        if sample.metadata is None:
+            sample.metadata = {}
+        sample.metadata.update(
+            {
+                "format_valid": format_valid,
+                "exact_match": exact_match,
+                "parsed_answer": parsed_answer,
+                "parsed_answer_number": parsed_answer_number,
+                "expected_answer_number": expected_answer_number,
+                "relative_error": relative_error,
+            }
+        )
 
-        parsed_answer = self.normalize_answer(match.group(1))
-        expected_answer = self.normalize_answer(task.answer)
-        if parsed_answer == expected_answer:
-            reward += 1.0
-
-        return reward
+        return 1.0 if exact_match else 0.0
 
 
 class RolloutGenerator:
     """
     Samples on-policy completions from the current model.
 
-    Given one Task, it should render the prompt via Environment, sample G
-    completions, cache sampled-token logprobs, ask Environment to score
-    samples, and return one RolloutGroup. It should not perform optimizer work.
+    Given one Task, it renders the prompt via Environment, samples G completions,
+    caches sampled-token logprobs, asks Environment to score samples, and returns
+    one RolloutGroup. It does not perform optimizer work.
     """
 
     def __init__(self, config: GRPOTrainingConfig) -> None:
@@ -445,28 +506,72 @@ class RolloutGenerator:
         task: Task,
         tokenizer: BytePairEncoder,
         environment: Environment,
+        *,
+        num_generations: Optional[int] = None,
     ) -> RolloutGroup:
         task_prompt: str = environment.render_task(task)
         prompt_tokens = np.array(tokenizer.encode(task_prompt), dtype=np.int32)
-        samples = generation(
-            model,
-            prompt_tokens=prompt_tokens,
-            tokenizer=tokenizer,
-            num_generations=self.config.num_generations,
-            max_generation_tokens=self.config.max_generation_tokens,
-            temperature=self.config.temperature,
-            top_k=self.config.top_k,
-        )
+        if num_generations is None:
+            num_generations = self.config.num_generations
+
+        # Sample G completions from the current model. `compute_logprobs=False`
+        # skips logprob computation in the sampler — the current GRPO loss
+        # recomputes them during training. E39's clipped surrogate will need to
+        # flip this back on so the cached log π_old is meaningful.
+        prompt_token_list = [int(token) for token in prompt_tokens]
+        available_new_tokens = model.max_seq_len - len(prompt_token_list)
+        if available_new_tokens <= 0:
+            raise ValueError(
+                f"prompt length {len(prompt_token_list)} leaves no room for "
+                f"generation within model max_seq_len {model.max_seq_len}"
+            )
+        eos_token_id = tokenizer.encode(EOS_TOKEN)[0]
+        was_training = getattr(model, "_is_training", None)
+        model.eval()
+        try:
+            results = generate(
+                model=model,
+                prediction_func=GPT2ForwardFn(),
+                prompt_tokens=prompt_token_list,
+                max_new_tokens=min(
+                    self.config.max_generation_tokens, available_new_tokens
+                ),
+                temperature=self.config.temperature,
+                top_k=self.config.top_k,
+                eos_token_id=eos_token_id,
+                show_progress=False,
+                num_generations=num_generations,
+                compute_logprobs=False,
+            )
+        finally:
+            if was_training:
+                model.train()
+
+        # Keep sampled token ids directly. Decoding and re-encoding can change
+        # BPE boundaries at the rendered-prompt/completion join.
+        samples = [
+            Sample(
+                completion_tokens=np.array(result.completion_tokens, dtype=np.int32),
+                completion_text=tokenizer.decode(result.completion_tokens),
+                sampled_token_logprobs=np.array(result.logprobs, dtype=np.float32),
+                reward=None,
+                advantage=None,
+                metadata={
+                    "stop_reason": result.stop_reason,
+                    "temperature": self.config.temperature,
+                    "top_k": self.config.top_k,
+                },
+            )
+            for result in results
+        ]
 
         rollout_group = RolloutGroup(
             prompt_id=task.task_id,
             prompt_tokens=prompt_tokens,
             samples=samples,
         )
-
         rollout_group = environment.score_group(task, rollout_group)
         self._compute_advantages(rollout_group)
-
         return rollout_group
 
     def _compute_advantages(self, rollout_group: RolloutGroup) -> None:
@@ -476,11 +581,10 @@ class RolloutGenerator:
         r = reward
 
         1. Calculate the mean
-        2. Calcuate the standard deviation
+        2. Calculate the standard deviation
         3. Calculate the advantage
 
         $A_i = \frac{r_i - \mu}{\sigma}$
-
         """
         rewards = []
         for sample in rollout_group.samples:
@@ -504,17 +608,32 @@ class GRPOTrainer(AbstractTrainer):
     """
     Trainer boundary for GRPOBatch optimization.
 
-    This can subclass AbstractTrainer because rollout has already happened by
-    the time it receives a GRPOBatch. The trainer can keep owning backward(),
-    gradient scaling, clipping, optimizer.step(), and step bookkeeping.
+    Rollout happens upstream; this owns forward, loss, backward, gradient
+    scaling/clipping, optimizer step, and global-step bookkeeping.
 
-    It should not own raw tasks, Environment, or RolloutGenerator. A higher
-    level orchestration loop is responsible for:
+    A higher-level orchestration loop is responsible for:
 
         Task -> RolloutGenerator.rollout(...) -> GRPOCollator -> self.train_step(...)
 
-    Each one-task GRPOBatch contains group_size rows.
+    Eval is rollout-based (pass@1, any@k, majority@k), not loss-based, so it
+    lives in `eval_callbacks` rather than `_evaluate`. The orchestration loop
+    triggers it via `run_eval_callbacks()` at its chosen cadence.
     """
+
+    def __init__(
+        self,
+        *args,
+        eval_callbacks: Optional[Sequence[Callable[["GRPOTrainer"], None]]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.eval_callbacks: List[Callable[["GRPOTrainer"], None]] = list(
+            eval_callbacks or ()
+        )
+
+    def run_eval_callbacks(self) -> None:
+        for callback in self.eval_callbacks:
+            callback(self)
 
     def _forward_and_loss(self, batch: GRPOBatch):
         """
@@ -524,7 +643,25 @@ class GRPOTrainer(AbstractTrainer):
         `self.model(batch.input_ids)`, `batch.advantages` for the group-relative
         learning signal, and `batch.generated_token_mask` so prompt/pad/forced
         tokens do not contribute.
+
+        Uses the sparse-output-head speed optimization when generated-token
+        indices are available: the model forward projects only rows that
+        contribute to the GRPO loss. Falls back to full-logits loss otherwise.
         """
+
+        generated_token_indices = batch.generated_token_indices
+        if generated_token_indices is not None:
+            # Prompt/pad rows have zero GRPO weight; ask the normal model
+            # forward to return logits only for rows that affect the loss.
+            selected_logits = self.model(
+                batch.input_ids,
+                selected_token_indices=generated_token_indices,
+            )
+            return grpo_loss_from_selected_logits(
+                selected_logits,
+                batch,
+                generated_token_indices,
+            )
 
         logits = self.model(batch.input_ids)
         return self.loss_fn(logits, batch)
@@ -538,10 +675,14 @@ class GRPOTrainer(AbstractTrainer):
         Long bad outputs -> large negative influence
         Long verbose correct outputs -> large positive influence
         """
+        if batch.generated_token_count is not None:
+            return xp.array(float(batch.generated_token_count), dtype=xp.float32)
         return xp.sum(batch.generated_token_mask)
 
     def _evaluate(self, val_data_loader):
-        pass
+        # Required override; GRPO evaluation happens via validate_policy outside
+        # the AbstractTrainer fit-loop.
+        del val_data_loader
 
     def train_step(self, batch: GRPOBatch) -> Tensor:
         """
@@ -552,20 +693,62 @@ class GRPOTrainer(AbstractTrainer):
         scaling/clipping, optimizer step, and global step bookkeeping.
 
         We might want to resort back to the normal trainer.fit() way of training later, after we decide to go off-policy with a separate generation policy and trained policy
+
+        Skips the optimizer entirely when reward variance is zero across the
+        group (all-correct or all-wrong) — in that case all advantages are zero
+        and the backward pass is wasted work.
         """
         self.model.train()
         self.optimizer.zero_grad()
+
+        has_nonzero_advantage = batch.has_nonzero_advantage
+        if has_nonzero_advantage is None:
+            has_nonzero_advantage = not bool(
+                xp.to_scalar(xp.all(xp.asarray(batch.advantages) == 0))
+            )
+        if not has_nonzero_advantage:
+            self.global_step += 1
+            return Tensor(xp.array(0.0, dtype=xp.float32), requires_grad=False)
 
         state = TrainingState()
         loss = self._forward_and_loss(batch)
         total_weight = self._loss_total_weight(batch)
         loss.backward()
-        state.record_loss(loss, total_weight=total_weight)
+        state.accumulated_batches = 1
+        state.accumulated_loss_total_weight = total_weight
 
-        if self.optimizer_step(state):
+        if self.optimizer_step(state, record_grad_norm=False):
             self.global_step += 1
 
         return loss
+
+    def save_checkpoint(self) -> tuple[str, str]:
+        checkpoint = {
+            "epoch": 0,
+            "step_count": self.global_step,
+            "steps_per_epoch": None,
+            "best_val_loss": self.best_val_loss,
+            "model_state_dict": self.model.state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "model_init_kwargs": self.checkpoint.get(
+                "model_init_kwargs",
+                self.config.model_kwargs,
+            ),
+            "optimizer_init_kwargs": self.checkpoint.get(
+                "optimizer_init_kwargs",
+                self.config.optimizer_kwargs,
+            ),
+            "config_repr": repr(self.config),
+        }
+        checkpoint_name = (
+            f"{self.config.training_run_name}_"
+            f"{self.model.__class__.__name__}_{self.global_step}_final"
+        )
+        return save_checkpoint(
+            checkpoint,
+            checkpoint_dir=self.CHECKPOINT_DIR,
+            checkpoint_name=checkpoint_name,
+        )
 
 
 def grpo_loss(logits: Tensor, batch: GRPOBatch) -> Tensor:
@@ -599,12 +782,11 @@ def grpo_loss(logits: Tensor, batch: GRPOBatch) -> Tensor:
     = \log \pi_\theta(\text{token}_{i,t}\mid \text{prompt},\text{token}_{i,<t})
     $$
 
-    TODO: add KL regularization against a reference policy once this example
-    introduces a separate reference model.
-    TODO: add a clipped surrogate once sampled-token logprobs are meant to
-    represent a distinct behavior policy.
-    TODO: add the policy-gradient/policy-ratio surrogate when old/current policy
-    ownership is explicit in the training loop.
+    TODO (E39): add KL regularization against a frozen reference policy.
+    TODO (E39): add a clipped surrogate that uses cached sampled_token_logprobs
+    as log π_old and applies DAPO Clip-Higher (lower 0.8, upper ~1.28).
+    TODO (E39): switch the per-row length normalization to Dr.GRPO's constant
+    max_completion_len so length bias is removed.
 
     Advantage-weighted token objective:
     $$
@@ -615,84 +797,275 @@ def grpo_loss(logits: Tensor, batch: GRPOBatch) -> Tensor:
     return -(sampled_token_logprobs * advantages * generated_token_mask).sum()
 
 
-def generation(
-    model: Module,
-    prompt_tokens: Array,
-    tokenizer: BytePairEncoder,
-    *,
-    num_generations: int,
-    max_generation_tokens: int,
-    temperature: float,
-    top_k: Optional[int] = None,
-    eos_token: str = EOS_TOKEN,
-) -> List[Sample]:
-    # Sampled-token logprobs must be raw-policy logprobs. With temperature=1 and no
-    # top-k, the current generate() sampling logprobs match raw model logprobs.
-    # TODO: split sampling-logprobs from raw-policy logprobs if we add rollout
-    # temperature/top-k exploration.
-    if temperature != 1.0 or top_k is not None:
-        raise ValueError("GRPO rollout requires temperature=1.0 and top_k=None")
+def grpo_loss_from_selected_logits(
+    logits: Tensor,
+    batch: GRPOBatch,
+    generated_token_indices: ArrayLike,
+) -> Tensor:
+    """
+    Same GRPO objective as grpo_loss when logits already contain only the
+    generated-token positions.
+    """
+    indices = xp.asarray(generated_token_indices, dtype=xp.int32)
 
-    prompt_token_list = [int(token) for token in prompt_tokens]
-    eos_token_id = tokenizer.encode(eos_token)[0]
+    labels = xp.asarray(batch.labels, dtype=xp.int32).reshape(-1)[indices]
+    advantages = xp.asarray(batch.advantages, dtype=xp.float32).reshape(-1)[indices]
 
-    available_new_tokens = model.max_seq_len - len(prompt_token_list)
-    if available_new_tokens <= 0:
-        raise ValueError(
-            f"prompt length {len(prompt_token_list)} leaves no room for generation "
-            f"within model max_seq_len {model.max_seq_len}"
+    logprobs = functional.log_softmax(logits, dim=-1)
+    row_idx = xp.arange(labels.shape[0])
+    sampled_token_logprobs = logprobs[row_idx, labels]
+    return -(sampled_token_logprobs * advantages).sum()
+
+
+def rollout_metrics(samples: Sequence[Sample]) -> dict[str, float]:
+    if not samples:
+        raise ValueError("rollout metrics require at least one sample")
+
+    rewards = []
+    format_valid = 0
+    exact_match = 0
+    turn_end = 0
+    completion_lengths = []
+    parsed_answers = []
+    nonzero_advantages = 0
+    for sample in samples:
+        if sample.reward is None:
+            raise ValueError("sample.reward must be set before logging")
+        metadata = sample.metadata or {}
+        rewards.append(sample.reward)
+        format_valid += int(bool(metadata.get("format_valid", False)))
+        exact_match += int(bool(metadata.get("exact_match", False)))
+        turn_end += int(metadata.get("stop_reason") == "eos")
+        completion_lengths.append(len(sample.completion_tokens))
+        parsed_answers.append(metadata.get("parsed_answer"))
+        nonzero_advantages += int(
+            sample.advantage is not None and sample.advantage != 0.0
         )
 
-    max_steps = min(max_generation_tokens, available_new_tokens)
-    was_training = getattr(model, "_is_training", None)
-    model.eval()
-    try:
-        results = generate(
-            model=model,
-            prediction_func=GPT2ForwardFn(),
-            prompt_tokens=prompt_token_list,
-            max_new_tokens=max_steps,
-            temperature=temperature,
-            top_k=top_k,
-            eos_token_id=eos_token_id,
-            show_progress=False,
+    rewards_array = np.array(rewards, dtype=np.float32)
+    sample_count = float(len(samples))
+    answer_counts = {
+        parsed_answer: parsed_answers.count(parsed_answer)
+        for parsed_answer in set(parsed_answers)
+    }
+    dominant_answer_count = max(answer_counts.values())
+    return {
+        "reward_mean": float(rewards_array.mean()),
+        "reward_std": float(rewards_array.std()),
+        "reward_max": float(rewards_array.max()),
+        "format_valid_rate": format_valid / sample_count,
+        "exact_match_rate": exact_match / sample_count,
+        "turn_end_rate": turn_end / sample_count,
+        "completion_len_mean": float(np.mean(completion_lengths)),
+        "answer_unique_count": float(len(answer_counts)),
+        "dominant_answer_rate": dominant_answer_count / sample_count,
+        "nonzero_advantage_rate": nonzero_advantages / sample_count,
+    }
+
+
+def validate_policy(
+    *,
+    step: int,
+    model: Module,
+    rollout_generator: RolloutGenerator,
+    validation_tasks: Sequence[Task],
+    tokenizer: BytePairEncoder,
+    environment: Environment,
+    progress_bar: tqdm,
+    label: str,
+    num_generations: Optional[int] = None,
+) -> dict[str, float]:
+    validation_samples = []
+    majority_exact = 0
+    any_exact = 0
+    best_sample = None
+    best_prompt_tokens = None
+    best_reward = -float("inf")
+    with no_grad():
+        for validation_task in validation_tasks:
+            validation_group = rollout_generator.rollout(
+                model=model,
+                task=validation_task,
+                tokenizer=tokenizer,
+                environment=environment,
+                num_generations=num_generations,
+            )
+            validation_samples.extend(validation_group.samples)
+            parsed_answers = [
+                sample.metadata.get("parsed_answer")
+                for sample in validation_group.samples
+                if sample.metadata is not None
+                and sample.metadata.get("parsed_answer") is not None
+            ]
+            answer_counts = {
+                parsed_answer: parsed_answers.count(parsed_answer)
+                for parsed_answer in set(parsed_answers)
+            }
+            majority_answer = None
+            if answer_counts:
+                majority_answer = max(answer_counts.items(), key=lambda item: item[1])[
+                    0
+                ]
+            majority_exact += int(
+                majority_answer is not None
+                and MathEnvironment.answers_match(
+                    majority_answer, validation_task.answer
+                )
+            )
+            any_exact += int(
+                any(
+                    bool((sample.metadata or {}).get("exact_match", False))
+                    for sample in validation_group.samples
+                )
+            )
+            for sample in validation_group.samples:
+                if sample.reward is None:
+                    raise ValueError(
+                        "validation sample reward must be set before logging"
+                    )
+                if sample.reward > best_reward:
+                    best_reward = sample.reward
+                    best_sample = sample
+                    best_prompt_tokens = validation_group.prompt_tokens
+
+    validation_metrics = rollout_metrics(validation_samples)
+    task_count = float(len(validation_tasks))
+    validation_metrics["majority_exact_match_rate"] = majority_exact / task_count
+    validation_metrics["any_exact_match_rate"] = any_exact / task_count
+    progress_bar.write(
+        "validation "
+        f"{label} "
+        f"step={step} "
+        f"reward_mean={validation_metrics['reward_mean']:.3f} "
+        f"reward_max={validation_metrics['reward_max']:.3f} "
+        f"exact={validation_metrics['majority_exact_match_rate']:.3f} "
+        f"sample_exact={validation_metrics['exact_match_rate']:.3f} "
+        f"any_exact={validation_metrics['any_exact_match_rate']:.3f} "
+        f"format={validation_metrics['format_valid_rate']:.3f} "
+        f"turn_end={validation_metrics['turn_end_rate']:.3f} "
+        f"len={validation_metrics['completion_len_mean']:.1f} "
+        f"answers={validation_metrics['answer_unique_count']:.0f} "
+        f"dominant={validation_metrics['dominant_answer_rate']:.3f} "
+        f"updates={validation_metrics['nonzero_advantage_rate']:.3f}"
+    )
+    if best_sample is not None and best_prompt_tokens is not None:
+        progress_bar.write("Prompt:")
+        progress_bar.write(tokenizer.decode(best_prompt_tokens))
+        progress_bar.write(best_sample.completion_text)
+        progress_bar.write(
+            "--------------------------------------------------------------"
+        )
+    _clear_backend_cache()
+    return validation_metrics
+
+
+def make_validation_callback(
+    *,
+    label: str,
+    validation_tasks: Sequence[Task],
+    rollout_generator: RolloutGenerator,
+    tokenizer: BytePairEncoder,
+    environment: Environment,
+    progress_bar: tqdm,
+    num_generations: Optional[int],
+) -> Callable[[GRPOTrainer], None]:
+    # Wraps validate_policy as a GRPOTrainer.eval_callbacks entry. The closure
+    # captures everything validate_policy needs except the live model + step,
+    # which it reads off the trainer when fired.
+    def callback(trainer: GRPOTrainer) -> None:
+        validate_policy(
+            step=trainer.global_step,
+            model=trainer.model,
+            rollout_generator=rollout_generator,
+            validation_tasks=validation_tasks,
+            tokenizer=tokenizer,
+            environment=environment,
+            progress_bar=progress_bar,
+            label=label,
             num_generations=num_generations,
         )
-    finally:
-        if was_training:
-            model.train()
 
-    # Keep sampled token ids directly. Decoding and re-encoding can change BPE
-    # boundaries at the rendered-prompt/completion join.
-    return [
-        Sample(
-            completion_tokens=np.array(result.completion_tokens, dtype=np.int32),
-            completion_text=tokenizer.decode(result.completion_tokens),
-            sampled_token_logprobs=np.array(result.logprobs, dtype=np.float32),
-            reward=None,
-            advantage=None,
-            metadata={
-                "stop_reason": result.stop_reason,
-                "temperature": temperature,
-                "top_k": top_k,
-            },
+    return callback
+
+
+def filter_fitting_tasks(
+    tasks: Sequence[Task],
+    *,
+    environment: Environment,
+    tokenizer: BytePairEncoder,
+    max_tokens: int,
+    max_generation_tokens: int,
+) -> list[Task]:
+    fitting_tasks = []
+    for task in tasks:
+        prompt_len = len(tokenizer.encode(environment.render_task(task)))
+        if prompt_len + max_generation_tokens <= max_tokens:
+            fitting_tasks.append(task)
+    return fitting_tasks
+
+
+def build_curriculum_datasets(
+    *,
+    environment: MathEnvironment,
+    tokenizer: BytePairEncoder,
+    max_tokens: int,
+    max_generation_tokens: int,
+    gsm8k_train_count: Optional[int] = None,
+    gsm8k_validation_count: int = 64,
+    gsm8k_validation_offset: Optional[int] = None,
+) -> CurriculumDatasets:
+    if gsm8k_validation_offset is None:
+        gsm8k_validation_offset = (
+            128 if gsm8k_train_count is None else gsm8k_train_count
         )
-        for result in results
-    ]
-
-
-def main():
-    pretrained_checkpoint_path = "checkpoints/sft_0428_GPT2_300"
-    ckpt = load_checkpoint(
-        f"{pretrained_checkpoint_path}.json",
-        f"{pretrained_checkpoint_path}.npz",
+    max_gsm8k_rows = None
+    if gsm8k_train_count is not None:
+        max_gsm8k_rows = max(
+            gsm8k_train_count,
+            gsm8k_validation_offset + gsm8k_validation_count,
+        )
+    gsm8k_tasks = filter_fitting_tasks(
+        environment.load_gsm8k_tasks(
+            split="train",
+            max_tasks=max_gsm8k_rows,
+        ),
+        environment=environment,
+        tokenizer=tokenizer,
+        max_tokens=max_tokens,
+        max_generation_tokens=max_generation_tokens,
+    )
+    if len(gsm8k_tasks) < gsm8k_validation_offset + gsm8k_validation_count:
+        raise ValueError(
+            "Not enough fitting GSM8K tasks for requested train/validation split: "
+            f"got {len(gsm8k_tasks)}"
+        )
+    if gsm8k_train_count is None:
+        gsm8k_train = (
+            gsm8k_tasks[:gsm8k_validation_offset]
+            + gsm8k_tasks[gsm8k_validation_offset + gsm8k_validation_count :]
+        )
+    else:
+        gsm8k_train = gsm8k_tasks[:gsm8k_train_count]
+    return CurriculumDatasets(
+        gsm8k_train=gsm8k_train,
+        gsm8k_validation=gsm8k_tasks[
+            gsm8k_validation_offset : gsm8k_validation_offset + gsm8k_validation_count
+        ],
     )
 
-    TRAIN_CONFIG = GRPOTrainingConfig(
-        max_steps=50,
-        max_eval_steps=5,
-        checkpoint_freq=50,
-        report_every_steps=5,
+
+def build_training_config(ckpt: dict[str, Any]) -> GRPOTrainingConfig:
+    # Default config runs actual GRPO from the configured checkpoint. The clean
+    # OpenWebText base produces ~0 reward signal on GSM8K, so groups will short
+    # -circuit through `has_nonzero_advantage` until the starting checkpoint has
+    # a non-trivial pass@1. Swap PRETRAINED_CHECKPOINT_PATH to an SFT checkpoint
+    # before expecting learning to happen.
+    return GRPOTrainingConfig(
+        training_run_name="grpo_gpt2",
+        max_steps=200,
+        max_eval_steps=32,
+        checkpoint_freq=100,
+        report_every_steps=50,
         # GRPO train_step currently performs one optimizer step per rollout
         # group. num_generations is the effective GRPO group-size knob until we
         # add GRPO gradient accumulation.
@@ -700,13 +1073,20 @@ def main():
         micro_batch_size=1,
         max_grad_norm=1.0,
         model_kwargs=ckpt["model_init_kwargs"],
-        optimizer_kwargs={"lr": 5e-5},
-        pretrained_checkpoint_path=pretrained_checkpoint_path,
-        max_generation_tokens=256,
-        temperature=1.0,
+        optimizer_kwargs={"lr": 1e-6},
+        pretrained_checkpoint_path=PRETRAINED_CHECKPOINT_PATH,
+        max_generation_tokens=128,
+        temperature=0.7,
         top_k=None,
         num_generations=16,
+        validation_num_generations=1,
     )
+
+
+def main():
+    ckpt = load_checkpoint_metadata(f"{PRETRAINED_CHECKPOINT_PATH}.json")
+
+    TRAIN_CONFIG = build_training_config(ckpt)
 
     trainer = GRPOTrainer(
         model_cls=GPT2,
@@ -716,20 +1096,39 @@ def main():
     )
 
     bpe = BytePairEncoder(
-        num_merges=12000,
-        vocab_file_path="training_data/wikipedia_simpleenglish_vocab_12000.pkl",
+        num_merges=49990,
+        vocab_file_path=TOKENIZER_VOCAB_PATH,
     )
     environment = MathEnvironment()
-    raw_tasks = environment.load_gsm8k_tasks(split="train", max_tasks=128)
-    tasks = []
-    for task in raw_tasks:
-        prompt_len = len(bpe.encode(environment.render_task(task)))
-        if prompt_len + TRAIN_CONFIG.max_generation_tokens <= trainer.model.max_seq_len:
-            tasks.append(task)
-    if not tasks:
+    datasets = build_curriculum_datasets(
+        environment=environment,
+        tokenizer=bpe,
+        max_tokens=trainer.model.max_seq_len,
+        max_generation_tokens=TRAIN_CONFIG.max_generation_tokens,
+    )
+    train_tasks = datasets.gsm8k_train
+    if not datasets.gsm8k_train or not datasets.gsm8k_validation:
         raise ValueError("No GSM8K tasks fit within the model context window")
 
+    print(
+        "Data length: "
+        f"gsm8k_train={len(datasets.gsm8k_train)} "
+        f"gsm8k_val={len(datasets.gsm8k_validation)}"
+    )
     rollout_generator = RolloutGenerator(TRAIN_CONFIG)
+    validation_rollout_generator = RolloutGenerator(
+        replace(TRAIN_CONFIG, temperature=VALIDATION_TEMPERATURE)
+    )
+    gsm8k_validation_sets = [
+        ("gsm8k_train_seen", datasets.gsm8k_train[:TRAIN_VALIDATION_COUNT]),
+        ("gsm8k", datasets.gsm8k_validation),
+    ]
+    print(
+        "Validation: "
+        f"temperature={VALIDATION_TEMPERATURE:.2f} "
+        f"gsm8k_train_seen={len(gsm8k_validation_sets[0][1])} "
+        f"gsm8k_heldout={len(datasets.gsm8k_validation)}"
+    )
     collator = GRPOCollator(
         max_tokens=trainer.model.max_seq_len,
         pad_idx=bpe.encode("<PAD>")[0],
@@ -741,60 +1140,54 @@ def main():
         initial=trainer.global_step,
         desc="GRPO training",
     ) as progress_bar:
+        # Register validation as eval callbacks once. Each callback closes over
+        # its own task split + label so the training loop can fire them all via
+        # trainer.run_eval_callbacks() without re-passing the per-split state.
+        trainer.eval_callbacks = [
+            make_validation_callback(
+                label=label,
+                validation_tasks=validation_tasks,
+                rollout_generator=validation_rollout_generator,
+                tokenizer=bpe,
+                environment=environment,
+                progress_bar=progress_bar,
+                num_generations=TRAIN_CONFIG.validation_num_generations,
+            )
+            for label, validation_tasks in gsm8k_validation_sets
+        ]
+        trainer.run_eval_callbacks()
+
         while trainer.global_step < TRAIN_CONFIG.max_steps:
             step_before = trainer.global_step
-            task = tasks[trainer.global_step % len(tasks)]
+            task = train_tasks[trainer.global_step % len(train_tasks)]
             rollout_group = rollout_generator.rollout(
                 model=trainer.model,
                 task=task,
                 tokenizer=bpe,
                 environment=environment,
             )
-            loss = trainer.train_step(collator([rollout_group]))
+            train_batch = collator([rollout_group])
+            train_loss = trainer.train_step(train_batch)
+            materialize(train_loss)
+            _clear_backend_cache()
 
-            rewards = []
-            for sample in rollout_group.samples:
-                if sample.reward is None:
-                    raise ValueError("sample.reward must be set before logging")
-                rewards.append(sample.reward)
-            rewards_array = np.array(rewards, dtype=np.float32)
+            train_metrics = rollout_metrics(rollout_group.samples)
             progress_bar.update(trainer.global_step - step_before)
             progress_bar.set_postfix(
-                loss=f"{float(xp.to_scalar(loss.data)):.4f}",
-                reward_mean=f"{float(rewards_array.mean()):.3f}",
-                reward_std=f"{float(rewards_array.std()):.3f}",
+                reward_mean=f"{train_metrics['reward_mean']:.3f}",
+                exact=f"{train_metrics['exact_match_rate']:.3f}",
+                format=f"{train_metrics['format_valid_rate']:.3f}",
+                answers=f"{train_metrics['answer_unique_count']:.0f}",
+                updates=f"{train_metrics['nonzero_advantage_rate']:.3f}",
             )
 
             if trainer.global_step != step_before:
                 should_validate = trainer.global_step % report_every_steps == 0
                 if should_validate or trainer.global_step >= TRAIN_CONFIG.max_steps:
-                    with no_grad():
-                        validation_group = rollout_generator.rollout(
-                            model=trainer.model,
-                            task=task,
-                            tokenizer=bpe,
-                            environment=environment,
-                        )
-                    validation_rewards = []
-                    for sample in validation_group.samples:
-                        if sample.reward is None:
-                            raise ValueError(
-                                "validation sample reward must be set before logging"
-                            )
-                        validation_rewards.append(sample.reward)
-                    validation_rewards_array = np.array(
-                        validation_rewards,
-                        dtype=np.float32,
-                    )
-                    best_sample_idx = int(np.argmax(validation_rewards_array))
-                    best_sample = validation_group.samples[best_sample_idx]
-                    progress_bar.write(
-                        "validation "
-                        f"step={trainer.global_step} "
-                        f"reward_mean={float(validation_rewards_array.mean()):.3f} "
-                        f"reward_max={float(validation_rewards_array.max()):.3f} "
-                        f"completion={best_sample.completion_text!r}"
-                    )
+                    trainer.run_eval_callbacks()
+
+        cp_path_json, cp_path_npz = trainer.save_checkpoint()
+        progress_bar.write(f"Saved final checkpoint: {cp_path_json}, {cp_path_npz}")
 
 
 if __name__ == "__main__":

--- a/test/autograd/tools/test_model.py
+++ b/test/autograd/tools/test_model.py
@@ -10,7 +10,11 @@ from autograd.init import xavier_uniform
 from autograd.nn import Module
 from autograd.optim import CosineScheduler
 from autograd.tensor import Tensor
-from autograd.tools.model import load_checkpoint, save_checkpoint
+from autograd.tools.model import (
+    load_checkpoint,
+    load_checkpoint_metadata,
+    save_checkpoint,
+)
 
 
 class MockModule(Module):
@@ -240,6 +244,50 @@ class TestModel(TestCase):
         loaded = load_checkpoint(json_path=self.json_path, npz_path=self.npz_path)
 
         self.assertIs(loaded["lr_scheduler_cls"], CosineScheduler)
+
+    def test_load_checkpoint_metadata_skips_arrays_and_never_opens_npz(self):
+        save_checkpoint(
+            {
+                "step_count": 4,
+                "model_state_dict": self.model.state_dict(),
+                "model_init_kwargs": {"arg0": 999, "kwarg0": "testing_kwarg0"},
+                "optimizer_init_kwargs": {
+                    "lr": 0.01,
+                    "lr_scheduler_kwargs": {"lr_scheduler_cls": CosineScheduler},
+                },
+            },
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
+        )
+        # Deleting the NPZ proves metadata loading touches only the JSON
+        # sidecar — the whole point of the function.
+        os.remove(self.npz_path)
+
+        metadata = load_checkpoint_metadata(self.json_path)
+
+        self.assertEqual(metadata["step_count"], 4)
+        self.assertEqual(
+            metadata["model_init_kwargs"],
+            {"arg0": 999, "kwarg0": "testing_kwarg0"},
+        )
+        self.assertIs(
+            metadata["optimizer_init_kwargs"]["lr_scheduler_kwargs"][
+                "lr_scheduler_cls"
+            ],
+            CosineScheduler,
+        )
+        self.assertNotIn("model_state_dict", metadata)
+        self.assertNotIn("optimizer_state_dict", metadata)
+
+    def test_load_checkpoint_metadata_rejects_arrays_outside_skip_keys(self):
+        save_checkpoint(
+            {"extra_state": self.model.state_dict(), "step_count": 4},
+            checkpoint_dir=self.checkpoint_dir,
+            checkpoint_name=self.checkpoint_name,
+        )
+
+        with self.assertRaisesRegex(ValueError, "cannot contain array data"):
+            load_checkpoint_metadata(self.json_path)
 
     def test_save_persists_dtype_in_sidecar(self):
         # The JSON sidecar must carry the original dtype for every array

--- a/test/test_grpo.py
+++ b/test/test_grpo.py
@@ -6,10 +6,12 @@ import torch
 
 from autograd.backend import xp
 from autograd.data.collator import Collator
+from autograd.data.sft import SFT_TURN_SEPARATOR
 from autograd.nn import Module
 from autograd.tensor import Tensor
 from autograd.text.tokenizer import BytePairEncoder
 from autograd.tools.config_schema import GenericTrainingConfig
+from examples.gpt_2 import GPT2
 from examples.grpo import (
     GRPOBatch,
     GRPOCollator,
@@ -20,8 +22,8 @@ from examples.grpo import (
     RolloutGroup,
     Sample,
     Task,
-    generation,
     grpo_loss,
+    grpo_loss_from_selected_logits,
 )
 
 
@@ -56,8 +58,10 @@ def test_grpo_training_config_extends_generic_training_config_for_rollouts():
 
 
 def test_grpo_training_config_rejects_sampling_that_breaks_logprob_contract():
-    with pytest.raises(ValueError, match="temperature=1.0 and top_k=None"):
-        _grpo_training_config(temperature=0.8)
+    with pytest.raises(ValueError, match="temperature > 0 and top_k=None"):
+        _grpo_training_config(temperature=0.0)
+    with pytest.raises(ValueError, match="temperature > 0 and top_k=None"):
+        _grpo_training_config(top_k=50)
 
 
 def test_grpo_training_config_requires_max_steps_argument():
@@ -102,31 +106,35 @@ def test_grpo_collator_aligns_generated_tokens_with_shifted_completion_labels():
         ],
     )
 
+    # Dynamic padding: rows are padded to batch_max_tokens = max(prompt+completion)
+    # over the batch (4 here), not to the configured max_tokens (5). After causal
+    # shift this yields shape (2, 3). This is a speed/memory optimization over
+    # fixed-length padding when actual rows are shorter than max_tokens.
     batch = GRPOCollator(max_tokens=5, pad_idx=0)([group])
 
     np.testing.assert_array_equal(
         xp.to_numpy(batch.input_ids),
-        np.array([[10, 11, 20, 21], [10, 11, 30, 0]], dtype=np.int32),
+        np.array([[10, 11, 20], [10, 11, 30]], dtype=np.int32),
     )
     np.testing.assert_array_equal(
         xp.to_numpy(batch.labels),
-        np.array([[11, 20, 21, 0], [11, 30, 0, 0]], dtype=np.int32),
+        np.array([[11, 20, 21], [11, 30, 0]], dtype=np.int32),
     )
     np.testing.assert_array_equal(
         xp.to_numpy(batch.generated_token_mask),
-        np.array([[0, 1, 1, 0], [0, 1, 0, 0]], dtype=np.int32),
+        np.array([[0, 1, 1], [0, 1, 0]], dtype=np.int32),
     )
     np.testing.assert_allclose(
         xp.to_numpy(batch.sampled_token_logprobs),
         np.array(
-            [[0.0, -0.1, -0.2, 0.0], [0.0, -0.3, 0.0, 0.0]],
+            [[0.0, -0.1, -0.2], [0.0, -0.3, 0.0]],
             dtype=np.float32,
         ),
     )
     np.testing.assert_allclose(
         xp.to_numpy(batch.advantages),
         np.array(
-            [[0.0, 0.5, 0.5, 0.0], [0.0, -1.0, 0.0, 0.0]],
+            [[0.0, 0.5, 0.5], [0.0, -1.0, 0.0]],
             dtype=np.float32,
         ),
     )
@@ -196,34 +204,45 @@ def test_grpo_collator_rejects_rows_longer_than_max_tokens():
 
 
 def test_math_environment_parses_answer_tags_for_reward():
+    # Exact-only reward (settled by E24/E33): format-valid completion that
+    # matches the reference answer earns 1.0; everything else earns 0.0. Shaped
+    # per-tag rewards on the previous trainer were dropped because they
+    # rewarded incoherent arithmetic without lifting pass@1.
     environment = MathEnvironment()
     task = Task(task_id="math-1", raw_input="What is 1 + 1?", answer="2")
+    eos = SFT_TURN_SEPARATOR
 
     correct = Sample(
         completion_tokens=xp.array([20], dtype=xp.int32),
-        completion_text="<think>1 + 1 = 2</think><answer>2</answer>",
+        completion_text=f"<think>1 + 1 = 2</think><answer>2</answer>{eos}",
         sampled_token_logprobs=xp.array([-0.1], dtype=xp.float32),
     )
-    wrong = Sample(
+    wrong_answer = Sample(
         completion_tokens=xp.array([21], dtype=xp.int32),
-        completion_text="<answer>3</answer>",
+        completion_text=f"<think>1 + 1 = 3</think><answer>3</answer>{eos}",
         sampled_token_logprobs=xp.array([-0.2], dtype=xp.float32),
     )
-    unformatted = Sample(
+    missing_think = Sample(
         completion_tokens=xp.array([22], dtype=xp.int32),
-        completion_text="2",
+        completion_text=f"<answer>2</answer>{eos}",
         sampled_token_logprobs=xp.array([-0.3], dtype=xp.float32),
     )
-    partial_format = Sample(
+    no_eos = Sample(
         completion_tokens=xp.array([23], dtype=xp.int32),
-        completion_text="<think>1 + 1 = 2</think><answer>3",
+        completion_text="<think>1 + 1 = 2</think><answer>2</answer>",
         sampled_token_logprobs=xp.array([-0.4], dtype=xp.float32),
     )
+    unformatted = Sample(
+        completion_tokens=xp.array([24], dtype=xp.int32),
+        completion_text="2",
+        sampled_token_logprobs=xp.array([-0.5], dtype=xp.float32),
+    )
 
-    assert environment._compute_reward(task, correct) == pytest.approx(1.4)
-    assert environment._compute_reward(task, wrong) == pytest.approx(0.2)
+    assert environment._compute_reward(task, correct) == pytest.approx(1.0)
+    assert environment._compute_reward(task, wrong_answer) == 0.0
+    assert environment._compute_reward(task, missing_think) == 0.0
+    assert environment._compute_reward(task, no_eos) == 0.0
     assert environment._compute_reward(task, unformatted) == 0.0
-    assert environment._compute_reward(task, partial_format) == pytest.approx(0.3)
 
 
 def test_math_environment_normalizes_comma_separated_answers():
@@ -231,11 +250,13 @@ def test_math_environment_normalizes_comma_separated_answers():
     task = Task(task_id="math-1", raw_input="How much profit?", answer="22500")
     sample = Sample(
         completion_tokens=xp.array([20], dtype=xp.int32),
-        completion_text="<think>math</think><answer>22,500</answer>",
+        completion_text=(
+            f"<think>math</think><answer>22,500</answer>{SFT_TURN_SEPARATOR}"
+        ),
         sampled_token_logprobs=xp.array([-0.1], dtype=xp.float32),
     )
 
-    assert environment._compute_reward(task, sample) == pytest.approx(1.4)
+    assert environment._compute_reward(task, sample) == pytest.approx(1.0)
 
 
 def test_extract_gsm8k_final_answer_from_hash_marker():
@@ -256,7 +277,12 @@ def test_gsm8k_row_to_task_uses_question_and_final_answer():
     assert task.task_id == "gsm8k-3"
     assert task.raw_input == "What is 1 + 1?"
     assert task.answer == "2"
-    assert task.metadata == {"source": "openai/gsm8k"}
+    # `reasoning` is the dataset's pre-final-answer text, kept on the Task so
+    # future rationale-target SFT (E37) can read it without re-parsing.
+    assert task.metadata == {
+        "source": "openai/gsm8k",
+        "reasoning": "1 + 1 = <<1+1=2>>2",
+    }
 
 
 def test_score_group_attaches_rewards_without_advantages():
@@ -366,23 +392,26 @@ def test_rollout_generator_batches_generation_forward_passes(monkeypatch):
         np.testing.assert_array_equal(xp.to_numpy(sample.completion_tokens), [1, 1])
 
 
-def test_generation_rejects_prompt_that_fills_context_window():
+def test_rollout_rejects_prompt_that_fills_context_window():
     class FakeModel:
         max_seq_len = 2
+        _is_training = False
 
     class FakeTokenizer:
-        def encode(self, token):
-            return [9]
+        # Rendered prompt encodes to more tokens than max_seq_len, so the
+        # rollout has no room left for completions and must raise.
+        def encode(self, text):
+            return [9, 10, 11]
+
+        def decode(self, tokens):
+            return ""
 
     with pytest.raises(ValueError, match="prompt length"):
-        generation(
-            FakeModel(),
-            xp.array([1, 2], dtype=xp.int32),
-            FakeTokenizer(),
-            num_generations=1,
-            max_generation_tokens=1,
-            temperature=1.0,
-            top_k=None,
+        RolloutGenerator(_grpo_training_config()).rollout(
+            model=cast(Module, FakeModel()),
+            task=Task(task_id="math-1", raw_input="x", answer="0"),
+            tokenizer=cast(BytePairEncoder, FakeTokenizer()),
+            environment=MathEnvironment(),
         )
 
 
@@ -435,6 +464,63 @@ def test_grpo_loss_matches_pytorch_reference():
     )
 
 
+def test_selected_token_forward_matches_full_logits_loss():
+    # The sparse output head must be a pure speedup: projecting only
+    # generated-token rows has to produce the same GRPO loss as the
+    # full-logits path it replaces.
+    model = GPT2(
+        vocab_size=17,
+        hidden_size=8,
+        num_attention_heads=2,
+        max_seq_len=16,
+        dropout_prob=0.0,
+        num_decoder_layers=1,
+    )
+    model.eval()
+
+    group = RolloutGroup(
+        prompt_id="math-1",
+        prompt_tokens=xp.array([3, 4], dtype=xp.int32),
+        samples=[
+            Sample(
+                completion_tokens=xp.array([5, 6], dtype=xp.int32),
+                completion_text="<answer>5</answer>",
+                sampled_token_logprobs=xp.array([-0.1, -0.2], dtype=xp.float32),
+                reward=1.0,
+                advantage=0.5,
+            ),
+            Sample(
+                completion_tokens=xp.array([7], dtype=xp.int32),
+                completion_text="<answer>7</answer>",
+                sampled_token_logprobs=xp.array([-0.3], dtype=xp.float32),
+                reward=0.0,
+                advantage=-1.0,
+            ),
+        ],
+    )
+    batch = GRPOCollator(max_tokens=8, pad_idx=0)([group])
+
+    full_logits = model(batch.input_ids)
+    full_loss = grpo_loss(full_logits, batch)
+
+    selected_logits = model(
+        batch.input_ids,
+        selected_token_indices=batch.generated_token_indices,
+    )
+    sparse_loss = grpo_loss_from_selected_logits(
+        selected_logits,
+        batch,
+        batch.generated_token_indices,
+    )
+
+    np.testing.assert_allclose(
+        xp.to_numpy(sparse_loss.data),
+        xp.to_numpy(full_loss.data),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
 def test_grpo_trainer_train_step_runs_one_optimizer_step():
     class FakeModel:
         def __init__(self):
@@ -465,8 +551,9 @@ def test_grpo_trainer_train_step_runs_one_optimizer_step():
         def _loss_total_weight(self, batch):
             return self.total_weight
 
-        def optimizer_step(self, state, *, record_grad_norm=True):
+        def optimizer_step(self, state, **kwargs):
             self.optimizer_step_called = True
+            self.optimizer_step_kwargs = kwargs
             assert state.accumulated_batches == 1
             np.testing.assert_allclose(
                 xp.to_numpy(state.accumulated_loss_total_weight),


### PR DESCRIPTION
## Summary
Two commits:

1. **`load_checkpoint_metadata`** (`autograd/tools/model.py`) — reads bookkeeping values (step count, `model_init_kwargs`, …) from the JSON sidecar without opening the NPZ. GRPO startup previously ran a full `load_checkpoint` just to read `model_init_kwargs`, then the trainer deserialized the same checkpoint again for the weights. Fails fast if an array hides outside the skipped state-dict keys; tested by deleting the NPZ before loading.
2. **GRPO overhaul** (`examples/grpo.py`, `examples/gpt_2.py`, `test/test_grpo.py`):
   - **Exact-only reward**: 1.0 only for a fully format-valid completion (`<think>/<answer>` closed by the turn separator) whose answer matches exactly; everything else 0.0. Settled by the accuracy experiment log (E24: strict parser is not hiding accuracy; E33: no surface signal separates correct rollouts) — the old shaped per-tag rewards (1.4/0.2/0.3) rewarded incoherent arithmetic without lifting pass@1.
   - **Rollouts use the SFT special-token chat format** (R1-style system prompt, `<|USER|>`/`<|ASSISTANT|>` markers), so GRPO starts from exactly what SFT taught.
   - **Sparse output head**: `GPT2.forward` optionally projects only selected token rows; prompt/pad rows have zero GRPO weight, so their final layernorm + tied vocab projection are wasted. Isolated 64-token train-step probe: 0.472s → 0.378s (~1.25×, `notes/grpo_optimization.md`). A new test proves the selected-row loss matches the full-logits loss on the same batch.
   - **Batch-local padding** in `GRPOCollator` (pad to the longest row, not `max_tokens`), zero-advantage **step skipping** (uniform rewards carry no gradient signal; skipping also avoids Adam momentum drift from a zero gradient), and rollout-based **validation callbacks** (pass@1 / any@k / majority@k on a seen-train slice and a held-out GSM8K slice).

## Evidence honesty
The loop design is what the experiment log converged on, but held-out GSM8K pass@1 stayed ≈0 with the 124M base model in those experiments — pre-GRPO pass@1 (~0.016) is the binding constraint, since GRPO concentrates existing capability rather than creating it. The default config comments this explicitly and points at swapping in an SFT checkpoint.

## Excluded (kernel/experimental bucket)
KV-cache generation paths, `warmup_kv`, fused GRPO loss kernels, and the `gpt_2_llama` example stay on the experimental branch. The fused scale+clip optimizer flag is unnecessary here — it became the default in #88.

## Test plan
- New: sparse-vs-full loss equivalence (nonzero loss, rtol 1e-5), metadata loader round-trip with NPZ deleted, array-outside-skip-keys rejection.
- Ported: exact-only reward cases (wrong answer / missing think / missing EOS / unformatted all 0.0), dynamic-padding collator shapes, config contract (`temperature > 0`, `top_k=None`), rollout context-window rejection.
- Full suite: 571 passed, 11 skipped. Ruff lint + format clean.