### PR TITLE
Review fixes: autograd correctness, optimizer/trainer robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 <img src="https://github.com/user-attachments/assets/0655f743-6bb0-46c8-9cdf-ec3a8c84058a" width="400" height="400">
 
 [![Unit Tests](https://github.com/workofart/ml-by-hand/actions/workflows/test.yml/badge.svg)](https://github.com/workofart/ml-by-hand/actions/workflows/test.yml) |
-📝 [Blog Post](https://www.henrypan.com/blog/2025-02-06-ml-by-hand/)
+📝 [Blog Post 1](https://www.henrypan.com/blog/2025-02-06-ml-by-hand/) |
+📝 [Blog Post 2](https://www.henrypan.com/blog/2026-03-14-how-deep-learning-library-enables-learning/)
 
 </div>
 
@@ -35,18 +36,91 @@ We are creating a deep learning library from scratch (that evolved from a simple
 
 </details>
 
-## **Demo/Examples**
+<table>
+<tr>
+<td width="45%" valign="top">
 
-<center><img src="https://www.henrypan.com/blog/assets/images/ml/ml-by-hand/ml-by-hand.gif" width="700" /></center>
+## Demo
 
+<img src="https://www.henrypan.com/blog/assets/images/ml/ml-by-hand/ml-by-hand.gif" width="480" />
+
+</td>
+<td width="50%" valign="top">
+
+## Try inference with the pre-trained checkpoint
+
+Using the library, we're able to pre-train GPT-2 124M model from scratch on OpenWebText (56k steps * 1024 context length * 480 global batch size = 27 billion tokens, bfloat16) at [GitHub release](https://github.com/workofart/ml-by-hand/releases/tag/gpt2-124m-openwebtext-56000), including its BPE tokenizer vocabulary.
+
+Download the weights (~240 MB) and run inference locally:
+
+```bash
+git clone https://github.com/workofart/ml-by-hand.git
+cd ml-by-hand
+./bootstrap.sh
+source .venv/bin/activate
+
+RELEASE=https://github.com/workofart/ml-by-hand/releases/download/gpt2-124m-openwebtext-56000
+CKPT=gpt2_124m_openwebtext_56000_inference
+VOCAB=openwebtext_vocab_49990.pkl
+curl -L --create-dirs -o "checkpoints/$CKPT.json" "$RELEASE/$CKPT.json"
+curl -L --create-dirs -o "checkpoints/$CKPT.npz" "$RELEASE/$CKPT.npz"
+curl -L --create-dirs -o "training_data/$VOCAB" "$RELEASE/$VOCAB"
+```
+
+Then, from the repo root (after the [Environment Setup](#environment-setup) below):
+
+```python
+from autograd.text.tokenizer import BytePairEncoder
+from autograd.text.utils import generate_text
+from autograd.tools.model import load_checkpoint
+from examples.gpt_2 import GPT2, GPT2ForwardFn
+
+ckpt = load_checkpoint(
+    "checkpoints/gpt2_124m_openwebtext_56000_inference.json",
+    "checkpoints/gpt2_124m_openwebtext_56000_inference.npz",
+)
+model = GPT2(**ckpt["model_init_kwargs"])
+model.load_state_dict(ckpt["model_state_dict"])
+
+bpe = BytePairEncoder(
+    num_merges=49990,
+    vocab_file_path="training_data/openwebtext_vocab_49990.pkl",
+)
+
+generate_text(
+    model=model,
+    prediction_func=GPT2ForwardFn(),
+    bpe=bpe,
+    start_tokens="The meaning of life is",
+    max_length=100,
+    temperature=0.8,
+    top_k=50,
+)
+
+> Inference: 100%|██████████| 95/95 [00:02<00:00, 31.90it/s]
+> [prompt 5 tokens + 95 new tokens in 2.98s, 31.9 tok/s]
+> 'The meaning of life is based on the ability to feel and remember the things that ...'
+```
+
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+## Examples
 
 Explore the [`examples/`](https://github.com/workofart/ml-by-hand/tree/main/examples) directory for real-world demonstrations of how this engine can power neural network training on various tasks:
 
-📌 **Transformers & GPT (Newly added):**
+📌 **LLMs:**
   - Original Transformers [(Code)](https://github.com/workofart/ml-by-hand/blob/main/examples/transformers.py)
   - Byte Pair Encoder (BPE) Tokenizer [(Code)](https://github.com/workofart/ml-by-hand/blob/main/autograd/text/tokenizer.py)
   - GPT-1 [(Code)](https://github.com/workofart/ml-by-hand/blob/main/examples/gpt-1.py)
   - GPT-2 [(Code)](https://github.com/workofart/ml-by-hand/blob/main/examples/gpt_2.py)
+  - (Newly added) Supervised Fine-Tuning (SFT) [(Code)](https://github.com/workofart/ml-by-hand/blob/main/examples/sft_gpt_2.py) — fine-tunes a pretrained GPT-2 on chat-formatted data ([no_robots](https://huggingface.co/datasets/HuggingFaceH4/no_robots))
+  - (Newly added) Group Relative Policy Optimization (GRPO) [(Code)](https://github.com/workofart/ml-by-hand/blob/main/examples/grpo.py) — reinforcement learning on GSM8K math problems (the technique behind DeepSeek-R1)
 
 <details>
   <summary><strong>Click to see all other examples</strong></summary>
@@ -79,8 +153,11 @@ Explore the [`examples/`](https://github.com/workofart/ml-by-hand/tree/main/exam
   - WikiSum [(Code)](https://github.com/workofart/ml-by-hand/blob/main/examples/seq2seq.py)
 </details>
 
+</td>
+<td width="50%" valign="top">
 
-## Toy Example
+## Toy Example of Using the Library
+
 <details>
   <summary><strong>Click to expand</strong></summary>
 
@@ -150,23 +227,36 @@ assert xp.to_scalar(xp.allclose(x.data @ weights + bias, y_true))
 ```
 </details>
 
-## **Documentation**
+</td>
+</tr>
+</table>
 
-Check out the modules in this project in the [docs website](https://ml-by-hand.readthedocs.io/en/latest/) built from the docs/ directory.
+## Environment Setup
 
-## **Environment Setup**
-
-This repo uses `uv.lock` as the source of truth for dependency installation.
-Use the bootstrap script for the intended setup flow:
+This repo uses `uv.lock` as the source of truth for dependency installation:
 ```bash
 ./bootstrap.sh
 source .venv/bin/activate
 ```
 
+## **Documentation**
+
+Check out the modules in this project in the [docs website](https://ml-by-hand.readthedocs.io/en/latest/) built from the docs/ directory.
+
+## Hardware Backends
+
+There are couple of hardware backends that are supported for acceleration, thanks to CuPy and MLX for the seemless NumPy-like primitive API.
+
 Backend selection happens automatically. In user code, import and use `autograd.backend.xp`; the alias is then bound to one of these backends:
 - `mlx` is preferred when available on macOS
-- `cupy` is preferred on Linux when a CUDA device is detected and CuPy is installed
-- otherwise the repo falls back to `numpy`
+- `cupy` is preferred on Linux when a CUDA device is detected
+  - `bootstrap.sh` auto-detects CUDA on Linux and syncs one of the pinned extras: `cuda11`, `cuda12`, or `cuda13`.
+  - Manual installs are also available through `pyproject.toml` extras:
+  ```bash
+  uv sync --extra dev --extra cuda12
+  ```
+  - Pick exactly one CUDA extra that matches your installed CUDA major version.
+- `numpy` is the fallback, which doesn't have any hardware acceleration
 
 You can also force a backend explicitly:
 ```bash
@@ -174,17 +264,6 @@ AUTOGRAD_BACKEND=numpy uv run pytest
 AUTOGRAD_BACKEND=mlx uv run pytest
 AUTOGRAD_BACKEND=cupy uv run pytest
 ```
-
-## CuPy Setup
-
-CuPy is optional and only used when a CUDA device is detected.
-
-- `bootstrap.sh` auto-detects CUDA on Linux and syncs one of the pinned extras: `cuda11`, `cuda12`, or `cuda13`.
-- Manual installs are also available through `pyproject.toml` extras:
-```bash
-uv sync --extra dev --extra cuda12
-```
-- Pick exactly one CUDA extra that matches your installed CUDA major version.
 
 ## Tests
 Comprehensive unit tests and integration tests available in `test/autograd`

--- a/autograd/distributed/__init__.py
+++ b/autograd/distributed/__init__.py
@@ -351,6 +351,19 @@ def allreduce_grads(parameters: Mapping[str, Tensor]) -> None:
             param.grad.data = summed / n_ranks
 
 
+def allreduce_sum(value: Any) -> Any:
+    """AllReduce-SUM a single array across ranks.
+
+    Used by the trainer to compute the global token count so gradient
+    normalization divides by the total tokens across all ranks rather than
+    each rank's local count. Returns the input unchanged when
+    `world_size == 1`.
+    """
+    if not is_distributed():
+        return value
+    return get_backend().all_reduce(value, op=ReduceOp.SUM)
+
+
 def _broadcast_array(
     arr: Any,
     *,

--- a/autograd/init.py
+++ b/autograd/init.py
@@ -58,11 +58,13 @@ def compute_in_out_tensor_count(tensor: Tensor) -> tuple[int, int]:
     The counts are computed as follows:
     $$
     \begin{align}
-    \text{\# of input tensor count} &= \text{tensor.shape}[0] \times \prod_{i=2}^{n} \text{tensor.shape}[i] \\
-    \text{\# of output tensor count} &= \text{tensor.shape}[-1] \times \prod_{i=2}^{n} \text{tensor.shape}[i]
+    \text{\# of input tensor count} &= \text{tensor.shape}[1] \times \prod_{i=2}^{n} \text{tensor.shape}[i] \\
+    \text{\# of output tensor count} &= \text{tensor.shape}[0] \times \prod_{i=2}^{n} \text{tensor.shape}[i]
     \end{align}
     $$
-    where \( n \) is the number of dimensions in the tensor.
+    where \( n \) is the number of dimensions in the tensor. For 2D weights
+    (fully-connected layers) the convention is (input_size, output_size), so the
+    counts are simply (tensor.shape[0], tensor.shape[1]).
 
     Args:
         tensor (Tensor): The tensor for which to compute the number of input and output tensor counts.
@@ -85,19 +87,26 @@ def compute_in_out_tensor_count(tensor: Tensor) -> tuple[int, int]:
         >>> # (output_channels, input_channels, kernel_height, kernel_width)
         >>> tensor_conv = Tensor(xp.empty((16, 3, 3, 3)))
         >>> # The receptive field size is 3*3 = 9
-        >>> # So, input tensor count = 16 * 9 = 144, output tensor count = 3 * 9 = 27
+        >>> # So, input tensor count = 3 * 9 = 27, output tensor count = 16 * 9 = 144
         >>> compute_in_out_tensor_count(tensor_conv.data)
-        (144, 27)
+        (27, 144)
     """
     tensor_shape = tensor.shape
     if len(tensor_shape) < 2:
         raise ValueError("Tensor must have at least 2 dimensions")
 
-    receptive_field_size = 1
-    if len(tensor_shape) > 2:
-        for s in tensor_shape[2:]:
-            receptive_field_size *= s
+    # fan_in/fan_out = number of connections feeding into / out of one unit;
+    # Xavier scales the init by these to keep activation variance stable.
+    if len(tensor_shape) == 2:
+        # Fully-connected weights: (input_size, output_size)
+        return tensor_shape[0], tensor_shape[1]
 
-    input_tensor_count = tensor_shape[0] * receptive_field_size
-    output_tensor_count = tensor_shape[-1] * receptive_field_size
+    # Convolution kernels: (out_channels, in_channels, *kernel_dims) — each
+    # output unit sees in_channels * receptive_field inputs.
+    receptive_field_size = 1
+    for s in tensor_shape[2:]:
+        receptive_field_size *= s
+
+    input_tensor_count = tensor_shape[1] * receptive_field_size
+    output_tensor_count = tensor_shape[0] * receptive_field_size
     return input_tensor_count, output_tensor_count

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -148,19 +148,21 @@ class Module:
 
     def __getattr__(self, name: str) -> Any:
         """
-        Retrieve a submodule or state by name.
+        Retrieve a submodule, parameter, or state by name.
 
         Args:
             name (str): The name of the attribute to retrieve.
 
         Returns:
-            Any: The submodule or state corresponding to the name.
+            Any: The submodule, parameter, or state corresponding to the name.
 
         Raises:
             AttributeError: If the attribute is not found.
         """
         if name in self._modules:
             return self._modules[name]
+        if name in self._parameters:
+            return self._parameters[name]
         if name in self._states:
             return self._states[name]
         raise AttributeError(

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -1574,8 +1574,8 @@ class ScaledDotProductAttention(Module):
                 are also accepted and routed through the implementation-specific
                 gating logic before falling back to dense when unsupported.
                 Defaults to None.
-            is_causal (bool, optional): Whether to apply structural causal masking
-                when no explicit mask is supplied. Defaults to False.
+            is_causal (bool, optional): Whether to apply causal masking. Combined
+                additively with `mask` when both are given. Defaults to False.
 
         Returns:
             Tensor: The attended output.
@@ -1622,16 +1622,28 @@ class ScaledDotProductAttention(Module):
         # (batch_size, num_heads, sequence_len, sequence_len)
         att_score = (query @ key.transpose(2, 3)) * attention_scale
 
-        # Non-MLX Causal Mask
-        if mask is None and is_causal:
+        # Non-MLX Causal Mask. Applied unconditionally when is_causal so an
+        # explicit (e.g. padding) mask never disables causality. (PyTorch
+        # differs: F.scaled_dot_product_attention forbids passing both.)
+        # Both masks are additive, which makes combining well-behaved:
+        # - mask already causal + is_causal: forbidden scores get -2e9
+        #   instead of -1e9; softmax output is unchanged in fp32/bf16.
+        # - fully-masked row (padding + causal forbid every position):
+        #   softmax over a constant row gives uniform weights, not NaN.
+        # - seq_q != seq_k: triu aligns query i with key i (top-left, same
+        #   as PyTorch). That is wrong for KV-cache decoding, where query i
+        #   should align with key seq_k - seq_q + i — callers in this repo
+        #   always pass full sequences.
+        if is_causal:
             seq_q = int(query.shape[-2])
             seq_k = int(key.shape[-2])
-            mask = Tensor(
+            causal_mask = Tensor(
                 xp.triu(
                     xp.ones((seq_q, seq_k), dtype=att_score.data.dtype), k=1
                 ).reshape(1, 1, seq_q, seq_k),
                 requires_grad=False,
             )
+            att_score = att_score + (causal_mask * -1e9)
 
         # mask (optional)
         if mask is not None:
@@ -1701,8 +1713,8 @@ class MultiHeadAttention(Module):
             key (Tensor): Key tensor.
             value (Tensor): Value tensor.
             mask (Optional[Tensor], optional): Mask tensor. Defaults to None.
-            is_causal (bool, optional): Whether to apply structural causal masking
-                when no explicit mask is supplied. Defaults to False.
+            is_causal (bool, optional): Whether to apply causal masking. Combined
+                additively with `mask` when both are given. Defaults to False.
 
         Returns:
             Tensor: Output tensor after multi-head attention.

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -58,11 +58,13 @@ class Module:
         >>> output = module(input_tensor) # Expected output: [2, 4, 6]
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self) -> None:
         """
         Initialize the Module.
 
         This constructor initializes empty dictionaries for parameters, submodules, and states.
+        It takes no arguments on purpose: silently accepting stray constructor
+        arguments would let a typo'd or unsupported config key go unnoticed.
         """
         self._parameters: Dict[str, Tensor] = {}
         self._modules: Dict[str, "Module"] = {}
@@ -578,16 +580,15 @@ class Linear(Module):
         >>> y = linear(x) # Expected shape: (3, 2)
     """
 
-    def __init__(self, input_size: int, output_size: int, **kwargs: Any) -> None:
+    def __init__(self, input_size: int, output_size: int) -> None:
         """
         Initialize the Linear layer.
 
         Args:
             input_size (int): The size of the input features.
             output_size (int): The size of the output features.
-            **kwargs: Additional keyword arguments.
         """
-        super().__init__(input_size, output_size, **kwargs)
+        super().__init__()
 
         # weight is a matrix of shape (input_size, output_size)
         self._parameters["weight"] = xavier_uniform(
@@ -649,7 +650,6 @@ class Conv2d(Module):
         stride: int = 1,
         padding_mode: str = "valid",
         bias: bool = True,
-        **kwargs: Any,
     ) -> None:
         """
         Initialize the Conv2d layer.
@@ -663,17 +663,8 @@ class Conv2d(Module):
             stride (int, optional): Stride of the convolution. Defaults to 1.
             padding_mode (str, optional): Padding mode ("valid" or "same"). Defaults to "valid".
             bias (bool, optional): Whether to include a bias term. Defaults to True.
-            **kwargs: Additional keyword arguments.
         """
-        super().__init__(
-            in_channels,
-            out_channels,
-            kernel_size,
-            stride=stride,
-            padding_mode=padding_mode,
-            bias=bias,
-            **kwargs,
-        )
+        super().__init__()
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.kernel_size = kernel_size
@@ -792,7 +783,6 @@ class MaxPool2d(Module):
         kernel_size: int,
         stride: Optional[int] = None,
         padding_mode: str = "valid",
-        **kwargs: Any,
     ) -> None:
         """
         Initialize the MaxPool2d layer.
@@ -801,9 +791,8 @@ class MaxPool2d(Module):
             kernel_size (int): Size of the pooling window.
             stride (Optional[int], optional): Stride of the pooling operation. Defaults to kernel_size.
             padding_mode (str, optional): Padding mode ("valid" or "same"). Defaults to "valid".
-            **kwargs: Additional keyword arguments.
         """
-        super().__init__(kernel_size, **kwargs)
+        super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride if stride is not None else kernel_size
         self.padding_mode = padding_mode
@@ -874,7 +863,7 @@ class ResidualBlock(Module):
             out_channels (int): Number of output channels.
             stride (int, optional): Stride for the convolution. Defaults to 1.
         """
-        super().__init__(in_channels, out_channels, stride=stride)
+        super().__init__()
         self.conv1 = Conv2d(
             in_channels, out_channels, kernel_size=3, stride=stride, padding_mode="same"
         )
@@ -953,12 +942,7 @@ class RecurrentBlock(Module):
         W_hh: transforms the hidden state into the next hidden state
         W_hy: transforms the hidden state into the output
         """
-        super().__init__(
-            input_size,
-            hidden_size,
-            output_size=output_size,
-            dropout_prob=dropout_prob,
-        )
+        super().__init__()
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.output_size = output_size
@@ -1086,9 +1070,7 @@ class LongShortTermMemoryBlock(Module):
         W_o/bias_o: weights for the output gate
         W_hy/bias_y: weights for the final output (if output_size is specified)
         """
-        super().__init__(
-            input_size, hidden_size, output_size=output_size, dropout_prob=dropout_prob
-        )
+        super().__init__()
         self.input_size = input_size
         self.hidden_size = hidden_size
         # Apply dropout only to non-recurrent connections
@@ -1303,16 +1285,15 @@ class LayerNorm(Module):
         >>> y = ln(x) # Expected: (4, 10)
     """
 
-    def __init__(self, input_size: int, epsilon: float = 1e-5, **kwargs: Any) -> None:
+    def __init__(self, input_size: int, epsilon: float = 1e-5) -> None:
         """
         Initialize the LayerNorm layer.
 
         Args:
             input_size (int): The number of features in the input.
             epsilon (float, optional): Small constant for numerical stability. Defaults to 1e-5.
-            **kwargs: Additional keyword arguments.
         """
-        super().__init__(**kwargs)
+        super().__init__()
         self.epsilon = epsilon
         self._parameters["gain"] = Tensor(xp.ones((input_size,), dtype=xp.float32))
         self._parameters["bias"] = Tensor(xp.zeros((input_size,), dtype=xp.float32))
@@ -1382,7 +1363,6 @@ class BatchNorm(Module):
         input_size: int,
         momentum: float = 0.1,
         epsilon: float = 1e-5,
-        **kwargs: Any,
     ) -> None:
         """
         Initialize the BatchNorm layer.
@@ -1391,9 +1371,8 @@ class BatchNorm(Module):
             input_size (int): The number of features in the input.
             momentum (float, optional): Momentum factor for running statistics. Defaults to 0.1.
             epsilon (float, optional): Small constant for numerical stability. Defaults to 1e-5.
-            **kwargs: Additional keyword arguments.
         """
-        super().__init__(input_size, momentum=momentum, epsilon=epsilon, **kwargs)
+        super().__init__()
 
         self.momentum = momentum  # used in running mean and variance calculation
         self.epsilon = epsilon  # small constant for numeric stability
@@ -1485,15 +1464,14 @@ class Dropout(Module):
         >>> y = dropout(x) # Approximately half of the elements should be 0
     """
 
-    def __init__(self, p: float = 0.5, **kwargs: Any) -> None:
+    def __init__(self, p: float = 0.5) -> None:
         """
         Initialize the Dropout layer.
 
         Args:
             p (float, optional): Fraction of the input units to drop. Defaults to 0.5.
-            **kwargs: Additional keyword arguments.
         """
-        super().__init__(p=p, **kwargs)
+        super().__init__()
         self.p = p
 
     def forward(self, x: Tensor) -> Tensor:

--- a/autograd/nn.py
+++ b/autograd/nn.py
@@ -77,9 +77,11 @@ class Module:
             >>> # Assuming module has trainable parameters with gradients.
             >>> module.zero_grad()
         """
-        # Zero gradients for parameters in current module
+        # Clear gradients for parameters in current module. Assigning None
+        # (like Optimizer.zero_grad) frees the old grad; the next backward
+        # pass starts a fresh accumulation.
         for p in self._parameters.values():
-            p.grad = 0
+            p.grad = None
 
         # Recursively zero gradients in submodules
         for module in self._modules.values():

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -505,6 +505,24 @@ class Adam(Optimizer):
             if param.data.dtype in LOW_PRECISION_FLOAT_DTYPES:
                 self._states["master"][name] = param.data.astype(xp.float32)
 
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        """Load Adam state, restoring the invariants __init__ establishes.
+
+        The base loader rebuilds `_states` as plain dicts, but Adam relies on:
+        - m/v defaulting to 0.0 for params absent from the checkpoint
+          (otherwise step() raises KeyError for them), and
+        - an fp32 master copy existing for every low-precision param
+          (otherwise older checkpoints without a 'master' group silently
+          drop mixed-precision masters).
+        """
+        super().load_state_dict(state_dict)
+        self._states["m"] = defaultdict(float, self._states["m"])
+        self._states["v"] = defaultdict(float, self._states["v"])
+        master = self._states.setdefault("master", {})
+        for name, param in self.model_parameters.items():
+            if param.data.dtype in LOW_PRECISION_FLOAT_DTYPES and name not in master:
+                master[name] = param.data.astype(xp.float32)
+
     def step(self) -> None:
         """
         Perform a single optimization step using the Adam algorithm.

--- a/autograd/optim.py
+++ b/autograd/optim.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Any, Dict, Optional
 
 from autograd.backend import LOW_PRECISION_FLOAT_DTYPES, Array, materialize, xp
-from autograd.distributed import allreduce_grads, broadcast_parameters
+from autograd.distributed import broadcast_parameters
 from autograd.tensor import Tensor
 
 logger = logging.getLogger(__name__)
@@ -421,8 +421,13 @@ class SGD(Optimizer):
 
         This method updates each parameter by subtracting the product of the learning rate
         and the parameter's gradient.
+
+        Contract: step() is purely local — it consumes whatever is in each
+        param.grad and never communicates across ranks. Under DDP, the
+        caller must synchronize gradients first: call `allreduce_grads`
+        after backward (the trainer does this in optimizer_step, before
+        scaling/clipping).
         """
-        allreduce_grads(self.model_parameters)
         self.timestep += 1
         self.update_lr()
 
@@ -507,12 +512,14 @@ class Adam(Optimizer):
         This method updates the biased first and second order momentum estimates,
         applies bias correction, performs a decoupled weight decay step if specified,
         and updates the parameters accordingly.
+
+        Contract: step() is purely local — it consumes whatever is in each
+        param.grad and never communicates across ranks. Under DDP, the
+        caller must synchronize gradients first: call `allreduce_grads`
+        after backward (the trainer does this in optimizer_step, before
+        scaling/clipping), so the optimizer state (m, v) is computed
+        against the true global mean gradient.
         """
-        # Average gradients across DDP ranks before Adam consumes them, so
-        # the optimizer state (m, v) is computed against the true global
-        # mean gradient — equivalent to a single forward+backward over the
-        # concatenated global batch. No-op when world_size == 1.
-        allreduce_grads(self.model_parameters)
         self.timestep += 1
         self.update_lr()
 

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -2690,6 +2690,8 @@ class Stack(Function):
         grads = []
         for i, tensor in enumerate(self.tensors):
             if not tensor.requires_grad:
+                # Placeholder keeps grads aligned with self.tensors in backward()
+                grads.append(None)
                 continue
 
             # Create slice indices

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -1820,8 +1820,12 @@ class Sum(Function):
         Returns:
             xp.ndarray: The sum of the tensor elements.
         """
-        # Handle scalar case
+        # Handle scalar case: sum is the identity, but backward still needs
+        # the axis/shape state set so it can broadcast the gradient back.
         if not hasattr(x, "ndim") or x.ndim == 0:
+            self.axis = None
+            self.keepdims = keepdims
+            self.x_shape = getattr(x, "shape", ())
             return x
         # Normalize axis
         self.axis = (axis,) if isinstance(axis, int) else axis

--- a/autograd/tensor.py
+++ b/autograd/tensor.py
@@ -274,44 +274,26 @@ class Tensor:
             >>> x = Tensor([1, 2, 3])
             >>> print(x.grad)  # Expected: None
         """
-        if self._grad is not None and not isinstance(self._grad, Tensor):
-            return Tensor(self._grad, requires_grad=False)
         return self._grad
 
     @grad.setter
     def grad(self, value: Union["Tensor", ArrayLike, None]) -> None:
         """
-        Set or accumulate gradient for this tensor.
+        Set the gradient for this tensor, replacing any existing gradient.
 
-        If the tensor does not have a gradient yet, we initialize it with the provided value.
-        Otherwise, the provided value is added in place to the existing gradient.
+        Gradient ACCUMULATION during backprop goes through _accumulate_grad;
+        plain assignment here always overwrites (so `p.grad = None` clears
+        and `p.grad = g` sets exactly g).
 
         Args:
             value (Union[Tensor, ArrayLike, None]): The gradient value or None.
         """
         if value is None:
             self._grad = None
-            return
-
-        # Convert to numpy array directly if it's a Tensor
-        if isinstance(value, Tensor):
-            value_data = value.data
+        elif isinstance(value, Tensor):
+            self._grad = Tensor(value.data, requires_grad=False)
         else:
-            value_data = xp.array(value)
-
-        # Set or accumulate gradient using numpy operations
-        if self._grad is None:
-            self._grad = Tensor(value_data, requires_grad=False)
-        else:
-            value_data = xp.broadcast_to(value_data, value_data.shape)
-            value_data = xp.array(value_data, dtype=value_data.dtype)
-            # IMPORTANT: this is not the same as self.data + value_data
-            # We need to do in-place addition here to preserve any views or references
-            # to the original gradient. For example, multiple operations
-            # (e.g. __mul__, __add__) might update the same gradient tensor,
-            # and we need to ensure that all updates are correctly reflected in
-            # the same underlying array.
-            self._grad.data += value_data
+            self._grad = Tensor(xp.array(value), requires_grad=False)
 
     def view(self, *shape: Union[int, Tuple[int, ...]]) -> "Tensor":
         """
@@ -778,7 +760,9 @@ class Tensor:
         if grad is None:
             grad = Tensor(xp.ones_like(self.data))
 
-        self.grad = grad  # store as np array directly
+        # Seed the traversal: overwrite (not accumulate) so repeated
+        # backward() calls don't compound stale gradients on the output.
+        self.grad = grad
 
         # Build computational graph in reverse order
         topological_sorted_tensors: list[Tensor] = []

--- a/autograd/text/tokenizer.py
+++ b/autograd/text/tokenizer.py
@@ -1,3 +1,4 @@
+import hashlib
 import heapq
 import logging
 import os
@@ -62,7 +63,7 @@ class BytePairEncoder:
         Args:
             num_merges (int): Number of BPE merges to learn during training.
             vocab_file_path (str): Path to store or load the pickled vocabulary.
-            encoded_data_path (str): Path to store or load the encoded data. The extension is replaced with ``.bin`` (the stored file is a raw little-endian int32 stream); see :meth:`load_encoded`.
+            encoded_data_path (str): Path to store or load the encoded data. The extension is replaced with ``.<vocab_fingerprint>.bin`` (the stored file is a raw little-endian int32 stream); see :attr:`mmap_path` and :meth:`load_encoded`.
             n_workers (Optional[int]): Number of processes for parallel operations. If None,
                 defaults to the number of CPU cores minus one.
             min_word_freq (int): Minimum frequency for a word form to be included in
@@ -78,9 +79,7 @@ class BytePairEncoder:
         self.min_word_freq = min_word_freq
         self.vocab_file_path = vocab_file_path
         self.encoded_data_path = encoded_data_path
-        # We store the encoded corpus as a raw little-endian int32 stream.
-        # No header — the count is recovered at load time from the file size.
-        self.mmap_path = os.path.splitext(encoded_data_path)[0] + ".bin"
+        self._mmap_base = os.path.splitext(encoded_data_path)[0]
         base, ext = os.path.splitext(vocab_file_path)
         self.word_freq_cache_path = base + ".word_freq" + ext
 
@@ -116,6 +115,18 @@ class BytePairEncoder:
         self._merge_priority_cache: Optional[Dict[Tuple[int, int], Tuple[int, int]]] = (
             None
         )
+
+    @property
+    def mmap_path(self) -> str:
+        """str: Encoded-data cache path, keyed by the vocabulary fingerprint.
+
+        A different vocabulary yields a different path, so a stale cache can
+        never be silently reused (which would mix token ID spaces) — it is
+        simply re-encoded. The file is a raw little-endian int32 stream with
+        no header; the token count is recovered from the file size at load
+        time (see :meth:`load_encoded`).
+        """
+        return f"{self._mmap_base}.{self._vocab_fingerprint()[:16]}.bin"
 
     @property
     def n_vocab(self) -> int:
@@ -362,6 +373,22 @@ class BytePairEncoder:
                 "to retrain from scratch."
             ) from e
 
+        # Every special token must exist in the loaded vocab; otherwise
+        # _pretokenize splits it out as a special chunk and encode() dies
+        # with a cryptic KeyError much later. Fail fast with the cause.
+        missing = [
+            tok
+            for tok in self.SPECIAL_TOKENS
+            if tok.encode("utf-8") not in self._unicode_to_int_vocab
+        ]
+        if missing:
+            raise RuntimeError(
+                f"Vocabulary at {self.vocab_file_path} is missing special tokens "
+                f"{missing} — it was likely trained with an older SPECIAL_TOKENS "
+                "list. Retrain the vocabulary (overwrite_vocabulary_file=True) or "
+                "use a matching tokenizer version."
+            )
+
     def _construct_unicode_to_int_vocab(self) -> Dict[bytes, int]:
         """Constructs a base vocabulary for all single-byte values plus special tokens.
 
@@ -408,18 +435,22 @@ class BytePairEncoder:
         if text_batch_size < 1:
             raise ValueError(f"text_batch_size must be >= 1, got {text_batch_size}")
 
-        if os.path.exists(self.mmap_path) and not overwrite_encoded_data:
+        # mmap_path embeds the vocabulary fingerprint, so the file existing
+        # is proof it was encoded with the currently loaded vocabulary —
+        # no further validation is needed before reusing it.
+        mmap_path = self.mmap_path
+        if os.path.exists(mmap_path) and not overwrite_encoded_data:
             logger.info(
-                f"Found existing memory-mapped encoded data at '{self.mmap_path}', "
+                f"Found existing memory-mapped encoded data at '{mmap_path}', "
                 "reusing it instead of re-encoding."
             )
-            return self.mmap_path
-        parent_dir = os.path.dirname(self.mmap_path)
+            return mmap_path
+        parent_dir = os.path.dirname(mmap_path)
         if parent_dir:
             os.makedirs(parent_dir, exist_ok=True)
 
         int32_dtype = np.dtype("<i4")
-        tmp_path = f"{self.mmap_path}.tmp"
+        tmp_path = f"{mmap_path}.tmp"
 
         try:
             if os.path.exists(tmp_path):
@@ -462,12 +493,20 @@ class BytePairEncoder:
                         )
                         flat_batch.tofile(out_file)
 
-            os.replace(tmp_path, self.mmap_path)
+            os.replace(tmp_path, mmap_path)
         finally:
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
 
-        return self.mmap_path
+        return mmap_path
+
+    def _vocab_fingerprint(self) -> str:
+        """Deterministic digest of the current vocabulary and merges."""
+        payload = pickle.dumps(
+            (sorted(self._unicode_to_int_vocab.items()), self.learned_merges),
+            protocol=4,
+        )
+        return hashlib.sha256(payload).hexdigest()
 
     @staticmethod
     def load_encoded(path: str) -> np.ndarray:

--- a/autograd/text/utils.py
+++ b/autograd/text/utils.py
@@ -272,13 +272,13 @@ def generate_text(
     top_k: Optional[int] = None,
     stop_token: str = "<|endoftext|>",
 ) -> str:
-    """Generate and print text from a string prompt.
+    """Generate text from a string prompt.
 
     This is a convenience wrapper around `generate`: it handles tokenizer
-    encode/decode, switches the model to eval mode for generation, restores the
-    prior training mode, and streams decoded completion tokens to stdout. After
-    generation it prints a one-line wall-time / tok/s summary so the user has a
-    stable throughput number that does not depend on tqdm's per-iter overhead.
+    encode/decode, switches the model to eval mode for generation, and restores
+    the prior training mode. It shows a token-level progress bar and a one-line
+    wall-time / tok/s summary; the generated text itself is only returned, so
+    callers decide how to display it (e.g. `print(generate_text(...))`).
 
     Args:
         model: Language model used for generation.
@@ -300,9 +300,6 @@ def generate_text(
         start_tokens = start_tokens or "<SOS>"
         output_ids = list(bpe.encode(start_tokens))
         prompt_len = len(output_ids)
-        print("Prompt:")
-        print(bpe.decode(output_ids))
-        print("\nGenerated:")
         t0 = time.perf_counter()
         result = generate(
             model=model,
@@ -319,18 +316,14 @@ def generate_text(
         )[0]
         elapsed = time.perf_counter() - t0
         output_ids.extend(result.completion_tokens)
-        for next_token in result.completion_tokens:
-            print(bpe.decode([next_token]), end="", flush=True)
+        text = bpe.decode(output_ids)
         n_generated = len(result.completion_tokens)
-        total_tokens = prompt_len + n_generated
         tok_per_sec = (n_generated / elapsed) if elapsed > 0 else float("nan")
         print(
-            "\n--------------------------------------------------------------"
-            f"\nPrompt {prompt_len} tokens, generated {n_generated} new tokens, "
-            f"total {total_tokens}/{max_length} tokens in {elapsed:.2f}s "
-            f"({tok_per_sec:.1f} tok/s)\n"
+            f"[prompt {prompt_len} tokens + {n_generated} new tokens "
+            f"in {elapsed:.2f}s, {tok_per_sec:.1f} tok/s]\n"
         )
-        return bpe.decode(output_ids)
+        return text
     finally:
         if was_training:
             model.train()

--- a/autograd/tools/config_schema.py
+++ b/autograd/tools/config_schema.py
@@ -91,6 +91,19 @@ class GenericTrainingConfig:
             )
         if self.checkpoint_freq <= 0:
             raise ValueError(f"checkpoint_freq must be > 0, got {self.checkpoint_freq}")
+        if (
+            self.max_steps is not None
+            and self.report_every_steps is not None
+            and self.checkpoint_freq % self.report_every_steps != 0
+        ):
+            # Checkpoints are only written on reporting steps, so a
+            # misaligned checkpoint_freq would silently degrade to
+            # lcm(report_every_steps, checkpoint_freq).
+            raise ValueError(
+                f"checkpoint_freq ({self.checkpoint_freq}) must be a multiple of "
+                f"report_every_steps ({self.report_every_steps}); checkpoints are "
+                "only written on reporting steps."
+            )
         if self.global_batch_size < 1:
             raise ValueError(
                 f"global_batch_size must be >= 1, got {self.global_batch_size}"

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -27,11 +27,14 @@ from autograd.backend import (
 from autograd.data.data_loader import DataLoader
 from autograd.distributed import (
     ReduceOp,
+    allreduce_grads,
+    allreduce_sum,
     broadcast_optimizer_state,
     broadcast_parameters,
     get_backend,
     is_distributed,
     rank,
+    world_size,
 )
 from autograd.tensor import Tensor, no_grad
 from autograd.tools.config_schema import (
@@ -571,8 +574,17 @@ class AbstractTrainer(ABC):
             state.accumulated_loss_total_weight,
         )
 
-        grad_scale = 1.0 / xp.maximum(
-            state.accumulated_loss_total_weight,
+        # Synchronize across DDP ranks BEFORE scaling/clipping so the token
+        # normalization and the clip both operate on the global gradient.
+        # allreduce_grads averages the per-rank gradient sums, so multiply by
+        # world_size to recover the global sum before dividing by the global
+        # token count: world_size * mean(grad_sums) / sum(token_counts)
+        # == sum(grad_sums) / sum(token_counts). Both collectives no-op when
+        # world_size == 1.
+        allreduce_grads(self.optimizer.model_parameters)
+        global_loss_total_weight = allreduce_sum(state.accumulated_loss_total_weight)
+        grad_scale = float(world_size()) / xp.maximum(
+            global_loss_total_weight,
             xp.array(1.0, dtype=xp.float32),
         )
         grad_l2_norm = None
@@ -628,8 +640,9 @@ class AbstractTrainer(ABC):
         if self.last_grad_l2_norm is not None:
             row["grad_l2_norm"] = self.last_grad_l2_norm
 
-        # File writes are rank-0-only under DDP (after AllReduce in step(),
-        # every rank holds identical params, so rank 0 is authoritative).
+        # File writes are rank-0-only under DDP (after the AllReduce in
+        # optimizer_step, every rank holds identical params, so rank 0 is
+        # authoritative).
         # Logging auto-quiets on non-rank-0 via the logger level set in __init__.
         if rank() == 0:
             if plan.should_checkpoint(self.global_step):

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -640,6 +640,10 @@ class AbstractTrainer(ABC):
         if self.last_grad_l2_norm is not None:
             row["grad_l2_norm"] = self.last_grad_l2_norm
 
+        # Append before saving so the row being reported (including the final
+        # one of the run) is part of the persisted metrics.
+        self.metric_rows.append(row)
+
         # File writes are rank-0-only under DDP (after the AllReduce in
         # optimizer_step, every rank holds identical params, so rank 0 is
         # authoritative).
@@ -649,8 +653,6 @@ class AbstractTrainer(ABC):
                 self._maybe_save_checkpoint(plan=plan, val_loss=metrics["val_loss"])
             if plan.should_save_metrics(self.global_step):
                 self._save_metrics()
-
-        self.metric_rows.append(row)
         log_payload = _format_log_values(
             {**row, "step": self.global_step, "lr": self.optimizer.lr},
             precision_overrides={"lr": 6},

--- a/autograd/tools/trainer.py
+++ b/autograd/tools/trainer.py
@@ -391,7 +391,7 @@ class AbstractTrainer(ABC):
         optimizer_cls: type[optim.Optimizer],
         loss_fn: Callable,
         config: GenericTrainingConfig,
-        **kwargs,
+        checkpoint_path: Optional[str] = None,
     ):
         """Initializes the trainer with model, optimizer, and config.
 
@@ -400,7 +400,8 @@ class AbstractTrainer(ABC):
             optimizer_cls (type[optim.Optimizer]): Class of the optimizer to instantiate.
             loss_fn (Callable): A function or callable that computes the loss.
             config (GenericTrainingConfig): Training configuration object.
-            **kwargs: Additional arguments for specialized trainers (e.g., checkpoint paths).
+            checkpoint_path (Optional[str]): Checkpoint basename (without
+                .json/.npz) to resume training from.
         """
         self.config = config
         self.loss_fn = loss_fn
@@ -426,7 +427,7 @@ class AbstractTrainer(ABC):
             optimizer_kwargs=config.optimizer_kwargs,
             resume_epoch=config.resume_epoch,
             pretrained_checkpoint_path=config.pretrained_checkpoint_path,
-            checkpoint_path=kwargs.get("checkpoint_path"),
+            checkpoint_path=checkpoint_path,
         )
         # `global_step` counts optimizer updates. Epoch-mode configs are converted
         # to optimizer-step targets before entering the training loop.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ docutils==0.22.4
     # via
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.11
+idna==3.18
     # via requests
 imagesize==2.0.0
     # via sphinx

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -48,9 +48,8 @@ class GPT1(nn.Module):
         max_seq_len,
         dropout_prob,
         num_decoder_layers,
-        **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__()
         self.hidden_size = hidden_size
         self.max_seq_len = max_seq_len
         self.token_embedding = nn.Embedding(vocab_size, hidden_size)
@@ -102,9 +101,8 @@ class DecoderSublayer(nn.Module):
         ff_hidden_size=2048,
         dropout_prob=0.1,
         num_attention_heads=2,
-        **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__()
         self.multi_head_attention = nn.MultiHeadAttention(
             hidden_size=hidden_size, num_heads=num_attention_heads
         )

--- a/examples/gpt-1.py
+++ b/examples/gpt-1.py
@@ -258,12 +258,14 @@ if __name__ == "__main__":
             max_length=trainer.model.max_seq_len // 3,
         )
 
-    generate_text(
-        model=trainer.model,
-        prediction_func=GPT1ForwardFn(),
-        bpe=bpe,
-        start_tokens=CONFIG.eval_start_string,
-        max_length=int(trainer.model.max_seq_len * 0.9),
-        temperature=0.8,
-        top_k=CONFIG.eval_top_k,
+    print(
+        generate_text(
+            model=trainer.model,
+            prediction_func=GPT1ForwardFn(),
+            bpe=bpe,
+            start_tokens=CONFIG.eval_start_string,
+            max_length=int(trainer.model.max_seq_len * 0.9),
+            temperature=0.8,
+            top_k=CONFIG.eval_top_k,
+        )
     )

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -455,14 +455,16 @@ if __name__ == "__main__":
         _val_data_loader,
         config: TransformerTrainingConfig,
     ) -> None:
-        generate_text(
-            model=model,
-            prediction_func=GPT2ForwardFn(),
-            bpe=bpe,
-            start_tokens=config.eval_start_string,
-            max_length=min(256, int(model.max_seq_len)),
-            temperature=0.8,
-            top_k=config.eval_top_k,
+        print(
+            generate_text(
+                model=model,
+                prediction_func=GPT2ForwardFn(),
+                bpe=bpe,
+                start_tokens=config.eval_start_string,
+                max_length=min(256, int(model.max_seq_len)),
+                temperature=0.8,
+                top_k=config.eval_top_k,
+            )
         )
 
     trainer = LLMTrainer(
@@ -528,13 +530,15 @@ if __name__ == "__main__":
 
     # Inference test
     for k in range(5):
-        generate_text(
-            model=trainer.model,
-            prediction_func=GPT2ForwardFn(),
-            bpe=bpe,
-            start_tokens=CONFIG.eval_start_string,
-            max_length=int(trainer.model.max_seq_len),
-            temperature=0.8,
-            top_k=CONFIG.eval_top_k,
+        print(
+            generate_text(
+                model=trainer.model,
+                prediction_func=GPT2ForwardFn(),
+                bpe=bpe,
+                start_tokens=CONFIG.eval_start_string,
+                max_length=int(trainer.model.max_seq_len),
+                temperature=0.8,
+                top_k=CONFIG.eval_top_k,
+            )
         )
         print("\n------------------------\n")

--- a/examples/gpt_2.py
+++ b/examples/gpt_2.py
@@ -67,9 +67,8 @@ class GPT2(nn.Module):
         num_decoder_layers: int = 12,  # GPT-2 small has 12 layers
         activation_checkpointing: bool = False,
         parameter_dtype=None,
-        **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__()
         if isinstance(parameter_dtype, str):
             parameter_dtype = resolve_dtype(parameter_dtype)
         self.hidden_size = hidden_size
@@ -172,9 +171,8 @@ class DecoderSublayer(nn.Module):
         ff_hidden_size: int = 3072,
         num_attention_heads: int = 12,
         dropout_prob: float = 0.1,
-        **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__()
 
         # First LayerNorm (for the attention sub-layer)
         self.layer_norm1 = nn.LayerNorm(hidden_size)

--- a/examples/neural_turing_machine.py
+++ b/examples/neural_turing_machine.py
@@ -212,9 +212,7 @@ class NeuralTuringMachine(nn.Module):
             hidden_size (int): Number of hidden units in the controller.
             output_size (int): Dimensionality of the model output.
         """
-        super().__init__(
-            input_size, memory_length, memory_dim, hidden_size, output_size
-        )
+        super().__init__()
         self.memory = Memory(
             memory_length=memory_length,
             memory_dim=memory_dim,
@@ -507,7 +505,7 @@ class LSTM(nn.Module):
             hidden_size (int): The number of hidden units in the LSTM block.
             output_size (int): The dimensionality of the output.
         """
-        super().__init__(input_size, hidden_size, output_size)
+        super().__init__()
         self.lstm = nn.LongShortTermMemoryBlock(input_size, hidden_size)
         self.fc = nn.Linear(hidden_size, output_size)
         self.hidden_size = hidden_size

--- a/examples/seq2seq.py
+++ b/examples/seq2seq.py
@@ -168,11 +168,11 @@ def main():
     labels, labels_vocab_idx = text_to_one_hot_and_sparse(
         train_y, vocab, max_sequence_length=60
     )
-    test_features, features_vocab_idx = text_to_one_hot_and_sparse(
-        train_X, vocab, max_sequence_length=120
+    test_features, _ = text_to_one_hot_and_sparse(
+        test_X, vocab, max_sequence_length=120
     )
-    test_labels, test_labels_vocab_idx = text_to_one_hot_and_sparse(
-        train_y, vocab, max_sequence_length=60
+    _, test_labels_vocab_idx = text_to_one_hot_and_sparse(
+        test_y, vocab, max_sequence_length=60
     )
 
     train_dataset = PairedMapDataset(features, labels_vocab_idx)

--- a/examples/sft_gpt_2.py
+++ b/examples/sft_gpt_2.py
@@ -4,7 +4,7 @@ from autograd import functional, optim
 from autograd.data.collator import BatchMaxLengthCausalLMCollator
 from autograd.data.data_loader import DataLoader
 from autograd.data.dataset import MapDataset
-from autograd.data.sampler import TokenLengthGroupedRandomSampler
+from autograd.data.sampler import SequentialSampler, TokenLengthGroupedRandomSampler
 from autograd.data.sft import (
     SFT_ROLE_MARKERS,
     SFT_SYSTEM_PROMPT,
@@ -40,11 +40,18 @@ def build_data_loader(
     max_tokens: int,
     pad_idx: int,
     sort_buffer_size: int,
+    shuffle: bool = True,
 ) -> DataLoader:
     dataset = MapDataset(examples)
     collator = BatchMaxLengthCausalLMCollator(max_tokens=max_tokens, pad_idx=pad_idx)
-    sampler = TokenLengthGroupedRandomSampler(
-        dataset, sort_buffer_size=sort_buffer_size
+    # Validation must iterate a fixed, deterministic order: with
+    # max_eval_steps capping the eval loop, a reshuffling sampler would
+    # measure a different random subset on every eval and add subset noise
+    # to the val-loss curve.
+    sampler = (
+        TokenLengthGroupedRandomSampler(dataset, sort_buffer_size=sort_buffer_size)
+        if shuffle
+        else SequentialSampler(dataset)
     )
     return DataLoader(dataset, batch_size, collator, sampler=sampler)
 
@@ -235,6 +242,7 @@ if __name__ == "__main__":
         max_tokens=max_tokens,
         pad_idx=pad_idx,
         sort_buffer_size=CONFIG.eval_batch_size,
+        shuffle=False,
     )
 
     trainer.fit(train_data_loader, val_data_loader)

--- a/examples/sft_gpt_2.py
+++ b/examples/sft_gpt_2.py
@@ -181,15 +181,17 @@ if __name__ == "__main__":
         _val_data_loader,
         config: TransformerTrainingConfig,
     ) -> None:
-        generate_text(
-            model=model,
-            prediction_func=GPT2ForwardFn(),
-            bpe=bpe,
-            start_tokens=config.eval_start_string,
-            max_length=min(256, int(model.max_seq_len)),
-            temperature=0.8,
-            top_k=config.eval_top_k,
-            stop_token=SFT_TURN_SEPARATOR,
+        print(
+            generate_text(
+                model=model,
+                prediction_func=GPT2ForwardFn(),
+                bpe=bpe,
+                start_tokens=config.eval_start_string,
+                max_length=min(256, int(model.max_seq_len)),
+                temperature=0.8,
+                top_k=config.eval_top_k,
+                stop_token=SFT_TURN_SEPARATOR,
+            )
         )
 
     trainer = LLMTrainer(
@@ -249,14 +251,16 @@ if __name__ == "__main__":
 
     # Inference test
     for k in range(5):
-        generate_text(
-            model=trainer.model,
-            prediction_func=GPT2ForwardFn(),
-            bpe=bpe,
-            start_tokens=CONFIG.eval_start_string,
-            max_length=int(trainer.model.max_seq_len),
-            temperature=0.8,
-            top_k=CONFIG.eval_top_k,
-            stop_token=SFT_TURN_SEPARATOR,
+        print(
+            generate_text(
+                model=trainer.model,
+                prediction_func=GPT2ForwardFn(),
+                bpe=bpe,
+                start_tokens=CONFIG.eval_start_string,
+                max_length=int(trainer.model.max_seq_len),
+                temperature=0.8,
+                top_k=CONFIG.eval_top_k,
+                stop_token=SFT_TURN_SEPARATOR,
+            )
         )
         print("\n------------------------\n")

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -742,12 +742,14 @@ if __name__ == "__main__":
             max_length=trainer.model.max_seq_len // 3,
         )
 
-    generate_text(
-        model=trainer.model,
-        prediction_func=TransformerForwardFn(),
-        bpe=bpe,
-        start_tokens=CONFIG.eval_start_string,
-        max_length=int(trainer.model.max_seq_len * 0.9),
-        temperature=0.8,
-        top_k=CONFIG.eval_top_k,
+    print(
+        generate_text(
+            model=trainer.model,
+            prediction_func=TransformerForwardFn(),
+            bpe=bpe,
+            start_tokens=CONFIG.eval_start_string,
+            max_length=int(trainer.model.max_seq_len * 0.9),
+            temperature=0.8,
+            top_k=CONFIG.eval_top_k,
+        )
     )

--- a/examples/transformers.py
+++ b/examples/transformers.py
@@ -36,7 +36,13 @@ class Transformer(nn.Module):
     """
 
     def __init__(
-        self, vocab_size: int, hidden_size: int, num_attention_heads: int, **kwargs: Any
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        num_attention_heads: int,
+        max_seq_len: Optional[int] = None,
+        num_decoder_layers: int = 6,
+        dropout_prob: float = 0.1,
     ) -> None:
         """
         Initialize the Transformer model.
@@ -45,22 +51,28 @@ class Transformer(nn.Module):
             vocab_size (int): Size of the vocabulary.
             hidden_size (int): Dimensionality of the model.
             num_attention_heads (int): Number of attention heads.
-            **kwargs: Additional keyword arguments (may include "max_seq_len").
+            max_seq_len (Optional[int]): Maximum sequence length for generation.
+            num_decoder_layers (int): Number of decoder sublayers. Defaults to 6 (Section 3.1).
+            dropout_prob (float): Dropout probability. Defaults to 0.1 (Section 5.4).
         """
-        super().__init__(**kwargs)
+        super().__init__()
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
-        self.max_seq_len = kwargs.get("max_seq_len")
+        self.max_seq_len = max_seq_len
         self.embedding = nn.Embedding(vocab_size, hidden_size)
 
-        # Encoder and dedcoder each have 6 layers
+        # The paper uses 6 identical layers for both stacks (Section 3.1)
         self.encoder = Encoder(
-            embedding_size=hidden_size, num_attention_heads=num_attention_heads
+            embedding_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            dropout_prob=dropout_prob,
         )
         self.decoder = Decoder(
             vocab_size=vocab_size,
             hidden_size=hidden_size,
             num_attention_heads=num_attention_heads,
+            num_layers=num_decoder_layers,
+            dropout_prob=dropout_prob,
         )
 
     def forward(
@@ -102,25 +114,36 @@ class Encoder(nn.Module):
     - 6 identical EncoderSublayer (Section 3.1)
     """
 
-    def __init__(self, embedding_size: int, num_attention_heads: int) -> None:
+    def __init__(
+        self,
+        embedding_size: int,
+        num_attention_heads: int,
+        num_layers: int = 6,
+        dropout_prob: float = 0.1,
+    ) -> None:
         """
         Initialize the Encoder.
 
         Args:
             embedding_size (int): Dimensionality of the token embeddings.
             num_attention_heads (int): Number of attention heads for the self-attention mechanism.
+            num_layers (int): Number of encoder sublayers. Defaults to 6 (Section 3.1).
+            dropout_prob (float): Dropout probability. Defaults to 0.1.
         """
         super().__init__()
         self.embedding_size = embedding_size
-        self.positional_encoder = PositionalEncoding(hidden_size=embedding_size)
+        self.positional_encoder = PositionalEncoding(
+            hidden_size=embedding_size, dropout_prob=dropout_prob
+        )
         self.sublayers = nn.ModuleList(
             [
                 EncoderSublayer(
                     hidden_size=embedding_size,
                     ff_hidden_size=embedding_size * 4,
                     num_attention_heads=num_attention_heads,
+                    dropout_prob=dropout_prob,
                 )
-                for _ in range(6)
+                for _ in range(num_layers)
             ]
         )
         self.layer_norm = nn.LayerNorm(embedding_size)
@@ -164,7 +187,12 @@ class Decoder(nn.Module):
     """
 
     def __init__(
-        self, vocab_size: int, hidden_size: int, num_attention_heads: int = 2
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        num_attention_heads: int = 2,
+        num_layers: int = 6,
+        dropout_prob: float = 0.1,
     ) -> None:
         """
         Initialize the Decoder.
@@ -173,9 +201,13 @@ class Decoder(nn.Module):
             vocab_size (int): Size of the vocabulary.
             hidden_size (int): Dimensionality of the model.
             num_attention_heads (int, optional): Number of attention heads. Defaults to 2.
+            num_layers (int): Number of decoder sublayers. Defaults to 6 (Section 3.1).
+            dropout_prob (float): Dropout probability. Defaults to 0.1.
         """
         super().__init__()
-        self.positional_encoder = PositionalEncoding(hidden_size=hidden_size)
+        self.positional_encoder = PositionalEncoding(
+            hidden_size=hidden_size, dropout_prob=dropout_prob
+        )
         self.hidden_size = hidden_size
         self.sublayers = nn.ModuleList(
             [
@@ -183,8 +215,9 @@ class Decoder(nn.Module):
                     hidden_size=hidden_size,
                     ff_hidden_size=hidden_size * 4,
                     num_attention_heads=num_attention_heads,
+                    dropout_prob=dropout_prob,
                 )
-                for _ in range(6)
+                for _ in range(num_layers)
             ]
         )
         self.linear = nn.Linear(hidden_size, output_size=vocab_size)
@@ -592,7 +625,9 @@ if __name__ == "__main__":
             "hidden_size": 768,
             "dropout_prob": 0.1,
             "max_seq_len": 512,
-            "num_decoder_layers": 12,
+            # 6 decoder layers, matching the paper (the previous value of 12
+            # was silently ignored by the model, which hardcoded 6).
+            "num_decoder_layers": 6,
         },
         optimizer_kwargs={
             "lr": 1e-3,

--- a/test/autograd/test_attention_structural_causal.py
+++ b/test/autograd/test_attention_structural_causal.py
@@ -74,6 +74,30 @@ class TestStructuralCausalAttention(TestCase):
 
         assert allclose(structural.data, explicit.data, atol=1e-5, rtol=1e-5)
 
+    def test_explicit_padding_mask_does_not_disable_causality(self):
+        """is_causal=True must stay causal even when a padding mask is supplied.
+
+        Regression test: `if mask is None and is_causal` skipped the causal
+        mask entirely whenever an explicit (e.g. padding) mask was passed,
+        letting the decoder attend to future positions.
+        """
+        attention = ScaledDotProductAttention(dropout_prob=0.0)
+        # All-zeros padding mask: every position allowed, so the result must
+        # match the purely causal output exactly.
+        pad_mask = Tensor(
+            xp.zeros((self.batch_size, 1, self.seq_len, self.seq_len)),
+            requires_grad=False,
+        )
+
+        causal_only = attention(
+            self.query, self.key, self.value, mask=None, is_causal=True
+        )
+        with_pad_mask = attention(
+            self.query, self.key, self.value, mask=pad_mask, is_causal=True
+        )
+
+        assert allclose(causal_only.data, with_pad_mask.data, atol=1e-5, rtol=1e-5)
+
     @skipUnless(IS_MLX, "mlx_custom requires the MLX backend")
     def test_structural_causal_attention_stays_on_dense_path(self):
         attention = ScaledDotProductAttention(dropout_prob=0.0)

--- a/test/autograd/test_init.py
+++ b/test/autograd/test_init.py
@@ -1,0 +1,26 @@
+import math
+from unittest import TestCase
+
+from autograd.backend import xp
+from autograd.init import compute_in_out_tensor_count, xavier_uniform
+from autograd.tensor import Tensor
+
+
+class TestComputeInOutTensorCount(TestCase):
+    def test_linear_weight_fans(self):
+        # Linear weights use the (input_size, output_size) convention
+        t = Tensor(xp.zeros((5, 10)))
+        assert compute_in_out_tensor_count(t) == (5, 10)
+
+    def test_conv_kernel_fans(self):
+        # Conv2d weights use the (out_channels, in_channels, kH, kW) convention,
+        # so fan_in = in_channels * receptive field, fan_out = out_channels * receptive field
+        t = Tensor(xp.zeros((16, 8, 3, 3)))
+        assert compute_in_out_tensor_count(t) == (8 * 9, 16 * 9)
+
+    def test_xavier_uniform_bound_uses_conv_fans(self):
+        xp.random.seed(42)
+        t = xavier_uniform(Tensor(xp.zeros((16, 8, 3, 3))))
+        limit = math.sqrt(6.0 / (8 * 9 + 16 * 9))
+        assert float(t.data.max()) <= limit
+        assert float(t.data.min()) >= -limit

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -73,6 +73,19 @@ class TestModule(TestCase):
         assert "submodule1.running_avg" in states
         assert allclose(states["submodule1.running_avg"], [10.0])
 
+    def test_zero_grad_clears_gradients(self):
+        x = Tensor(xp.ones((2, 3)), requires_grad=False)
+        main_weight = self.model.parameters["main_weight"]
+        (x @ main_weight).sum().backward()
+
+        assert main_weight.grad is not None
+        assert not allclose(main_weight.grad.data, 0.0)
+
+        self.model.zero_grad()
+
+        grad = main_weight.grad
+        assert grad is None or allclose(grad.data, 0.0)
+
     def test_num_parameters(self):
         # main_weight: shape (3,3) => 9 elements
         # sub_weight: shape (2,2) => 4 elements

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -73,6 +73,19 @@ class TestModule(TestCase):
         assert "submodule1.running_avg" in states
         assert allclose(states["submodule1.running_avg"], [10.0])
 
+    def test_parameter_attribute_access(self):
+        """A Tensor assigned via self.name = ... is registered in _parameters
+        and must remain readable as a plain attribute."""
+        assert self.model.main_weight is self.model._parameters["main_weight"]
+        assert (
+            self.model.submodule1.sub_weight
+            is self.model.submodule1._parameters["sub_weight"]
+        )
+        # forward() uses self.main_weight directly
+        x = Tensor(xp.ones((2, 3)), requires_grad=False)
+        out = self.model(x)
+        assert out.shape == (2, 3)
+
     def test_zero_grad_clears_gradients(self):
         x = Tensor(xp.ones((2, 3)), requires_grad=False)
         main_weight = self.model.parameters["main_weight"]

--- a/test/autograd/test_nn.py
+++ b/test/autograd/test_nn.py
@@ -73,6 +73,18 @@ class TestModule(TestCase):
         assert "submodule1.running_avg" in states
         assert allclose(states["submodule1.running_avg"], [10.0])
 
+    def test_module_init_rejects_unknown_arguments(self):
+        """Module.__init__ must not swallow stray constructor arguments —
+        a config key the model ignores means the user trains a different
+        architecture than the config claims."""
+
+        class StrictModule(Module):
+            def forward(self, x):
+                return x
+
+        with self.assertRaises(TypeError):
+            StrictModule(totally_bogus_arg=True)
+
     def test_parameter_attribute_access(self):
         """A Tensor assigned via self.name = ... is registered in _parameters
         and must remain readable as a plain attribute."""

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -492,34 +492,34 @@ class TestAdam(TestCase):
         )
 
     def test_zero_grad(self):
-        self.optim.zero_grad()
-        self.optim.step()
-        self.torch_optim.zero_grad()
-        self.torch_optim.step()
+        self.param1.grad = self.grad1_val
+        self.param2.grad = self.grad2_val
 
-        assert allclose(
-            self.param1.data,
-            self.torch_params[0].detach().numpy(),
-            atol=1e-6,
-        )
-        assert allclose(
-            self.param2.data,
-            self.torch_params[1].detach().numpy(),
-            atol=1e-6,
-        )
+        self.optim.zero_grad()
+
+        assert self.param1.grad is None
+        assert self.param2.grad is None
+        # With cleared gradients, step() must not move the parameters.
+        before1 = float(self.param1.data)
+        before2 = float(self.param2.data)
+        self.optim.step()
+        assert float(self.param1.data) == before1
+        assert float(self.param2.data) == before2
 
     def test_step(self):
-        # Perform multiple steps and compare results
+        # Multiple consecutive steps on the same optimizer instance, so the
+        # momentum buffers and bias correction must track torch across steps.
         for _ in range(5):
-            # Step both optimizers
+            self.param1.grad = self.grad1_val
+            self.param2.grad = self.grad2_val
+            self.torch_params[0].grad = torch.tensor(self.grad1_val)
+            self.torch_params[1].grad = torch.tensor(self.grad2_val)
+
             self.optim.step()
             self.torch_optim.step()
-
-            # Zero out gradients (this is similar to our training step)
             self.optim.zero_grad()
             self.torch_optim.zero_grad()
 
-            # Compare parameters
             assert allclose(
                 self.param1.data,
                 self.torch_params[0].detach().numpy(),
@@ -530,9 +530,6 @@ class TestAdam(TestCase):
                 self.torch_params[1].detach().numpy(),
                 atol=1e-6,
             )
-
-            # Set new gradients for next step
-            self.setUp()
 
     def test_different_gradients(self):
         # Test with different gradient values

--- a/test/autograd/test_optim.py
+++ b/test/autograd/test_optim.py
@@ -646,6 +646,53 @@ class TestAdam(TestCase):
 
         assert allclose(decayed.data, undecayed.data, atol=0.0, rtol=0.0)
 
+    def test_load_state_dict_defaults_momenta_for_new_params(self):
+        """Params absent from the checkpoint must get zero-initialized m/v
+        on the next step, not raise KeyError."""
+        params_old = {"w1": Tensor([1.0, 2.0])}
+        adam_old = Adam(params_old, lr=0.01)
+        params_old["w1"].grad = Tensor([0.1, 0.2]).data
+        adam_old.step()
+        saved = deepcopy(adam_old.state_dict())
+
+        # The new model has an extra parameter the checkpoint doesn't know about.
+        params_new = {"w1": Tensor([1.0, 2.0]), "w2": Tensor([3.0, 4.0])}
+        adam_new = Adam(params_new, lr=0.01)
+        adam_new.load_state_dict(saved)
+
+        for p in params_new.values():
+            p.grad = Tensor([0.1, 0.2]).data
+        adam_new.step()  # raised KeyError("w2") before the fix
+
+        # w1's momentum continued from the checkpointed value:
+        # beta1 * m_ckpt + (1 - beta1) * grad = 0.9 * [0.01, 0.02] + 0.1 * [0.1, 0.2]
+        assert allclose(adam_new._states["m"]["w1"], [0.019, 0.038])
+        # w2 started from zero momentum: (1 - beta1) * grad
+        assert allclose(adam_new._states["m"]["w2"], [0.01, 0.02])
+
+    def test_load_state_dict_without_master_rebuilds_fp32_masters(self):
+        """Loading a checkpoint without a 'master' group (e.g. saved before
+        master copies existed) must rebuild fp32 masters for low-precision
+        params instead of silently dropping them."""
+        if not hasattr(xp, "bfloat16"):
+            self.skipTest("backend lacks bfloat16")
+
+        param = Tensor(xp.array([1.0, -2.0], dtype=xp.bfloat16))
+        adam = Adam({"w": param}, lr=0.01)
+        assert "w" in adam._states["master"]
+
+        saved = deepcopy(adam.state_dict())
+        del saved["states"]["master"]
+
+        param2 = Tensor(xp.array([1.0, -2.0], dtype=xp.bfloat16))
+        adam2 = Adam({"w": param2}, lr=0.01)
+        adam2.load_state_dict(saved)
+
+        assert "w" in adam2._states["master"], (
+            "fp32 master copy was dropped when loading a checkpoint "
+            "without a 'master' state group"
+        )
+
     def test_bf16_step_matches_fp32_reference(self):
         if not IS_CUPY:
             self.skipTest("bf16 requires CuPy backend")

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -553,6 +553,12 @@ class TestTensorSum(TestTensor):
         assert s.data == 2.0
         assert s.requires_grad == self.x_scalar.requires_grad
 
+    def test_x_scalar_sum_backward(self):
+        s = self.x_scalar.sum()
+        s.backward()
+        assert self.x_scalar.grad is not None
+        assert float(self.x_scalar.grad.data) == 1.0
+
     def test_1d_tensor_sum_global(self):
         s = self.x_vector.sum()
         assert s.data == 3.0

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -1275,6 +1275,57 @@ class TestTensorAccumulateGradDtype(TestCase):
                 )
 
 
+class TestTensorGradAssignment(TestCase):
+    """Assigning .grad must SET the gradient; accumulation is the job of
+    _accumulate_grad during backward. Accumulate-on-assign made p.grad = 0
+    a silent no-op and surprised every external caller."""
+
+    def test_grad_assignment_replaces_existing_grad(self):
+        x = Tensor([1.0, 2.0])
+        x.grad = [5.0, 5.0]
+        x.grad = [1.0, 1.0]
+        assert array_equal(x.grad.data, [1.0, 1.0])
+
+    def test_grad_assignment_none_clears(self):
+        x = Tensor([1.0, 2.0])
+        x.grad = [5.0, 5.0]
+        x.grad = None
+        assert x.grad is None
+
+    def test_backward_still_accumulates_across_branches(self):
+        # Fan-out: y = x + x, so dy/dx = 2. Backward accumulation goes
+        # through _accumulate_grad and must be unaffected by the setter.
+        x = Tensor([1.0, 2.0])
+        y = x + x
+        y.backward()
+        assert array_equal(x.grad.data, [2.0, 2.0])
+
+    def test_grad_assignment_accepts_tensor_and_detaches(self):
+        x = Tensor([1.0, 2.0])
+        x.grad = Tensor([3.0, 4.0], requires_grad=True)
+        assert array_equal(x.grad.data, [3.0, 4.0])
+        # The stored grad is a plain value, never part of the autograd graph.
+        assert x.grad.requires_grad is False
+
+    def test_backward_across_fresh_graphs_accumulates(self):
+        # Two forward+backward passes without clearing sum the leaf grads —
+        # the contract gradient accumulation (microbatching) relies on.
+        # NOTE: calling backward() twice on the SAME graph is unsupported:
+        # backward frees the graph for memory (like retain_graph=False).
+        x = Tensor([1.0, 2.0])
+        (x * 3).backward()
+        (x * 3).backward()
+        assert array_equal(x.grad.data, [6.0, 6.0])
+
+    def test_backward_accumulates_into_manually_set_grad(self):
+        # PyTorch parity: a pre-set .grad is the accumulation starting point
+        # for backward, not something backward replaces.
+        x = Tensor([1.0, 2.0])
+        x.grad = [10.0, 10.0]
+        (x * 3).sum().backward()
+        assert array_equal(x.grad.data, [13.0, 13.0])
+
+
 class TestTensorIAdd(TestTensor):
     def test_iadd_basic(self):
         """Test basic in-place addition between two tensors"""

--- a/test/autograd/test_tensor.py
+++ b/test/autograd/test_tensor.py
@@ -1326,6 +1326,20 @@ class TestTensorStack(TestTensor):
         assert array_equal(self.x_vector.grad.data, self.x_vector_torch.grad.numpy())
         assert array_equal(self.y_vector.grad.data, self.y_vector_torch.grad.numpy())
 
+    def test_stack_mixed_requires_grad(self):
+        """Inputs after a non-requires-grad input must still receive gradients."""
+        a = Tensor([1.0, 2.0], requires_grad=True)
+        b = Tensor([3.0, 4.0], requires_grad=False)
+        c = Tensor([5.0, 6.0], requires_grad=True)
+
+        z = Tensor.stack([a, b, c])
+        z.backward()
+
+        assert array_equal(a.grad.data, [1.0, 1.0])
+        assert b.grad is None
+        assert c.grad is not None
+        assert array_equal(c.grad.data, [1.0, 1.0])
+
 
 class TestTensorPad(TestTensor):
     def test_pad_1d(self):

--- a/test/autograd/test_train.py
+++ b/test/autograd/test_train.py
@@ -13,7 +13,7 @@ from autograd.data.dataset import PairedMapDataset
 from autograd.data.sampler import RandomSampler
 from autograd.tools.config_schema import GenericTrainingConfig
 from autograd.tools.metrics import accuracy, mean_squared_error
-from autograd.tools.trainer import SimpleTrainer
+from autograd.tools.trainer import SimpleTrainer, TrainingPlan, TrainingState
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +119,39 @@ class TestTrain(TestCase):
         acc = accuracy(xp.asarray(y_pred > 0.5).astype(xp.int32).squeeze(), y)
         logger.info(f"Accuracy: {acc}")
         assert acc > 0.9
+
+    def test_report_persists_current_row(self):
+        """The metrics NPZ must include the row being reported, so the final
+        report of a run is not lost."""
+        config = GenericTrainingConfig(
+            training_run_name="metrics_row_test",
+            checkpoint_freq=1000,
+            max_steps=10,
+            model_kwargs={"input_size": 4, "hidden_size": 4, "output_size": 1},
+            optimizer_kwargs={"lr": 1e-3},
+        )
+        trainer = SimpleTrainer(
+            model_cls=RegressionModel,
+            optimizer_cls=optim.SGD,
+            loss_fn=functional.mean_squared_loss,
+            config=config,
+            output_type=None,
+        )
+        plan = TrainingPlan.for_steps(
+            max_steps=10, report_every_steps=1, checkpoint_every=1000
+        )
+        trainer.global_step = 1
+        state = TrainingState()
+        state.record_loss(2.0, total_weight=xp.array(4.0, dtype=xp.float32))
+
+        trainer.report(state, plan, eval_state=None)
+
+        path = os.path.join(
+            SimpleTrainer.METRICS_DIR, "RegressionModel_metrics_row_test.npz"
+        )
+        saved = xp.load(path)
+        assert "train_loss" in saved, "reported row missing from saved metrics"
+        assert len(saved["train_loss"]) == 1
 
     def test_regression(self):
         X, y = load_diabetes(return_X_y=True)

--- a/test/autograd/text/test_tokenizer.py
+++ b/test/autograd/text/test_tokenizer.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import tempfile
 from unittest import TestCase
 
@@ -94,6 +95,59 @@ class TestTokenizer(TestCase):
         # the file (or change the path) before retrying.
         with self.assertRaisesRegex(RuntimeError, "Failed to load vocabulary"):
             BytePairEncoder(num_merges=50, vocab_file_path=self.bpe.vocab_file_path)
+
+    def test_load_dictionary_rejects_vocab_missing_special_tokens(self):
+        """A pickled vocab that predates the current SPECIAL_TOKENS list must
+        fail loudly at load time, not with a cryptic KeyError at encode time."""
+        self.bpe.train_vocabulary([self.original_text], overwrite_saved_file=True)
+        with open(self.bpe.vocab_file_path, "rb") as f:
+            u2i, i2u, merges = pickle.load(f)
+        removed = "<|TOOL|>".encode("utf-8")
+        token_id = u2i.pop(removed)
+        i2u.pop(token_id)
+        with open(self.bpe.vocab_file_path, "wb") as f:
+            pickle.dump((u2i, i2u, merges), f)
+
+        with self.assertRaisesRegex(RuntimeError, "missing special tokens"):
+            BytePairEncoder(num_merges=50, vocab_file_path=self.bpe.vocab_file_path)
+
+    def test_encoded_cache_is_keyed_by_vocab_fingerprint(self):
+        """The cache path embeds the vocab fingerprint, so a different
+        vocabulary must produce a different cache file rather than silently
+        reusing (and mixing token ID spaces with) another vocab's encoding."""
+        self.bpe.prepare_data(
+            [self.original_text],
+            overwrite_vocabulary_file=True,
+            overwrite_encoded_data=True,
+        )
+        first_cache_path = self.bpe.mmap_path
+        assert os.path.exists(first_cache_path)
+
+        other_vocab_path = "test_vocab_other.pkl"
+        self.addCleanup(
+            lambda: os.path.exists(other_vocab_path) and os.remove(other_vocab_path)
+        )
+        bpe2 = BytePairEncoder(
+            num_merges=5,
+            vocab_file_path=other_vocab_path,
+            encoded_data_path=self.bpe.encoded_data_path,
+        )
+        bpe2.train_vocabulary(
+            ["a completely different corpus 12345"], overwrite_saved_file=True
+        )
+        self.addCleanup(
+            lambda: os.path.exists(bpe2.mmap_path) and os.remove(bpe2.mmap_path)
+        )
+
+        assert bpe2.mmap_path != first_cache_path
+        bpe2.prepare_data(
+            ["a completely different corpus 12345"],
+            overwrite_vocabulary_file=False,
+            overwrite_encoded_data=False,
+        )
+        # Both caches coexist; neither vocab can ever load the other's tokens.
+        assert os.path.exists(first_cache_path)
+        assert os.path.exists(bpe2.mmap_path)
 
     def test_train_vocabulary_skip_if_loaded_and_no_overwrite(self):
         # First train

--- a/test/autograd/text/test_utils.py
+++ b/test/autograd/text/test_utils.py
@@ -530,7 +530,7 @@ class TestTextUtils(TestCase):
         stdout = io.StringIO()
 
         with redirect_stdout(stdout):
-            generate_text(
+            result = generate_text(
                 model=MagicMock(),
                 prediction_func=MagicMock(side_effect=fake_prediction),
                 bpe=self.bpe,  # type: ignore
@@ -541,11 +541,10 @@ class TestTextUtils(TestCase):
             )
 
         output = stdout.getvalue()
-        self.assertIn("Prompt:\nAB\n\nGenerated:\nBBB", output)
-        self.assertIn(
-            "Prompt 2 tokens, generated 3 new tokens, total 5/5 tokens",
-            output,
-        )
+        # The text is returned (not printed); stdout only carries the summary.
+        self.assertEqual(result, "ABBBB")
+        self.assertNotIn("ABBBB", output)
+        self.assertIn("[prompt 2 tokens + 3 new tokens", output)
 
     @patch("autograd.text.utils.xp.sample_categorical")
     def test_generate_text_stops_at_endoftext(self, mock_choice):

--- a/test/autograd/tools/test_config_schema.py
+++ b/test/autograd/tools/test_config_schema.py
@@ -68,6 +68,43 @@ class TestTransformerTrainingConfig(TestCase):
         self.assertEqual(config.gradient_accumulation_steps, 8)
         self.assertEqual(config.eval_batch_size, 16)
 
+    def test_rejects_checkpoint_freq_not_multiple_of_report_every_steps(self):
+        """Checkpoints are only written on reporting steps, so a
+        checkpoint_freq that isn't a multiple of report_every_steps would
+        silently checkpoint every lcm(report, freq) steps instead."""
+        with self.assertRaisesRegex(
+            ValueError, "checkpoint_freq.*multiple of report_every_steps"
+        ):
+            TransformerTrainingConfig(
+                training_run_name="test",
+                dataset_name="dataset",
+                max_steps=100,
+                checkpoint_freq=10,
+                report_every_steps=3,
+                global_batch_size=1,
+                micro_batch_size=1,
+                model_kwargs={},
+                optimizer_kwargs={"lr": 1e-3},
+                label_smoothing=0.0,
+                teacher_forcing=False,
+            )
+
+    def test_allows_checkpoint_freq_multiple_of_report_every_steps(self):
+        config = TransformerTrainingConfig(
+            training_run_name="test",
+            dataset_name="dataset",
+            max_steps=100,
+            checkpoint_freq=10,
+            report_every_steps=5,
+            global_batch_size=1,
+            micro_batch_size=1,
+            model_kwargs={},
+            optimizer_kwargs={"lr": 1e-3},
+            label_smoothing=0.0,
+            teacher_forcing=False,
+        )
+        self.assertEqual(config.report_every_steps, 5)
+
     def test_rejects_non_positive_eval_batch_size(self):
         with self.assertRaisesRegex(ValueError, "eval_batch_size must be >= 1"):
             TransformerTrainingConfig(

--- a/test/autograd/tools/test_model.py
+++ b/test/autograd/tools/test_model.py
@@ -19,7 +19,7 @@ from autograd.tools.model import (
 
 class MockModule(Module):
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__()
         self._parameters["weight"] = xavier_uniform(Tensor(xp.zeros((4, 5))))
         self._parameters["bias"] = xavier_uniform(Tensor(xp.zeros((1, 1))))
 

--- a/test/autograd/tools/test_trainer.py
+++ b/test/autograd/tools/test_trainer.py
@@ -351,6 +351,19 @@ class TestSimpleTrainer(BaseTrainerTest):
         # 2 epochs * 2 train batches = 4 steps
         self.assertEqual(self.trainer.optimizer.step_call_count, 4)
 
+    def test_unknown_trainer_kwarg_raises(self):
+        """A typo'd kwarg (e.g. misspelled checkpoint_path) must raise instead
+        of being silently swallowed and training from scratch."""
+        with self.assertRaises(TypeError):
+            SimpleTrainer(
+                model_cls=MockModelClass,
+                optimizer_cls=MockOptimizerClass,
+                loss_fn=self.loss_fn,
+                config=self.config,
+                output_type="logits",
+                checkpont_path="dummy",  # intentional typo
+            )
+
     def test_forward_and_loss_returns_tensor(self):
         """Check that _forward_and_loss returns the expected scalar Tensor."""
         batch = next(iter(self.train_data))

--- a/test/distributed/smoke_ddp_cupy.py
+++ b/test/distributed/smoke_ddp_cupy.py
@@ -40,12 +40,17 @@ def _mse_loss(W: Tensor, X, y) -> Tensor:
 
 
 def _train(W: Tensor, X, y, *, steps: int, lr: float) -> Tensor:
+    from autograd.distributed import allreduce_grads
+
     params = {"W": W}
     optimizer = optim.SGD(params, lr=lr)
     for _ in range(steps):
         W.grad = None
         loss = _mse_loss(W, X, y)
         loss.backward()
+        # Grad sync is the caller's responsibility (the trainer does this
+        # before scaling/clipping); optimizer.step() is purely local.
+        allreduce_grads(params)
         optimizer.step()
     return W
 

--- a/test/distributed/test_ddp_equivalence.py
+++ b/test/distributed/test_ddp_equivalence.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from autograd import optim
+from autograd import nn, optim
 from autograd.backend import IS_MLX, xp
 from autograd.tensor import Tensor
+from autograd.tools.config_schema import GenericTrainingConfig
+from autograd.tools.trainer import SimpleTrainer, TrainingState
 
 from .mock import run_mock_ranks
 
@@ -98,7 +100,7 @@ def test_ddp_2rank_matches_single_rank_baseline():
     # ---- DDP: 2 ranks, each takes one half ----------------------------
     def per_rank_train():
         # Match the baseline init (zeros) — no per-rank divergence.
-        from autograd.distributed import rank
+        from autograd.distributed import allreduce_grads, rank
 
         W = _make_param(X.shape[1])
         params = {"W": W}
@@ -109,6 +111,9 @@ def test_ddp_2rank_matches_single_rank_baseline():
             W.grad = None
             loss = _mse_loss_and_grad(W, rank_X, rank_y)
             loss.backward()
+            # Grad sync is the caller's responsibility (the trainer does
+            # this before scaling/clipping); optimizer.step() is local.
+            allreduce_grads(params)
             optimizer.step()
         return xp.to_numpy(W.data)
 
@@ -130,6 +135,132 @@ def test_ddp_2rank_matches_single_rank_baseline():
         rtol=1e-5,
         atol=1e-5,
         err_msg="DDP 2-rank result differs from single-rank baseline",
+    )
+
+
+class _ZeroLinear(nn.Module):
+    """Deterministic zero-initialized linear map so every rank (and the
+    baseline) starts from identical weights without relying on RNG."""
+
+    def __init__(self, dim: int = 4):
+        super().__init__()
+        self._parameters["W"] = Tensor(xp.zeros((dim, 1), dtype=xp.float32))
+
+    def forward(self, x):
+        return x @ self._parameters["W"]
+
+
+def _make_trainer(max_grad_norm) -> SimpleTrainer:
+    config = GenericTrainingConfig(
+        training_run_name="ddp_trainer_equivalence",
+        checkpoint_freq=1000,
+        max_steps=100,
+        model_kwargs={"dim": 4},
+        optimizer_kwargs={"lr": 0.1},
+        global_batch_size=2,
+        micro_batch_size=1,
+        max_grad_norm=max_grad_norm,
+    )
+    return SimpleTrainer(
+        model_cls=_ZeroLinear,
+        optimizer_cls=optim.SGD,
+        loss_fn=None,  # loss is computed manually below; fit() is never called
+        config=config,
+    )
+
+
+def _train_via_trainer(
+    trainer: SimpleTrainer, X: np.ndarray, y: np.ndarray, n_steps: int
+) -> np.ndarray:
+    """Drive the production update path: backward, record token weight,
+    then trainer.optimizer_step (token normalization + clip + step)."""
+    W = trainer.model.parameters["W"]
+    X_t = Tensor(xp.asarray(X), requires_grad=False)
+    y_t = Tensor(xp.asarray(y), requires_grad=False)
+    for _ in range(n_steps):
+        state = TrainingState()
+        diff = X_t @ W - y_t
+        loss = (diff * diff).sum()  # token-sum loss; weight = number of rows
+        loss.backward()
+        state.record_loss(
+            loss, total_weight=xp.array(float(X.shape[0]), dtype=xp.float32)
+        )
+        assert trainer.optimizer_step(state)
+    return xp.to_numpy(W.data)
+
+
+def test_trainer_ddp_unequal_token_counts_match_global_token_mean():
+    """Token normalization must be global-sum / global-token-count.
+
+    With unequal per-rank token counts, normalizing per-rank before the
+    AllReduce yields a mean-of-per-rank-means, which differs from the
+    single-rank baseline that divides the full-batch gradient by the
+    full-batch token count.
+    """
+    X, y = _make_problem(seed=7, n=16, dim=4)
+    n0 = 4  # rank 0 gets 4 rows, rank 1 gets 12 — unequal on purpose
+    n_steps = 3
+
+    baseline = _train_via_trainer(_make_trainer(None), X, y, n_steps)
+
+    def per_rank():
+        from autograd.distributed import rank
+
+        trainer = _make_trainer(None)
+        Xr = X[:n0] if rank() == 0 else X[n0:]
+        yr = y[:n0] if rank() == 0 else y[n0:]
+        return _train_via_trainer(trainer, Xr, yr, n_steps)
+
+    rank_results = run_mock_ranks(2, per_rank)
+
+    np.testing.assert_allclose(
+        rank_results[1],
+        rank_results[0],
+        err_msg="ranks disagree after AllReduce",
+    )
+    np.testing.assert_allclose(
+        rank_results[0],
+        baseline,
+        rtol=1e-5,
+        atol=1e-6,
+        err_msg="DDP unequal-token result differs from single-rank baseline",
+    )
+
+
+def test_trainer_ddp_clipping_applied_to_global_gradient():
+    """Gradient clipping must clip the AllReduced global gradient.
+
+    Clipping per-rank gradients by their local norms before the AllReduce
+    applies a different clip factor on each rank; the averaged result is
+    not any valid clipping of the global gradient.
+    """
+    X, y = _make_problem(seed=11, n=16, dim=4)
+    half = X.shape[0] // 2
+    n_steps = 3
+
+    baseline = _train_via_trainer(_make_trainer(0.05), X, y, n_steps)
+
+    def per_rank():
+        from autograd.distributed import rank
+
+        trainer = _make_trainer(0.05)
+        Xr = X[:half] if rank() == 0 else X[half:]
+        yr = y[:half] if rank() == 0 else y[half:]
+        return _train_via_trainer(trainer, Xr, yr, n_steps)
+
+    rank_results = run_mock_ranks(2, per_rank)
+
+    np.testing.assert_allclose(
+        rank_results[1],
+        rank_results[0],
+        err_msg="ranks disagree after AllReduce",
+    )
+    np.testing.assert_allclose(
+        rank_results[0],
+        baseline,
+        rtol=1e-5,
+        atol=1e-6,
+        err_msg="DDP clipped result differs from single-rank baseline",
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -377,11 +377,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

A batch of 18 correctness and robustness fixes across the autograd core, NN modules, optimizer, trainer, and examples:

**Autograd / tensor core**
- Fix `Stack.backward` dropping grads after a non-requires-grad input
- Fix backward crash for `sum()` on 0-d tensors
- Make `Tensor.grad` assignment set instead of accumulate

**NN modules**
- Fix `is_causal` being ignored when an explicit mask is supplied
- Fix Xavier init fan computation for conv kernels
- Fix `Module.zero_grad` being a silent no-op
- Make registered parameters readable as module attributes
- Make `Module.__init__` strict; stop layers swallowing constructor args

**Optimizer / DDP**
- Fix DDP gradient scaling/clipping happening before the AllReduce
- Fix `Adam.load_state_dict` dropping defaultdict and master invariants
- Make TestAdam step/zero_grad tests actually exercise the optimizer

**Trainer / checkpointing**
- Fix final metrics row never being persisted
- Fail fast on `checkpoint_freq` not aligned with `report_every_steps`
- Make `checkpoint_path` an explicit trainer parameter

**Data / examples**
- Validate tokenizer vocab on load; key encoded cache by vocab fingerprint
- Use a sequential sampler for the SFT validation loader
- Evaluate seq2seq example on the test split, not training data
- Add `autograd/tools/__init__.py` so the package ships in builds

**README update**
- Include latest post-training techniques and include inference example with pre-trained checkpoint

## Test plan
- [x] PyTorch-based unit tests pass (correctness validation per repo guidance)

**Dependencies**
- Bump `idna` 3.11 → 3.18 in `uv.lock` and `docs/requirements.txt`, resolving both open Dependabot alerts (medium: CVE-2024-3651 fix bypass in `idna.encode()`)
